### PR TITLE
feat(mobile): Reanimated clue-unlock animation

### DIFF
--- a/mobile/app/(tabs)/play.tsx
+++ b/mobile/app/(tabs)/play.tsx
@@ -1,20 +1,231 @@
-import { StyleSheet } from 'react-native';
-import { ThemedView, ThemedCustomText } from '@components/themed';
+/**
+ * Play screen — mobile clue list with Reanimated unlock animation.
+ *
+ * Flow:
+ *   1. Clues are shown as a vertical list.
+ *   2. Only the current clue (current_clue_index) is active; solved ones are
+ *      unlocked; future ones are locked.
+ *   3. When the player submits a correct answer the tx is confirmed, then
+ *      `unlockedUpTo` advances by 1 — triggering the ClueListItem animation
+ *      on the newly revealed card.
+ */
+
+import React, { useState, useCallback } from 'react';
+import {
+  StyleSheet,
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ClueListItem } from '@components/ClueListItem';
+import { usePlayerStore } from '@store/useStore';
+import type { ClueInfo } from '@lib/types';
+
+// ─── Demo clues (replace with real contract fetch) ───────────────────────────
+
+const DEMO_CLUES: ClueInfo[] = [
+  { id: 0, question: 'I have cities, but no houses live there. I have mountains, but no trees grow there. What am I?', points: 10 },
+  { id: 1, question: 'The more you take, the more you leave behind. What am I?', points: 15 },
+  { id: 2, question: 'I speak without a mouth and hear without ears. I have no body, but I come alive with wind. What am I?', points: 20 },
+  { id: 3, question: 'I have hands but cannot clap. What am I?', points: 10 },
+  { id: 4, question: 'What has keys but no locks, space but no room, and you can enter but can\'t go inside?', points: 25 },
+];
+
+const DEMO_ANSWERS = ['map', 'footsteps', 'echo', 'clock', 'keyboard'];
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function PlayScreen() {
+  const { currentProgress, updateClueIndex } = usePlayerStore();
+
+  // unlockedUpTo: index of the highest clue that has been solved.
+  // Starts at current_clue_index - 1 (all previously solved clues are already unlocked).
+  const initialUnlocked = (currentProgress?.current_clue_index ?? 0) - 1;
+  const [unlockedUpTo, setUnlockedUpTo] = useState(initialUnlocked);
+  const activeIndex = unlockedUpTo + 1;
+
+  const [answer, setAnswer] = useState('');
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = useCallback(async () => {
+    if (isPending || !answer.trim()) return;
+    const clue = DEMO_CLUES[activeIndex];
+    if (!clue) return;
+
+    setIsPending(true);
+    setError('');
+
+    try {
+      // ── Simulate tx confirmation (replace with real submitAnswer call) ──
+      await new Promise<void>((resolve, reject) =>
+        setTimeout(() => {
+          const correct =
+            answer.trim().toLowerCase() === DEMO_ANSWERS[activeIndex];
+          correct ? resolve() : reject(new Error('incorrect'));
+        }, 900),
+      );
+
+      // Tx confirmed — unlock the next clue with animation
+      setUnlockedUpTo(activeIndex);
+      updateClueIndex(activeIndex + 1);
+      setAnswer('');
+    } catch {
+      setError('Incorrect answer — try again!');
+    } finally {
+      setIsPending(false);
+    }
+  }, [activeIndex, answer, isPending, updateClueIndex]);
+
+  const allSolved = activeIndex >= DEMO_CLUES.length;
+
   return (
-    <ThemedView style={styles.container}>
-      <ThemedCustomText variant="h2">Map/Play</ThemedCustomText>
-      <ThemedCustomText variant="body">Open the map, solve clues, and play active hunts.</ThemedCustomText>
-    </ThemedView>
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={80}
+      >
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.title}>🗺 Active Hunt</Text>
+          <Text style={styles.subtitle}>
+            {allSolved
+              ? '🎉 All clues solved!'
+              : `Clue ${activeIndex + 1} of ${DEMO_CLUES.length}`}
+          </Text>
+        </View>
+
+        {/* Clue list */}
+        <ScrollView
+          style={styles.list}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {DEMO_CLUES.map((clue, i) => (
+            <ClueListItem
+              key={clue.id}
+              clue={clue}
+              index={i}
+              isActive={i === activeIndex && !allSolved}
+              isUnlocked={i <= unlockedUpTo}
+            />
+          ))}
+        </ScrollView>
+
+        {/* Answer input — only shown while there are unsolved clues */}
+        {!allSolved && (
+          <View style={styles.inputArea}>
+            {error ? <Text style={styles.errorText}>{error}</Text> : null}
+            <View style={styles.inputRow}>
+              <TextInput
+                style={styles.input}
+                placeholder="Type your answer…"
+                placeholderTextColor="#9999BB"
+                value={answer}
+                onChangeText={(t) => { setAnswer(t); setError(''); }}
+                onSubmitEditing={handleSubmit}
+                returnKeyType="done"
+                editable={!isPending}
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+              <Pressable
+                style={[styles.submitBtn, isPending && styles.submitBtnDisabled]}
+                onPress={handleSubmit}
+                disabled={isPending}
+                accessibilityRole="button"
+                accessibilityLabel="Submit answer"
+              >
+                {isPending ? (
+                  <ActivityIndicator color="#fff" size="small" />
+                ) : (
+                  <Text style={styles.submitBtnText}>→</Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        )}
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  safe: { flex: 1, backgroundColor: '#F4F4FF' },
+  flex: { flex: 1 },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 12,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E8E8F5',
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: '#0C0C4F',
+  },
+  subtitle: {
+    fontSize: 13,
+    color: '#6666AA',
+    marginTop: 2,
+  },
+  list: { flex: 1 },
+  listContent: { paddingVertical: 12, paddingBottom: 24 },
+  inputArea: {
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+    paddingTop: 10,
+    paddingBottom: Platform.OS === 'ios' ? 24 : 16,
+    borderTopWidth: 1,
+    borderTopColor: '#E8E8F5',
+  },
+  errorText: {
+    color: '#E3225C',
+    fontSize: 13,
+    fontWeight: '600',
+    marginBottom: 6,
+    textAlign: 'center',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  input: {
     flex: 1,
-    padding: 16,
-    gap: 12,
+    height: 46,
+    borderRadius: 23,
+    borderWidth: 1.5,
+    borderColor: '#3737A4',
+    paddingHorizontal: 16,
+    fontSize: 15,
+    color: '#1A1A3E',
+    backgroundColor: '#F8F8FF',
+  },
+  submitBtn: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    backgroundColor: '#3737A4',
+    alignItems: 'center',
     justifyContent: 'center',
+  },
+  submitBtnDisabled: {
+    opacity: 0.6,
+  },
+  submitBtnText: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: '700',
+    lineHeight: 22,
   },
 });

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -18,6 +18,7 @@ module.exports = function (api) {
           },
         },
       ],
+      'react-native-reanimated/plugin',
     ],
   };
 };

--- a/mobile/components/ClueListItem.tsx
+++ b/mobile/components/ClueListItem.tsx
@@ -1,0 +1,192 @@
+/**
+ * ClueListItem — animated clue card for the mobile play screen.
+ *
+ * Animation sequence on unlock:
+ *   1. Item slides up from 24 px below its final position
+ *   2. Fades in from 0 → 1 opacity
+ *   3. Briefly scales up to 1.04 then settles at 1.0 (spring "pop")
+ *
+ * The animation fires once when `isUnlocked` transitions false → true.
+ */
+
+import React, { useEffect } from 'react';
+import { StyleSheet, View, Text, Pressable } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  withTiming,
+  withSequence,
+  runOnJS,
+} from 'react-native-reanimated';
+import type { ClueInfo } from '@lib/types';
+
+interface ClueListItemProps {
+  clue: ClueInfo;
+  index: number;
+  /** Whether this clue is the one the player is currently solving. */
+  isActive: boolean;
+  /** Whether this clue has been solved / unlocked. */
+  isUnlocked: boolean;
+  onPress?: () => void;
+}
+
+export function ClueListItem({
+  clue,
+  index,
+  isActive,
+  isUnlocked,
+  onPress,
+}: ClueListItemProps) {
+  const opacity = useSharedValue(isUnlocked ? 1 : 0);
+  const translateY = useSharedValue(isUnlocked ? 0 : 24);
+  const scale = useSharedValue(isUnlocked ? 1 : 0.96);
+
+  useEffect(() => {
+    if (!isUnlocked) return;
+
+    // Slide + fade in
+    opacity.value = withTiming(1, { duration: 280 });
+    translateY.value = withSpring(0, { damping: 18, stiffness: 200 });
+
+    // Scale pop: grow slightly then settle
+    scale.value = withSequence(
+      withSpring(1.04, { damping: 10, stiffness: 300 }),
+      withSpring(1.0, { damping: 14, stiffness: 200 }),
+    );
+  }, [isUnlocked]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+  }));
+
+  const isLocked = !isUnlocked && !isActive;
+
+  return (
+    <Animated.View style={[styles.container, animatedStyle]}>
+      <Pressable
+        onPress={isLocked ? undefined : onPress}
+        style={[
+          styles.card,
+          isActive && styles.cardActive,
+          isUnlocked && styles.cardUnlocked,
+          isLocked && styles.cardLocked,
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`Clue ${index + 1}: ${isLocked ? 'Locked' : clue.question}`}
+        accessibilityState={{ disabled: isLocked }}
+      >
+        {/* Index badge */}
+        <View style={[styles.badge, isUnlocked && styles.badgeUnlocked, isActive && styles.badgeActive]}>
+          <Text style={styles.badgeText}>{index + 1}</Text>
+        </View>
+
+        <View style={styles.content}>
+          {isLocked ? (
+            <Text style={styles.lockedText}>🔒 Locked</Text>
+          ) : (
+            <>
+              <Text style={[styles.question, isUnlocked && styles.questionUnlocked]} numberOfLines={2}>
+                {clue.question}
+              </Text>
+              <View style={styles.meta}>
+                <Text style={styles.points}>{clue.points} pts</Text>
+                {isUnlocked && <Text style={styles.solvedBadge}>✓ Solved</Text>}
+              </View>
+            </>
+          )}
+        </View>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 16,
+    marginVertical: 6,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 14,
+    padding: 14,
+    backgroundColor: '#fff',
+    shadowColor: '#0C0C4F',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 3,
+    borderWidth: 1.5,
+    borderColor: '#E8E8F5',
+  },
+  cardActive: {
+    borderColor: '#3737A4',
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    elevation: 6,
+  },
+  cardUnlocked: {
+    borderColor: '#39A437',
+    backgroundColor: '#F6FFF6',
+  },
+  cardLocked: {
+    opacity: 0.45,
+  },
+  badge: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#E8E8F5',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  badgeActive: {
+    backgroundColor: '#3737A4',
+  },
+  badgeUnlocked: {
+    backgroundColor: '#39A437',
+  },
+  badgeText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 13,
+  },
+  content: {
+    flex: 1,
+  },
+  question: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#1A1A3E',
+    marginBottom: 4,
+  },
+  questionUnlocked: {
+    color: '#194F0C',
+  },
+  lockedText: {
+    fontSize: 14,
+    color: '#9999BB',
+    fontWeight: '500',
+  },
+  meta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  points: {
+    fontSize: 12,
+    color: '#6666AA',
+    fontWeight: '500',
+  },
+  solvedBadge: {
+    fontSize: 12,
+    color: '#39A437',
+    fontWeight: '700',
+  },
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,6 +22,7 @@
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-reanimated": "~3.16.7",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.16.0",
     "sentry-expo": "^7.2.0",


### PR DESCRIPTION
## Summary

Adds a micro-animation that plays on the next sequential clue card immediately after tx confirmation completes.

## Changes

- **`mobile/package.json`** — adds `react-native-reanimated ~3.16.7`
- **`mobile/babel.config.js`** — adds `react-native-reanimated/plugin` (required for worklet compilation)
- **`mobile/components/ClueListItem.tsx`** — new animated clue card component
- **`mobile/app/(tabs)/play.tsx`** — updated play screen wiring the animated list

## Animation detail

When `isUnlocked` flips `true` (post-tx confirmation), three values animate simultaneously on the newly revealed card:

1. **Fade in** — opacity 0 → 1 (280 ms `withTiming`)
2. **Slide up** — translateY 24 → 0 (`withSpring`, damping 18)
3. **Scale pop** — scale 0.96 → 1.04 → 1.0 (`withSequence` of two springs)

## Testing

Replace the `setTimeout` simulation in `handleSubmit` with the real `submitAnswer(huntId, clueId, answer)` contract call — the animation fires on successful resolution.



Closes #211