### PR TITLE
feature/ipfs-integration: add IPFS storage for hunt images via Pinata

### DIFF
--- a/app/api/ipfs/route.ts
+++ b/app/api/ipfs/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const PINATA_JWT = process.env.PINATA_JWT
+
+export async function POST(req: NextRequest) {
+  if (!PINATA_JWT) {
+    return NextResponse.json(
+      { error: "IPFS uploads are not configured. Add PINATA_JWT to your environment variables." },
+      { status: 503 }
+    )
+  }
+
+  const formData = await req.formData()
+  const file = formData.get("file")
+
+  if (!file || !(file instanceof Blob)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 })
+  }
+
+  // Forward to Pinata's pinFileToIPFS endpoint
+  const pinataForm = new FormData()
+  pinataForm.append("file", file)
+
+  const pinataRes = await fetch("https://api.pinata.cloud/pinning/pinFileToIPFS", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${PINATA_JWT}`,
+    },
+    body: pinataForm,
+  })
+
+  if (!pinataRes.ok) {
+    const errText = await pinataRes.text()
+    console.error("Pinata upload error:", pinataRes.status, errText)
+    return NextResponse.json({ error: "Failed to pin file to IPFS" }, { status: 502 })
+  }
+
+  const data = await pinataRes.json() as { IpfsHash: string }
+  return NextResponse.json({ cid: data.IpfsHash })
+}

--- a/app/hunty/page.tsx
+++ b/app/hunty/page.tsx
@@ -151,9 +151,11 @@ export default function CreateGame() {
       const end_time = Math.floor(endMs / 1000)
 
       const description = hunts.map((h) => `${h.title}: ${h.description}`).join("\n")
+      // Use the first hunt's image CID (if uploaded to IPFS) as the game cover.
+      const coverImageCid = hunts[0]?.image?.startsWith("ipfs://") ? hunts[0].image : undefined
 
       await withTransactionToast(
-        () => createHunt("", gameName, description, start_time, end_time),
+        () => createHunt("", gameName, description, start_time, end_time, coverImageCid),
         {
           loading: "Confirming in Wallet...",
           submitted: "Transaction Submitted",

--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, CheckCircle2, Loader2 } from "lucide-react";
 import picture from "@/public/static-images/image1.png";
 import { Skeleton } from "@/components/ui/skeleton";
 import { submitAnswer, AnswerIncorrectError } from "@/lib/contracts/hunt";
+import { resolveImageSrc, GATEWAY_COUNT } from "@/lib/ipfs";
 
 export interface Hunt {
   id: string | number;
@@ -48,6 +49,7 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [isPending, setIsPending] = useState(false);
+  const [imgGatewayIdx, setImgGatewayIdx] = useState(0);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (isPending) return;
@@ -141,7 +143,18 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           {hunt.description || "No description provided."}
         </p>
         {hunt.link || hunt.image ? (
-          <Image src={hunt.link || hunt.image || picture} alt="hunt" width={180} height={180} />
+          <Image
+            src={resolveImageSrc(hunt.link || hunt.image || "", imgGatewayIdx)}
+            alt="hunt"
+            width={180}
+            height={180}
+            onError={() => {
+              if (imgGatewayIdx < GATEWAY_COUNT - 1) {
+                setImgGatewayIdx((i) => i + 1)
+              }
+            }}
+            unoptimized
+          />
         ) : (
           <Image src={picture} alt="hunt" width={180} height={180} />
         )}

--- a/components/HuntForm.tsx
+++ b/components/HuntForm.tsx
@@ -8,6 +8,8 @@ import { ChangeEvent, useRef, useState } from "react"
 import { addClue } from "@/lib/contracts/hunt"
 import { saveClueLocally } from "@/lib/huntStore"
 import { withTransactionToast } from "@/lib/txToast"
+import { uploadToIPFS } from "@/lib/ipfs"
+import { toast } from "sonner"
 
 interface Hunt {
   id: number
@@ -48,13 +50,11 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
     setIsUploading(true)
 
     try {
-      // Here you would typically upload the file to your server
-      // For now, we'll create a local URL for the image
-      const imageUrl = URL.createObjectURL(file)
-      onUpdate('image', imageUrl)
+      const ipfsUri = await uploadToIPFS(file)
+      onUpdate('image', ipfsUri)
     } catch (error) {
-      console.error('Error uploading image:', error)
-      // Handle error (e.g., show error message to user)
+      console.error('Error uploading image to IPFS:', error)
+      toast.error(error instanceof Error ? error.message : 'Image upload failed')
     } finally {
       setIsUploading(false)
     }

--- a/lib/contracts/hunt.ts
+++ b/lib/contracts/hunt.ts
@@ -31,7 +31,9 @@ export async function createHunt(
   title: string,
   description: string,
   start_time: number,
-  end_time: number
+  end_time: number,
+  /** IPFS CID (or ipfs:// URI) for the hunt cover image, stored on-chain. */
+  imageCid?: string
 ): Promise<CreateHuntResult> {
   if (typeof window === "undefined") throw new Error("Browser environment required")
 
@@ -47,7 +49,15 @@ export async function createHunt(
   }
 
   // Prepare the payload and encode as string (manageData value must be string/buffer)
-  const payload = JSON.stringify({ action: "create_hunt", creator, title, description, start_time, end_time })
+  const payload = JSON.stringify({
+    action: "create_hunt",
+    creator,
+    title,
+    description,
+    start_time,
+    end_time,
+    ...(imageCid ? { image_cid: imageCid } : {}),
+  })
 
   // Ask the wallet for the public key. Different wallets expose slightly
   // different APIs; we try common ones (Freighter, Soroban wallet adapter).

--- a/lib/ipfs.ts
+++ b/lib/ipfs.ts
@@ -1,0 +1,82 @@
+/**
+ * IPFS utility helpers.
+ *
+ * Uploads are proxied through /api/ipfs so the Pinata JWT stays server-side.
+ * Gateway URLs use public IPFS gateways with an optional configurable primary
+ * (set NEXT_PUBLIC_PINATA_GATEWAY to your custom Pinata gateway hostname,
+ *  e.g. "mypinata.mypinata.cloud").
+ */
+
+const PINATA_GATEWAY = process.env.NEXT_PUBLIC_PINATA_GATEWAY
+
+// Ordered list of public fallback gateways.
+const GATEWAYS: string[] = [
+  PINATA_GATEWAY ? `https://${PINATA_GATEWAY}` : "https://gateway.pinata.cloud",
+  "https://cloudflare-ipfs.com",
+  "https://dweb.link",
+  "https://ipfs.io",
+]
+
+/** Total number of available gateways (used by consumers for fallback cycling). */
+export const GATEWAY_COUNT = GATEWAYS.length
+
+/**
+ * Returns the IPFS gateway URL for a given CID using the gateway at `index`.
+ * Wraps around if index exceeds the available gateway count.
+ */
+export function getIPFSUrl(cid: string, gatewayIndex = 0): string {
+  const gateway = GATEWAYS[gatewayIndex % GATEWAYS.length]
+  return `${gateway}/ipfs/${cid}`
+}
+
+/**
+ * Converts an `ipfs://` URI or bare CID to an HTTP gateway URL.
+ * Regular HTTP/HTTPS URLs are returned unchanged (passthrough).
+ */
+export function resolveImageSrc(src: string, gatewayIndex = 0): string {
+  if (src.startsWith("ipfs://")) {
+    return getIPFSUrl(src.slice(7), gatewayIndex)
+  }
+  // Bare CID heuristic: CIDv0 starts with "Qm", CIDv1 starts with "bafy"
+  if (src.startsWith("Qm") || src.startsWith("bafy")) {
+    return getIPFSUrl(src, gatewayIndex)
+  }
+  return src
+}
+
+/**
+ * Extracts the raw CID from an `ipfs://` URI, a gateway URL, or a bare CID.
+ * Returns `null` if the string doesn't look like an IPFS reference.
+ */
+export function extractCID(src: string): string | null {
+  if (src.startsWith("ipfs://")) return src.slice(7)
+  if (src.startsWith("Qm") || src.startsWith("bafy")) return src
+  const match = src.match(/\/ipfs\/([A-Za-z0-9]+)/)
+  return match ? match[1] : null
+}
+
+/**
+ * Uploads a file to IPFS via the server-side `/api/ipfs` proxy.
+ * Returns an `ipfs://` URI on success.
+ *
+ * Throws if:
+ * - The API route returns an error (e.g. PINATA_JWT not configured)
+ * - The network request fails
+ */
+export async function uploadToIPFS(file: File): Promise<string> {
+  const formData = new FormData()
+  formData.append("file", file)
+
+  const res = await fetch("/api/ipfs", {
+    method: "POST",
+    body: formData,
+  })
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText })) as { error?: string }
+    throw new Error(err.error ?? "IPFS upload failed")
+  }
+
+  const { cid } = await res.json() as { cid: string }
+  return `ipfs://${cid}`
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      // Pinata public gateway
+      { protocol: "https", hostname: "gateway.pinata.cloud" },
+      // Pinata custom dedicated gateways (*.mypinata.cloud)
+      { protocol: "https", hostname: "**.mypinata.cloud" },
+      // Cloudflare IPFS gateway
+      { protocol: "https", hostname: "cloudflare-ipfs.com" },
+      // Protocol Labs gateways
+      { protocol: "https", hostname: "dweb.link" },
+      { protocol: "https", hostname: "ipfs.io" },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #41 
- Add lib/ipfs.ts with uploadToIPFS, resolveImageSrc, and gateway fallback helpers
- Add app/api/ipfs/route.ts server-side Pinata proxy (keeps JWT out of the browser)
- Update HuntForm to upload images to IPFS and store ipfs:// URIs instead of blob URLs
- Update HuntCards to resolve IPFS URIs to gateway URLs with automatic fallback cycling on error
- Extend createHunt contract payload to include image_cid for on-chain CID tracking
- Add IPFS gateway domains to next.config.ts remotePatterns