### PR TITLE
Fix async clue storage and add offline clue caching

### DIFF
--- a/mobile/store/huntStore.ts
+++ b/mobile/store/huntStore.ts
@@ -5,6 +5,7 @@
 
 import type { HuntStatus, StoredHunt, Clue } from "@lib/types";
 import * as SecureStore from "expo-secure-store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const STORAGE_KEY = "hunty_hunts";
 const CLUES_KEY = "hunty_clues";
@@ -99,91 +100,147 @@ async function writeHunts(hunts: StoredHunt[]): Promise<void> {
   }
 }
 
+/** Cache clues for a joined hunt offline in AsyncStorage */
+export async function cacheJoinedHuntClues(huntId: number, clues: Clue[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(`hunty_clues_hunt_${huntId}`, JSON.stringify(clues));
+  } catch (error) {
+    console.error(`Failed to cache clues for hunt ${huntId} offline:`, error);
+  }
+}
+
+/** Get offline cached clues for a hunt from AsyncStorage */
+export async function getOfflineCachedClues(huntId: number): Promise<Clue[]> {
+  try {
+    const raw = await AsyncStorage.getItem(`hunty_clues_hunt_${huntId}`);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Clue[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 /** All hunts (for Game Arcade: filter by status === "Active"). Private hunts are excluded. */
-export function getAllHunts(): StoredHunt[] {
-  return readHunts().filter((h) => !h.is_private);
+export async function getAllHunts(): Promise<StoredHunt[]> {
+  const hunts = await readHunts();
+  return hunts.filter((h) => !h.is_private);
 }
 
 /** All hunts including private ones (for creator dashboard). */
-export function getAllHuntsIncludingPrivate(): StoredHunt[] {
-  return readHunts();
+export async function getAllHuntsIncludingPrivate(): Promise<StoredHunt[]> {
+  return await readHunts();
 }
 
 /** Creator hunts for dashboard (all stored hunts including private; creator filter can be added later). */
-export function getCreatorHunts(): StoredHunt[] {
-  return readHunts();
+export async function getCreatorHunts(): Promise<StoredHunt[]> {
+  return await readHunts();
 }
 
 /** Get hunts for a creator (creator public-key filter not implemented yet; returns all hunts). */
-export function getHuntsByCreator(): StoredHunt[] {
-  return readHunts();
+export async function getHuntsByCreator(): Promise<StoredHunt[]> {
+  return await readHunts();
 }
 
 /** Update a hunt's status (e.g. Draft → Active after activate_hunt). */
-export function updateHuntStatus(huntId: number, status: HuntStatus): void {
-  const hunts = readHunts().map((h) => (h.id === huntId ? { ...h, status } : h));
-  writeHunts(hunts);
+export async function updateHuntStatus(huntId: number, status: HuntStatus): Promise<void> {
+  const hunts = await readHunts();
+  const updated = hunts.map((h) => (h.id === huntId ? { ...h, status } : h));
+  await writeHunts(updated);
 }
 
 /** Delete multiple hunts by IDs. */
-export function deleteHunts(ids: number[]): void {
-  const hunts = readHunts().filter((h) => !ids.includes(h.id));
-  writeHunts(hunts);
+export async function deleteHunts(ids: number[]): Promise<void> {
+  const hunts = await readHunts();
+  const remainingHunts = hunts.filter((h) => !ids.includes(h.id));
+  await writeHunts(remainingHunts);
   
   // Also clean up clues for these hunts
-  const allClues = readClues();
+  const allClues = await readClues();
   const remainingClues = allClues.filter((c) => !ids.includes(c.huntId));
-  writeClues(remainingClues);
+  await writeClues(remainingClues);
+
+  // Clean up offline cached clues from AsyncStorage
+  for (const id of ids) {
+    try {
+      await AsyncStorage.removeItem(`hunty_clues_hunt_${id}`);
+    } catch {
+      // ignore
+    }
+  }
 }
 
 /** Archive (Cancel) multiple hunts by IDs. */
-export function archiveHunts(ids: number[]): void {
-  const hunts = readHunts().map((h) => 
+export async function archiveHunts(ids: number[]): Promise<void> {
+  const hunts = await readHunts();
+  const updated = hunts.map((h) => 
     ids.includes(h.id) ? { ...h, status: "Cancelled" as HuntStatus } : h
   );
-  writeHunts(hunts);
+  await writeHunts(updated);
 }
 
 /** Get a single hunt by ID */
-export function getHuntById(id: number): StoredHunt | undefined {
-  return readHunts().find((h) => h.id === id);
+export async function getHuntById(id: number): Promise<StoredHunt | undefined> {
+  const hunts = await readHunts();
+  return hunts.find((h) => h.id === id);
 }
 
 /** Add a new hunt (e.g. after createHunt). */
-export function addHunt(hunt: StoredHunt): void {
-  const hunts = readHunts();
+export async function addHunt(hunt: StoredHunt): Promise<void> {
+  const hunts = await readHunts();
   if (hunts.some((h) => h.id === hunt.id)) return;
-  writeHunts([...hunts, hunt]);
+  await writeHunts([...hunts, hunt]);
 }
 
-/** Get all clues for a specific hunt. */
-export function getHuntClues(huntId: number): Clue[] {
-  return readClues().filter((c) => c.huntId === huntId);
+/** Get all clues for a specific hunt with an offline cache fallback */
+export async function getHuntClues(huntId: number): Promise<Clue[]> {
+  // First attempt: read from the primary clues store
+  const allClues = await readClues();
+  const filtered = allClues.filter((c) => c.huntId === huntId);
+  
+  if (filtered.length > 0) {
+    // Optimistically update the offline cache in case it changed
+    await cacheJoinedHuntClues(huntId, filtered);
+    return filtered;
+  }
+  
+  // Fallback: if no clues in primary store (e.g., offline or cleared), read from the offline cache
+  return await getOfflineCachedClues(huntId);
 }
 
-/** Persist a new clue locally and increment the hunt's cluesCount. */
-export function saveClueLocally(clue: Omit<Clue, "id">): void {
-  const all = readClues();
+/** Persist a new clue locally, increment the hunt's cluesCount, and update the offline cache. */
+export async function saveClueLocally(clue: Omit<Clue, "id">): Promise<void> {
+  const all = await readClues();
   const newId = all.length > 0 ? Math.max(...all.map((c) => c.id)) + 1 : 1;
-  writeClues([...all, { ...clue, id: newId }]);
-  const hunts = readHunts().map((h) =>
+  const newClue: Clue = { ...clue, id: newId };
+  const updatedClues = [...all, newClue];
+  await writeClues(updatedClues);
+  
+  const hunts = await readHunts();
+  const updatedHunts = hunts.map((h) =>
     h.id === clue.huntId ? { ...h, cluesCount: h.cluesCount + 1 } : h
   );
-  writeHunts(hunts);
+  await writeHunts(updatedHunts);
+
+  // Update the offline cache for this hunt
+  const huntClues = updatedClues.filter((c) => c.huntId === clue.huntId);
+  await cacheJoinedHuntClues(clue.huntId, huntClues);
 }
 
 /** Get a single hunt by string ID */
-export const getHunt = (id: string) => {
-  return readHunts().find((c) => c.id === Number(id));
-};
+export async function getHunt(id: string): Promise<StoredHunt | undefined> {
+  const hunts = await readHunts();
+  return hunts.find((c) => c.id === Number(id));
+}
 
 /**
  * Return up to `limit` featured hunts, ranked by a trending score.
  * Score factors: clue count, reward type variety, time remaining, recency.
  */
-export function getFeaturedHunts(limit = 3): StoredHunt[] {
+export async function getFeaturedHunts(limit = 3): Promise<StoredHunt[]> {
   const now = Math.floor(Date.now() / 1000);
-  const active = readHunts().filter((h) => h.status === "Active" && !h.is_private);
+  const hunts = await readHunts();
+  const active = hunts.filter((h) => h.status === "Active" && !h.is_private);
 
   const scored = active.map((hunt) => {
     let score = 0;


### PR DESCRIPTION
## Summary

Fixes offline clue caching for joined hunts in the mobile app.

### Changes

* refactored `huntStore.ts` to properly use async/await with React Native storage APIs
* added AsyncStorage-based offline clue caching
* added offline fallback retrieval for cached clues
* cleaned up cached clues when hunts are deleted

### Related

Closes #218
