### PR TITLE
feature/activate-hunt-publish

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Header } from "@/components/Header"
+import { HuntDashboard } from "@/components/HuntDashboard"
+import { getCreatorHunts, updateHuntStatus, type StoredHunt } from "@/lib/huntStore"
+import { activateHunt } from "@/lib/contracts/hunt"
+import { withTransactionToast } from "@/lib/txToast"
+
+export default function DashboardPage() {
+  const [hunts, setHunts] = useState<StoredHunt[]>([])
+
+  const refresh = useCallback(() => {
+    setHunts(getCreatorHunts())
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const handleActivate = useCallback(async (huntId: number) => {
+    await withTransactionToast(
+      () => activateHunt(huntId),
+      {
+        loading: "Confirming in Wallet...",
+        submitted: "Transaction Submitted",
+        success: "Hunt activated. It is now visible in the Game Arcade.",
+      }
+    )
+    updateHuntStatus(huntId, "Active")
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-gradient-to-tr from-blue-100 via-purple-100 to-[#f9f9ff] pb-12">
+      <Header balance="24.2453" />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8 flex items-center gap-4">
+          <Button
+            variant="ghost"
+            asChild
+            className="flex items-center gap-2 text-slate-700 hover:text-slate-900"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Game Arcade
+            </Link>
+          </Button>
+        </div>
+
+        <h1 className="mb-2 text-3xl font-bold bg-gradient-to-br from-[#3737A4] to-[#0C0C4F] text-transparent bg-clip-text">
+          My Hunts
+        </h1>
+        <p className="mb-8 text-slate-600">
+          Activate a draft hunt so players can see it in the Game Arcade. Active hunts cannot be edited.
+        </p>
+
+        <HuntDashboard hunts={hunts} onActivate={handleActivate} onRefresh={refresh} />
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,16 @@
 "use client"
 
-import {hankenGrotesk} from "@/lib/font"
-
 import { useEffect, useState } from "react"
+import Image from "next/image"
+import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { X, ArrowRight, ArrowLeftRight } from "lucide-react"
-import Image from "next/image"
-import Link from "next/link"
+import { X, ArrowRight } from "lucide-react"
 import { Card, CardDescription, CardTitle } from "@/components/ui/card"
 import { Header } from "@/components/Header"
-
-
-
+import { getAllHunts } from "@/lib/huntStore"
+import { hankenGrotesk } from "@/lib/font"
 
 interface WalletOption {
   id: string
@@ -24,43 +21,9 @@ interface WalletOption {
 
 const walletOptions: WalletOption[] = []
 
-type HuntStatus = "Active" | "Completed" | "Draft"
-
-interface ArcadeHunt {
-  id: string | number
-  title: string
-  description: string
-  cluesCount: number
-  status: HuntStatus
-}
-
-// Temporary data fetcher; replace with real Soroban/indexer integration.
-async function fetchAllHunts(): Promise<ArcadeHunt[]> {
-  // TODO: wire this to Soroban or an indexer once available.
-  // For now this simulates a small list of hunts.
-  return [
-    {
-      id: 1,
-      title: "City Secrets",
-      description: "Race across town to uncover hidden murals and landmarks.",
-      cluesCount: 5,
-      status: "Active",
-    },
-    {
-      id: 2,
-      title: "Campus Quest",
-      description: "Solve riddles scattered around campus before the timer ends.",
-      cluesCount: 7,
-      status: "Active",
-    },
-    {
-      id: 3,
-      title: "Office Onboarding Hunt",
-      description: "A playful intro game for new teammates around the office.",
-      cluesCount: 4,
-      status: "Completed",
-    },
-  ]
+// Active hunts for the public Game Arcade (Draft hunts become visible here after activation).
+function fetchAllHunts() {
+  return getAllHunts().filter((h) => h.status === "Active")
 }
 
 export default function GameArcade() {
@@ -73,31 +36,18 @@ export default function GameArcade() {
   const [walletAddress, setWalletAddress] = useState("")
   const [balance, setBalance] = useState("")
 
-  const [hunts, setHunts] = useState<ArcadeHunt[]>([])
+  const [hunts, setHunts] = useState<ReturnType<typeof fetchAllHunts>>([])
   const [isLoadingHunts, setIsLoadingHunts] = useState(true)
 
   useEffect(() => {
     let cancelled = false
-
-    const loadHunts = async () => {
-      try {
-        const all = await fetchAllHunts()
-        if (cancelled) return
-        const active = all.filter((hunt) => hunt.status === "Active")
-        setHunts(active)
-      } catch (error) {
-        console.error("Failed to fetch hunts", error)
-      } finally {
-        if (!cancelled) {
-          setIsLoadingHunts(false)
-        }
-      }
-    }
-
-    loadHunts()
-
-    return () => {
-      cancelled = true
+    try {
+      const active = fetchAllHunts()
+      if (!cancelled) setHunts(active)
+    } catch (error) {
+      console.error("Failed to fetch hunts", error)
+    } finally {
+      if (!cancelled) setIsLoadingHunts(false)
     }
   }, [])
 
@@ -149,8 +99,11 @@ export default function GameArcade() {
 
         {/* Action Buttons */}
         <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-          <Button className={`bg-[#0C0C4F] hover:bg-slate-700 text-white px-6 py-3 rounded-lg text-xl font-black`} onClick={handleCreateGame}>
+          <Button className="bg-[#0C0C4F] hover:bg-slate-700 text-white px-6 py-3 rounded-lg text-xl font-black" onClick={handleCreateGame}>
             Create Game
+          </Button>
+          <Button asChild variant="outline" className="border-2 border-[#0C0C4F] text-[#0C0C4F] hover:bg-[#0C0C4F]/10 px-6 py-3 rounded-lg text-xl font-black">
+            <Link href="/dashboard">My Hunts</Link>
           </Button>
           <Button className="bg-[#E87785] hover:bg-[#d4606f] text-white px-6 py-3 rounded-lg text-xl font-black">Play Game</Button>
         </div>

--- a/components/ActivateHuntModal.tsx
+++ b/components/ActivateHuntModal.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface ActivateHuntModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  huntTitle: string
+  isActivating?: boolean
+}
+
+export function ActivateHuntModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  huntTitle,
+  isActivating = false,
+}: ActivateHuntModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-md text-center">
+        <DialogHeader>
+          <DialogTitle className="font-bold bg-gradient-to-b from-[#2D4FEB] to-[#0C0C4F] text-transparent bg-clip-text mb-4 text-center text-2xl">
+            Activate this hunt?
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <p className="text-slate-600 text-lg">
+            Once activated, <strong>an active hunt cannot be edited.</strong> Players will be able to
+            participate and it will appear in the public Game Arcade.
+          </p>
+          {huntTitle && (
+            <p className="text-slate-500 text-sm">
+              Hunt: &quot;{huntTitle}&quot;
+            </p>
+          )}
+          <div className="flex gap-4">
+            <Button
+              onClick={onClose}
+              variant="outline"
+              className="flex-1"
+              disabled={isActivating}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={onConfirm}
+              className="flex-1 bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 text-white"
+              disabled={isActivating}
+            >
+              {isActivating ? "Activating…" : "Activate"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/HuntDashboard.tsx
+++ b/components/HuntDashboard.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardDescription, CardTitle } from "@/components/ui/card"
+import type { StoredHunt } from "@/lib/huntStore"
+import { ActivateHuntModal } from "@/components/ActivateHuntModal"
+
+interface HuntDashboardProps {
+  hunts: StoredHunt[]
+  onActivate: (huntId: number) => Promise<void>
+  onRefresh: () => void
+}
+
+function StatusBadge({ status }: { status: StoredHunt["status"] }) {
+  const styles =
+    status === "Active"
+      ? "bg-emerald-100 text-emerald-800 border-emerald-200"
+      : status === "Completed"
+        ? "bg-slate-100 text-slate-700 border-slate-200"
+        : "bg-amber-100 text-amber-800 border-amber-200"
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${styles}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+export function HuntDashboard({ hunts, onActivate, onRefresh }: HuntDashboardProps) {
+  const [modalHunt, setModalHunt] = useState<StoredHunt | null>(null)
+  const [activatingId, setActivatingId] = useState<number | null>(null)
+
+  const handleActivateClick = (hunt: StoredHunt) => {
+    setModalHunt(hunt)
+  }
+
+  const handleConfirmActivate = async () => {
+    if (!modalHunt) return
+    setActivatingId(modalHunt.id)
+    try {
+      await onActivate(modalHunt.id)
+      onRefresh()
+      setModalHunt(null)
+    } finally {
+      setActivatingId(null)
+    }
+  }
+
+  return (
+    <>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {hunts.map((hunt) => {
+          const isDraft = hunt.status === "Draft"
+          const hasClues = hunt.cluesCount > 0
+          const canActivate = isDraft && hasClues
+
+          return (
+            <Card
+              key={hunt.id}
+              className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+            >
+              <div className="p-5">
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <CardTitle className="line-clamp-2 text-lg">{hunt.title}</CardTitle>
+                  <StatusBadge status={hunt.status} />
+                </div>
+                <CardDescription className="mb-4 line-clamp-3 text-sm text-slate-600">
+                  {hunt.description}
+                </CardDescription>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="text-xs text-slate-500">
+                    {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
+                  </span>
+                  <Button
+                    size="sm"
+                    onClick={() => handleActivateClick(hunt)}
+                    disabled={!canActivate}
+                    className="bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Activate
+                  </Button>
+                </div>
+                {isDraft && !hasClues && (
+                  <p className="mt-2 text-xs text-amber-600">
+                    Add at least one clue to activate.
+                  </p>
+                )}
+              </div>
+            </Card>
+          )
+        })}
+      </div>
+
+      <ActivateHuntModal
+        isOpen={!!modalHunt}
+        onClose={() => setModalHunt(null)}
+        onConfirm={handleConfirmActivate}
+        huntTitle={modalHunt?.title ?? ""}
+        isActivating={activatingId !== null}
+      />
+    </>
+  )
+}

--- a/lib/huntStore.ts
+++ b/lib/huntStore.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared hunt list for dashboard (creator hunts) and Game Arcade (active hunts).
+ * Persisted in localStorage so activated hunts appear in the arcade after refresh.
+ */
+
+export type HuntStatus = "Active" | "Completed" | "Draft"
+
+export interface StoredHunt {
+  id: number
+  title: string
+  description: string
+  cluesCount: number
+  status: HuntStatus
+}
+
+const STORAGE_KEY = "hunty_hunts"
+
+const SEED_HUNTS: StoredHunt[] = [
+  {
+    id: 1,
+    title: "City Secrets",
+    description: "Race across town to uncover hidden murals and landmarks.",
+    cluesCount: 5,
+    status: "Active",
+  },
+  {
+    id: 2,
+    title: "Campus Quest",
+    description: "Solve riddles scattered around campus before the timer ends.",
+    cluesCount: 7,
+    status: "Active",
+  },
+  {
+    id: 3,
+    title: "Office Onboarding Hunt",
+    description: "A playful intro game for new teammates around the office.",
+    cluesCount: 4,
+    status: "Completed",
+  },
+  {
+    id: 4,
+    title: "Summer Treasure Hunt",
+    description: "Find hidden clues in the park.",
+    cluesCount: 3,
+    status: "Draft",
+  },
+  {
+    id: 5,
+    title: "Museum Mystery",
+    description: "Discover art and history through clues.",
+    cluesCount: 0,
+    status: "Draft",
+  },
+]
+
+function readHunts(): StoredHunt[] {
+  if (typeof window === "undefined") return [...SEED_HUNTS]
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return [...SEED_HUNTS]
+    const parsed = JSON.parse(raw) as StoredHunt[]
+    return Array.isArray(parsed) ? parsed : [...SEED_HUNTS]
+  } catch {
+    return [...SEED_HUNTS]
+  }
+}
+
+function writeHunts(hunts: StoredHunt[]): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(hunts))
+  } catch {
+    // ignore
+  }
+}
+
+/** All hunts (for Game Arcade: filter by status === "Active"). */
+export function getAllHunts(): StoredHunt[] {
+  return readHunts()
+}
+
+/** Creator hunts for dashboard (all stored hunts; creator filter can be added later). */
+export function getCreatorHunts(): StoredHunt[] {
+  return readHunts()
+}
+
+/** Update a hunt's status (e.g. Draft → Active after activate_hunt). */
+export function updateHuntStatus(huntId: number, status: HuntStatus): void {
+  const hunts = readHunts().map((h) => (h.id === huntId ? { ...h, status } : h))
+  writeHunts(hunts)
+}
+
+/** Add a new hunt (e.g. after createHunt). */
+export function addHunt(hunt: StoredHunt): void {
+  const hunts = readHunts()
+  if (hunts.some((h) => h.id === hunt.id)) return
+  writeHunts([...hunts, hunt])
+}


### PR DESCRIPTION
## Activate hunt: Draft → Active (publish for players)

### Summary
Adds a creator flow to move a hunt from **Draft** to **Active** via the `activate_hunt(hunt_id: u64)` contract path. Includes validation (Activate only when the hunt has at least one clue), a confirmation modal, and makes activated hunts show in the public Game Arcade.
closes #5 
### Changes
- **`lib/contracts/hunt.ts`** – New `activateHunt(huntId: number)` that builds and submits the activate transaction (wallet sign + Soroban RPC). Ready to plug in a real contract `activate_hunt(hunt_id: u64)` when deployed.
- **`lib/huntStore.ts`** – Shared hunt list (localStorage): `getAllHunts()`, `getCreatorHunts()`, `updateHuntStatus()`. Seed data includes Draft and Active hunts for testing.
- **`components/ActivateHuntModal.tsx`** – Confirmation modal warning that **an active hunt cannot be edited**; Cancel / Activate (with loading state).
- **`components/HuntDashboard.tsx`** – Creator hunt cards with status badge (Draft / Active / Completed) and **Activate** button enabled only when status is Draft **and** `cluesCount > 0`; disabled with hint when 0 clues.
- **`app/dashboard/page.tsx`** – “My Hunts” dashboard: lists creator hunts, calls `activateHunt` then `updateHuntStatus(id, "Active")` and refreshes list.
- **`app/page.tsx`** – Game Arcade reads active hunts from the same store (`getAllHunts()` filtered by `status === "Active"`). Added **My Hunts** button linking to `/dashboard`.

### Acceptance criteria
- [x] Activate button only enabled for valid states (Draft + at least one clue).
- [x] Confirmation modal warns that an active hunt cannot be edited.
- [x] Successful transaction updates the hunt status badge to “Active”.
- [x] Activated hunt is visible in the public Game Arcade (and persists after refresh).

### How to test
1. Open **Game Arcade** → **My Hunts** (or go to `/dashboard`).
2. Find a **Draft** hunt with **clues > 0** → **Activate** is enabled; with **0 clues** it’s disabled and shows “Add at least one clue to activate.”
3. Click **Activate** → confirm in the modal → sign in wallet; after success the card shows **Active** and the list refreshes.
4. Go to **Game Arcade** (or refresh) and confirm the hunt appears under “Browse Active Hunts.”