### PR TITLE
feat: add Zustand stores for wallet and player progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "galagiorchi",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-collection": "^1.1.7",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
@@ -25,12 +26,14 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.72.0",
         "react-joyride": "^3.0.0",
         "resend": "^6.9.4",
         "sonner": "^2.0.7",
         "soroban-client": "^0.11.0",
         "tailwind-merge": "^3.3.1",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -995,6 +998,18 @@
       "license": "MIT",
       "dependencies": {
         "type-fest": "^4.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2626,6 +2641,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@stellar/freighter-api": {
@@ -8001,6 +8022,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
+      "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-innertext": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
@@ -9951,6 +9988,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "sonner": "^2.0.7",
     "soroban-client": "^0.11.0",
     "tailwind-merge": "^3.3.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/store/useStore.ts
+++ b/store/useStore.ts
@@ -1,0 +1,105 @@
+/**
+ * Global Zustand store for Hunty.
+ *
+ * Replaces prop drilling for wallet state and current player progress.
+ *
+ * Usage:
+ *   const { walletAddress, walletBalance, isConnected } = useWalletStore()
+ *   const { currentProgress, setProgress } = usePlayerStore()
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { PlayerProgress } from "@/lib/types";
+
+// ─── Wallet Store ─────────────────────────────────────────────────────────────
+
+interface WalletState {
+  /** Full Stellar public key of the connected account, or empty string */
+  walletAddress: string;
+  /** XLM balance as a formatted string (e.g. "42.5000000"), or null if not yet fetched */
+  walletBalance: string | null;
+  /** Whether a wallet is currently connected */
+  isConnected: boolean;
+
+  // Actions
+  setWallet: (address: string) => void;
+  setBalance: (balance: string | null) => void;
+  clearWallet: () => void;
+}
+
+/**
+ * Wallet store — persisted to localStorage so the session survives page refreshes.
+ *
+ * Sync this store whenever useFreighterWallet fires connect / disconnect,
+ * or call setWallet / clearWallet directly.
+ */
+export const useWalletStore = create<WalletState>()(
+  persist(
+    (set) => ({
+      walletAddress: "",
+      walletBalance: null,
+      isConnected: false,
+
+      setWallet: (address) =>
+        set({ walletAddress: address, isConnected: Boolean(address) }),
+
+      setBalance: (balance) => set({ walletBalance: balance }),
+
+      clearWallet: () =>
+        set({ walletAddress: "", walletBalance: null, isConnected: false }),
+    }),
+    {
+      name: "hunty-wallet",
+      // Only persist the address — balance is fetched on demand
+      partialize: (state) => ({ walletAddress: state.walletAddress }),
+      // Re-hydrate isConnected after restoring the address
+      onRehydrateStorage: () => (state) => {
+        if (state?.walletAddress) {
+          state.isConnected = true;
+        }
+      },
+    },
+  ),
+);
+
+// ─── Player Progress Store ────────────────────────────────────────────────────
+
+interface PlayerState {
+  /** Progress for the hunt the player is currently active in, or null */
+  currentProgress: PlayerProgress | null;
+
+  // Actions
+  setProgress: (progress: PlayerProgress) => void;
+  updateClueIndex: (index: number) => void;
+  markCompleted: () => void;
+  clearProgress: () => void;
+}
+
+/**
+ * Player progress store — tracks the active hunt session in memory.
+ *
+ * Set currentProgress when a player registers or resumes a hunt.
+ * Clear it when the hunt ends or the player navigates away.
+ */
+export const usePlayerStore = create<PlayerState>()((set) => ({
+  currentProgress: null,
+
+  setProgress: (progress) => set({ currentProgress: progress }),
+
+  updateClueIndex: (index) =>
+    set((state) =>
+      state.currentProgress
+        ? { currentProgress: { ...state.currentProgress, current_clue_index: index } }
+        : state,
+    ),
+
+  markCompleted: () =>
+    set((state) =>
+      state.currentProgress
+        ? { currentProgress: { ...state.currentProgress, completed: true } }
+        : state,
+    ),
+
+  clearProgress: () => set({ currentProgress: null }),
+}));


### PR DESCRIPTION
Summary
Add store/useStore.ts with two Zustand slices to replace prop drilling
useWalletStore — manages wallet address, XLM balance, and connection state; persisted to localStorage so sessions survive page refreshes
usePlayerStore — tracks current hunt progress, active clue index, and completion flag in memory
What changed
New file: store/useStore.ts

useWalletStore
const { walletAddress, walletBalance, isConnected, setWallet, setBalance, clearWallet } = useWalletStore()
Persisted via zustand/middleware persist (key: hunty-wallet, address only)
isConnected is re-derived on rehydration — no stale booleans
usePlayerStore
const { currentProgress, setProgress, updateClueIndex, markCompleted, clearProgress } = usePlayerStore()
In-memory only — cleared when a hunt session ends
Acceptance criteria
 walletAddress and walletBalance accessible via useWalletStore() hook from any component
 currentProgress (including current_clue_index and completed) accessible via usePlayerStore() hook
 No TypeScript errors introduced
 Zero prop drilling required for wallet or player state
Test plan
 Connect Freighter wallet → call setWallet(address) → verify walletAddress and isConnected update
 Refresh page → verify walletAddress is restored from localStorage
 Call clearWallet() → verify all wallet state resets
 Register for a hunt → call setProgress(...) → verify currentProgress reflects correct clue index
 Submit correct answer → call updateClueIndex(i) → verify index advances
 Complete hunt → call markCompleted() → verify completed: true
closes https://github.com/Samuel1-ona/hunty/issues/
closes #83