### PR TITLE
fix: replaced hardcoded reward with sum of rewards state

### DIFF
--- a/app/hunty/page.tsx
+++ b/app/hunty/page.tsx
@@ -213,7 +213,7 @@ export default function CreateGame() {
               setShowGameCompleteModal(false)
               window.location.href = "/?tab=leaderboard"
             }}
-            reward={5.43}
+            reward={rewardPool}
           />
         }
       />


### PR DESCRIPTION
## Fix: Replace Hardcoded Reward Amount with Dynamic Reward Pool

### Description
Fixes the hardcoded reward amount in the `GameCompleteModal` component. Winners now see the actual total reward amount from the configured reward pool instead of a fixed 5.43 value.

### Changes
- **Modified**: `app/hunty/page.tsx` (Line 216)
  - Changed `reward={5.43}` to `reward={rewardPool}`
  - The `rewardPool` is dynamically calculated by summing all reward amounts from the rewards state

### Technical Details
- `rewardPool` is calculated on line 85: `rewards.reduce((sum, r) => sum + r.amount, 0)`
- `GameCompleteModal` component already supports dynamic reward values via the `reward` prop
- No component interface changes needed

### Testing
- Verify modal displays correct total when rewards are added to the pool
- Test with various reward configurations (single reward, multiple rewards, zero rewards)

### Closes
#55