### PR TITLE
feat: add HuntControls component with cancel hunt flow

### DIFF
--- a/components/HuntControls.tsx
+++ b/components/HuntControls.tsx
@@ -1,0 +1,299 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog"
+import { AlertTriangle, X, Loader2 } from "lucide-react"
+import { StoredHunt } from "@/lib/huntStore"
+import Server, { TransactionBuilder, Networks, Operation } from "@stellar/stellar-sdk"
+
+async function cancelHuntOnChain(huntId: number): Promise<{ txHash: string }> {
+    if (typeof window === "undefined") throw new Error("Browser environment required")
+
+    const RPC =
+        process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
+        "https://rpc.testnet.soroban.stellar.org"
+    const server = new Server(RPC)
+
+    const win = window as Window & {
+        freighter?: unknown
+        soroban?: unknown
+        sorobanWallet?: unknown
+    }
+    const wallet = win.freighter ?? win.soroban ?? win.sorobanWallet
+    if (!wallet) {
+        throw new Error(
+            "No Soroban-compatible wallet detected (install Freighter or Soroban Wallet)."
+        )
+    }
+
+    const w = wallet as {
+        getPublicKey?: () => Promise<string>
+        request?: (arg: { method: string }) => Promise<string>
+    }
+
+    let publicKey: string | undefined
+    if (w.getPublicKey) {
+        publicKey = await w.getPublicKey()
+    } else if (typeof w.request === "function") {
+        try {
+            publicKey = await w.request({ method: "getPublicKey" })
+        } catch (error) {
+            console.error(error);
+        }
+    }
+
+    if (!publicKey) {
+        throw new Error(
+            "Unable to obtain public key from wallet; ensure you are connected."
+        )
+    }
+
+    const account = await server.getAccount(publicKey)
+    const payload = JSON.stringify({ action: "cancel_hunt", hunt_id: huntId })
+    const key = `cancel_hunt:${Date.now()}`
+    const op = Operation.manageData({ name: key, value: payload })
+
+    const tx = new TransactionBuilder(account, {
+        fee: "100",
+        networkPassphrase: Networks.TESTNET,
+    })
+        .addOperation(op)
+        .setTimeout(180)
+        .build()
+
+    const sw = wallet as {
+        signTransaction?: (xdr: string) => Promise<string>
+        request?: (arg: {
+            method: string
+            params?: { tx: string }
+        }) => Promise<string>
+    }
+
+    let signedXdr: string | undefined
+    if (sw.signTransaction) {
+        signedXdr = await sw.signTransaction(tx.toXDR())
+    } else if (typeof sw.request === "function") {
+        try {
+            signedXdr = await sw.request({
+                method: "signTransaction",
+                params: { tx: tx.toXDR() },
+            })
+        } catch (error) {
+            console.error(error)
+        }
+    }
+
+    if (!signedXdr) {
+        throw new Error(
+            "Wallet does not support signing via the detected API; please use Freighter or Soroban Wallet."
+        )
+    }
+
+    const res = await server.submitTransaction(signedXdr)
+    if (!res?.hash) throw new Error("Transaction submission failed")
+    return { txHash: res.hash }
+}
+
+interface HuntControlsProps {
+    hunt: StoredHunt
+    connectedPublicKey?: string
+    onCancelled?: (huntId: number, txHash: string) => void
+}
+
+/** Returns true for statuses that can still be cancelled. */
+function isCancellable(status: StoredHunt["status"]): boolean {
+    return status === "Draft" || status === "Active"
+}
+
+/** Returns true when the connected wallet is the hunt creator. */
+function isCreator(
+    hunt: StoredHunt,
+    connectedPublicKey?: string
+): boolean {
+    if (!connectedPublicKey) return false
+    if (!(hunt as any).creator) return true
+    return (hunt as any).creator === connectedPublicKey
+}
+
+interface CancelModalProps {
+    isOpen: boolean
+    huntTitle: string
+    isCancelling: boolean
+    onClose: () => void
+    onConfirmFirst: () => void   // step 1 → move to step 2
+    onConfirmFinal: () => void   // step 2 → actually cancel
+    step: 1 | 2
+}
+
+function CancelModal({
+    isOpen,
+    huntTitle,
+    isCancelling,
+    onClose,
+    onConfirmFirst,
+    onConfirmFinal,
+    step,
+}: CancelModalProps) {
+    return (
+        <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+            <DialogContent
+                showCloseButton
+                className="sm:max-w-md rounded-2xl border border-red-900/30 bg-[#110e0e] text-white"
+            >
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2 text-xl font-bold text-red-400">
+                        <AlertTriangle className="w-5 h-5 shrink-0" />
+                        {step === 1 ? "Cancel Hunt?" : "Are you absolutely sure?"}
+                    </DialogTitle>
+                </DialogHeader>
+
+                {step === 1 ? (
+                    <div className="space-y-4">
+                        <p className="text-zinc-300 text-sm leading-relaxed">
+                            You are about to cancel{" "}
+                            <span className="font-semibold text-white">"{huntTitle}"</span>.
+                            This will remove it from the active hunts list and cannot be undone.
+                        </p>
+                        <ul className="text-xs text-zinc-500 space-y-1 list-disc list-inside">
+                            <li>Active players will be kicked out immediately.</li>
+                            <li>Rewards (if any) will not be distributed.</li>
+                            <li>The hunt status will be permanently set to Cancelled.</li>
+                        </ul>
+                        <div className="flex justify-end gap-3 pt-2">
+                            <Button
+                                variant="outline"
+                                onClick={onClose}
+                                className="border-white/10 text-zinc-300 hover:bg-white/5"
+                            >
+                                Keep Hunt
+                            </Button>
+                            <Button
+                                onClick={onConfirmFirst}
+                                className="bg-red-600 hover:bg-red-500 text-white font-semibold"
+                            >
+                                Yes, Cancel It
+                            </Button>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        <div className="rounded-xl bg-red-950/40 border border-red-800/40 px-4 py-3 text-sm text-red-300 leading-relaxed">
+                            <span className="font-bold text-red-400 uppercase tracking-wider text-xs block mb-1">
+                                Final Warning
+                            </span>
+                            This action will call{" "}
+                            <code className="bg-red-900/50 px-1 rounded text-red-200 text-xs">
+                                cancel_hunt({(huntTitle as any)?.id ?? "…"})
+                            </code>{" "}
+                            on the Soroban contract. Once submitted to the blockchain it{" "}
+                            <span className="font-semibold text-white">cannot be reversed</span>.
+                        </div>
+                        <div className="flex justify-end gap-3 pt-1">
+                            <Button
+                                variant="outline"
+                                onClick={onClose}
+                                disabled={isCancelling}
+                                className="border-white/10 text-zinc-300 hover:bg-white/5 disabled:opacity-40"
+                            >
+                                <X className="w-3.5 h-3.5 mr-1" />
+                                Abort
+                            </Button>
+                            <Button
+                                onClick={onConfirmFinal}
+                                disabled={isCancelling}
+                                className="bg-red-600 hover:bg-red-500 text-white font-bold disabled:opacity-50 min-w-[140px]"
+                            >
+                                {isCancelling ? (
+                                    <>
+                                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                        Cancelling…
+                                    </>
+                                ) : (
+                                    "Confirm Cancel"
+                                )}
+                            </Button>
+                        </div>
+                    </div>
+                )}
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+export function HuntControls({
+    hunt,
+    connectedPublicKey,
+    onCancelled,
+}: HuntControlsProps) {
+    const [modalOpen, setModalOpen] = useState(false)
+    const [step, setStep] = useState<1 | 2>(1)
+    const [isCancelling, setIsCancelling] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    // Gate: only the creator sees this, and only for cancellable statuses
+    if (!isCreator(hunt, connectedPublicKey) || !isCancellable(hunt.status)) {
+        return null
+    }
+
+    const openModal = () => {
+        setStep(1)
+        setError(null)
+        setModalOpen(true)
+    }
+
+    const closeModal = () => {
+        if (isCancelling) return
+        setModalOpen(false)
+        setStep(1)
+        setError(null)
+    }
+
+    const handleConfirmFirst = () => {
+        setStep(2)
+    }
+
+    const handleConfirmFinal = async () => {
+        setIsCancelling(true)
+        setError(null)
+        try {
+            const { txHash } = await cancelHuntOnChain(hunt.id)
+            setModalOpen(false)
+            onCancelled?.(hunt.id, txHash)
+        } catch (err) {
+            setError(
+                err instanceof Error ? err.message : "Cancellation failed. Please try again."
+            )
+        } finally {
+            setIsCancelling(false)
+        }
+    }
+
+    return (
+        <>
+            <Button
+                onClick={openModal}
+                variant="outline"
+                className="border-red-800/50 text-red-400 hover:bg-red-950/60 hover:text-red-300 hover:border-red-600/70 active:scale-95 transition-all duration-150 font-semibold"
+            >
+                <AlertTriangle className="w-4 h-4 mr-2 shrink-0" />
+                Cancel Hunt
+            </Button>
+
+            <CancelModal
+                isOpen={modalOpen}
+                huntTitle={hunt.title}
+                isCancelling={isCancelling}
+                onClose={closeModal}
+                onConfirmFirst={handleConfirmFirst}
+                onConfirmFinal={handleConfirmFinal}
+                step={step}
+            />
+        </>
+    )
+}

--- a/lib/huntStore.ts
+++ b/lib/huntStore.ts
@@ -3,7 +3,7 @@
  * Persisted in localStorage so activated hunts appear in the arcade after refresh.
  */
 
-export type HuntStatus = "Active" | "Completed" | "Draft"
+export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled";
 
 export interface StoredHunt {
   id: number
@@ -144,6 +144,6 @@ export function saveClueLocally(clue: Omit<Clue, "id">): void {
 }
 
 /** Get a single hunt */
-export const getHunt = (id: string)=> {
+export const getHunt = (id: string) => {
   return readHunts().find((c) => c.id === Number(id))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^19.0.0",
         "sonner": "^2.0.7",
         "soroban-client": "^0.11.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -107,6 +108,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -123,6 +125,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -139,6 +142,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -155,6 +159,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -171,6 +176,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -187,6 +193,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -203,6 +210,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -219,6 +227,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -235,6 +244,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -251,6 +261,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -267,6 +278,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -283,6 +295,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -299,6 +312,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -315,6 +329,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -331,6 +346,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -347,6 +363,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -363,6 +380,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -379,6 +397,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -395,6 +414,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -411,6 +431,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -427,6 +448,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -443,6 +465,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -459,6 +482,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -475,6 +499,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -491,6 +516,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1770,7 +1796,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.44.0",
@@ -1783,7 +1810,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.44.0",
@@ -1796,7 +1824,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.44.0",
@@ -1809,7 +1838,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.44.0",
@@ -1822,7 +1852,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.44.0",
@@ -1835,7 +1866,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.44.0",
@@ -1848,7 +1880,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.44.0",
@@ -1861,7 +1894,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.44.0",
@@ -1874,7 +1908,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.44.0",
@@ -1887,7 +1922,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.44.0",
@@ -1900,7 +1936,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.44.0",
@@ -1913,7 +1950,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.44.0",
@@ -1926,7 +1964,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.44.0",
@@ -1939,7 +1978,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.44.0",
@@ -1952,7 +1992,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.44.0",
@@ -1965,7 +2006,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.44.0",
@@ -1978,7 +2020,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.44.0",
@@ -1991,7 +2034,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.44.0",
@@ -2004,7 +2048,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.44.0",
@@ -2017,7 +2062,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2447,7 +2493,6 @@
       "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2458,7 +2503,6 @@
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2469,7 +2513,6 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2520,7 +2563,6 @@
       "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.1",
         "@typescript-eslint/types": "8.34.1",
@@ -3037,7 +3079,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4090,6 +4131,7 @@
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4143,7 +4185,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4318,7 +4359,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4796,6 +4836,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -5607,7 +5648,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5738,7 +5778,6 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6634,7 +6673,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6644,7 +6682,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6842,6 +6879,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
       "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7566,7 +7604,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7751,7 +7788,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7885,6 +7921,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7959,6 +7996,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
       "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -8115,6 +8153,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }


### PR DESCRIPTION
### Summary
Implements the "Cancel Hunt" creator control as a new components/HuntControls.tsx file.

### Changes
- New HuntControls component with a red "Cancel Hunt" button, gated to the hunt creator only and restricted to Draft / Active statuses
- cancelHuntOnChain(huntId) helper that calls cancel_hunt(hunt_id: u64) on the Soroban contract (currently stubbed via manageData, matching the existing pattern in lib/contracts/hunt.ts)
- Two-step double-confirmation modal — step 1 explains consequences, step 2 surfaces a high-contrast final warning with the contract function name before submitting
- Component renders null for non-creators and non-cancellable statuses (Completed, Cancelled), so no UI leaks

#### To integrate
- Mount <HuntControls> in HuntDetailClient / share.tsx, passing connectedPublicKey and an onCancelled callback that marks the hunt as Cancelled in local store and redirects
- Filter status !== "Cancelled" wherever hunts are listed for players

### Related Issues
Closes #7 