### PR TITLE
feat: trigger confetti on hunt completion and difficult clues

### DIFF
--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import confetti from "canvas-confetti";
 import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -70,6 +71,26 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
         await submitAnswer(huntId, Number(hunt.id), input);
         // ClueCompleted event received
         setSuccess(true);
+        
+        // Celebratory confetti (Requirement #146)
+        const isLastClue = currentIndex === totalHunts;
+        const isDifficultClue = (points ?? DEFAULT_POINTS) >= 20;
+        
+        if (isLastClue) {
+          confetti({
+            particleCount: 150,
+            spread: 100,
+            origin: { y: 0.6 },
+            colors: ["#3737A4", "#E3225C", "#39A437", "#FFD43E"]
+          });
+        } else if (isDifficultClue) {
+          confetti({
+            particleCount: 80,
+            spread: 60,
+            origin: { y: 0.7 }
+          });
+        }
+
         setInput("");
         const actualPoints = Math.max(0, (points ?? DEFAULT_POINTS) - (hintRevealed ? (hunt.hintCost || 0) : 0));
         onScoreUpdate?.(actualPoints);
@@ -91,6 +112,25 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
       // Local fallback (test / preview mode — no wallet required)
       if (input.trim().toLowerCase() === (hunt.code || "").trim().toLowerCase()) {
         setSuccess(true);
+        
+        // Celebratory confetti for local/preview mode (Requirement #146)
+        const isLastClue = currentIndex === totalHunts;
+        const isDifficultClue = (points ?? DEFAULT_POINTS) >= 20;
+
+        if (isLastClue) {
+          confetti({
+            particleCount: 150,
+            spread: 100,
+            origin: { y: 0.6 }
+          });
+        } else if (isDifficultClue) {
+          confetti({
+            particleCount: 80,
+            spread: 60,
+            origin: { y: 0.7 }
+          });
+        }
+
         setError("");
         setInput("");
         const actualPoints = Math.max(0, (points ?? DEFAULT_POINTS) - (hintRevealed ? (hunt.hintCost || 0) : 0));


### PR DESCRIPTION
closes #146 

Summary of Changes
1. Confetti Integration
I updated components/HuntCards.tsx to import and utilize the canvas-confetti library. The animation is triggered immediately after a correct answer is verified, providing instant positive reinforcement.

2. Conditional Celebration Logic
I implemented logic to distinguish between different levels of success:

Difficult Clues: Triggered when a clue with 20 points or more is solved. This results in a moderate confetti burst.
Hunt Completion: Triggered when the final clue of a hunt is solved. This results in a large, multi-colored burst using the application's brand colors.
The implementation covers both the primary on-chain submission flow and the local preview/test mode.
