### PR TITLE
[#197] [Mobile] Hunt Details Screen Build

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,7 +3,7 @@
  * All shared interfaces and types live here — import from "@/lib/types".
  */
 
-import type { ReactNode } from "react"
+type ReactNode = unknown
 
 // ─── Hunt ────────────────────────────────────────────────────────────────────
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -7,33 +7,23 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
-
     "scheme": "hunty",
-
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-
-    "splashScreen": {
-      "image": "./assets/splash-icon.png",
-      "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
-    },
-
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.hunty.app",
+      "bundleIdentifier": "io.hunty.mobile",
+      "buildNumber": "1",
       "associatedDomains": [
         "applinks:hunty.io"
       ]
-      "bundleIdentifier": "io.hunty.mobile",
-      "buildNumber": "1"
     },
-
     "android": {
-      "package": "com.hunty.app",
+      "package": "io.hunty.mobile",
+      "versionCode": 1,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
@@ -44,7 +34,10 @@
         {
           "action": "VIEW",
           "autoVerify": true,
-          "category": ["BROWSABLE", "DEFAULT"],
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ],
           "data": [
             {
               "scheme": "https",
@@ -54,14 +47,10 @@
           ]
         }
       ]
-      "package": "io.hunty.mobile",
-      "versionCode": 1
     },
-
     "web": {
       "favicon": "./assets/favicon.png"
     },
-
     "plugins": [
       "expo-router",
       [
@@ -71,8 +60,6 @@
           "locationWhenInUsePermission": "Hunty needs your location to show nearby clue zones on the map."
         }
       ]
-    ]
-      "expo-router"
     ],
     "extra": {
       "eas": {

--- a/mobile/app/(tabs)/dashboard.tsx
+++ b/mobile/app/(tabs)/dashboard.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { ScrollView, View, Text } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
-import { HuntyRefreshControl } from '@/components/HuntyRefreshControl';
-import { useRefreshByUser } from '@/hooks/useRefreshByUser';
+import { HuntyRefreshControl } from '@components/HuntyRefreshControl';
+import { useRefreshByUser } from '@hooks/useRefreshByUser';
 
 // Placeholder for dashboard data fetching
 const fetchDashboard = async () => ({ balance: 0 });
@@ -17,7 +17,7 @@ export default function Dashboard() {
 
   return (
     <ScrollView
-      className="flex-1 bg-white dark:bg-slate-900"
+      style={styles.container}
       refreshControl={
         <HuntyRefreshControl 
           refreshing={isRefreshing} 
@@ -25,10 +25,29 @@ export default function Dashboard() {
         />
       }
     >
-      <View className="p-6">
-        <Text className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Dashboard</Text>
-        <Text className="text-slate-600 dark:text-slate-400">Balance: {data?.balance} XLM</Text>
+      <View style={styles.content}>
+        <Text style={styles.title}>Dashboard</Text>
+        <Text style={styles.subtitle}>Balance: {data?.balance} XLM</Text>
       </View>
     </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  content: {
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 12,
+  },
+  subtitle: {
+    color: '#64748b',
+  },
+});

--- a/mobile/app/(tabs)/feed.tsx
+++ b/mobile/app/(tabs)/feed.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { FlatList, View, Text } from 'react-native';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
-import { HuntyRefreshControl } from '@/components/HuntyRefreshControl';
-import { useRefreshByUser } from '@/hooks/useRefreshByUser';
+import { HuntyRefreshControl } from '@components/HuntyRefreshControl';
+import { useRefreshByUser } from '@hooks/useRefreshByUser';
 
 // Placeholder for hunt data fetching
 const fetchHunts = async () => [];
@@ -16,13 +16,13 @@ export default function HomeFeed() {
   const { isRefreshing, onRefresh } = useRefreshByUser(refetch);
 
   return (
-    <View className="flex-1 bg-white dark:bg-slate-900">
+    <View style={styles.container}>
       <FlatList
         data={hunts}
         keyExtractor={(item: any) => item.id}
         renderItem={({ item }) => (
-          <View className="p-4 border-b border-slate-100 dark:border-slate-800">
-            <Text className="text-slate-900 dark:text-white font-semibold">{item.title}</Text>
+          <View style={styles.item}>
+            <Text style={styles.title}>{item.title}</Text>
           </View>
         )}
         refreshControl={
@@ -31,8 +31,29 @@ export default function HomeFeed() {
             onRefresh={onRefresh} 
           />
         }
-        ListEmptyComponent={<Text className="p-10 text-center text-slate-500">No active hunts found.</Text>}
+        ListEmptyComponent={<Text style={styles.empty}>No active hunts found.</Text>}
       />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  item: {
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f1f5f9',
+  },
+  title: {
+    color: '#0f172a',
+    fontWeight: '600',
+  },
+  empty: {
+    padding: 40,
+    textAlign: 'center',
+    color: '#64748b',
+  },
+});

--- a/mobile/app/(tabs)/hunts.tsx
+++ b/mobile/app/(tabs)/hunts.tsx
@@ -1,106 +1,40 @@
-import { useState, useEffect } from 'react';
-import { StyleSheet, FlatList, View, Text, Pressable } from 'react-native';
+import { useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
+import { ThemedButton, ThemedCustomText, ThemedView } from '@components/themed';
+import { useTheme } from '@providers/ThemeProvider';
 import { getAllHunts } from '@store/huntStore';
+import { usePlayerStore } from '@store/useStore';
 import type { StoredHunt } from '@lib/types';
 
 export default function HuntsScreen() {
+  const { colors } = useTheme();
+  const { currentProgress, setProgress } = usePlayerStore();
   const router = useRouter();
   const [hunts, setHunts] = useState<StoredHunt[]>([]);
+  const [loadingHuntId, setLoadingHuntId] = useState<number | null>(null);
 
   useEffect(() => {
     getAllHunts().then((data) => {
-      setHunts(data.filter((h) => h.status === 'Active'));
+      setHunts(data.filter((hunt) => hunt.status === 'Active'));
     });
   }, []);
 
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Active Hunts</Text>
-      <FlatList
-        data={hunts}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item }) => (
-          <Pressable
-            onPress={() => router.push(`/details?huntId=${item.id}`)}
-            style={styles.card}
-          >
-            <Text style={styles.cardTitle}>{item.title}</Text>
-            <Text style={styles.cardDesc}>{item.description}</Text>
-            <Text style={styles.cardMeta}>{item.cluesCount} clues</Text>
-          </Pressable>
-        )}
-      />
-    </View>
-import { StyleSheet } from 'react-native';
-import { ThemedView } from '@components/themed';
-import { GraphQLHuntsFeed } from '@components/GraphQLHuntsFeed';
-import { HuntsList } from '@components/HuntsList';
-import React, { useState } from 'react';
-import { StyleSheet, View, ScrollView, ActivityIndicator, Alert } from 'react-native';
-import { ThemedView, ThemedCustomText, ThemedButton } from '@components/themed';
-import { useHaptics } from '@/hooks/useHaptics';
-import { usePlayerStore } from '@store/useStore';
-import { useTheme } from '@providers/ThemeProvider';
-
-interface HuntItem {
-  id: number;
-  title: string;
-  description: string;
-  cluesCount: number;
-  rewardType: 'XLM' | 'NFT' | 'Both';
-  rewardAmount: string;
-  difficulty: 'Easy' | 'Medium' | 'Hard';
-}
-
-const FEATURED_HUNTS: HuntItem[] = [
-  {
-    id: 1,
-    title: 'City Secrets',
-    description: 'Race across town to uncover hidden murals and landmarks.',
-    cluesCount: 5,
-    rewardType: 'Both',
-    rewardAmount: '100 XLM + Rare NFT',
-    difficulty: 'Medium',
-  },
-  {
-    id: 2,
-    title: 'Campus Quest',
-    description: 'Solve riddles scattered around campus before the timer ends.',
-    cluesCount: 7,
-    rewardType: 'NFT',
-    rewardAmount: 'Exclusive Student NFT',
-    difficulty: 'Easy',
-  },
-  {
-    id: 3,
-    title: 'Cyberpunk Odyssey',
-    description: 'Decipher futuristic encrypted codes in the downtown core.',
-    cluesCount: 10,
-    rewardType: 'XLM',
-    rewardAmount: '250 XLM',
-    difficulty: 'Hard',
-  },
-];
-
-export default function HuntsScreen() {
-  const { colors } = useTheme();
-  const haptics = useHaptics();
-  const { currentProgress, setProgress } = usePlayerStore();
-  
-  // Track loading and joined status for each hunt
-  const [loadingHuntId, setLoadingHuntId] = useState<number | null>(null);
-
-  const handleJoinHunt = async (hunt: HuntItem) => {
+  const handleJoinHunt = (hunt: StoredHunt) => {
     if (loadingHuntId !== null) return;
-    
-    // Trigger subtle haptic for initiation
-    haptics.triggerImpact('light');
+
     setLoadingHuntId(hunt.id);
 
-    // Simulate real-world Stellar transaction / server request
+    router.push({
+      pathname: '/transaction/pending',
+      params: {
+        action: 'join',
+        huntId: String(hunt.id),
+        huntTitle: hunt.title,
+      },
+    });
+
     setTimeout(() => {
-      // Set global player progress in Zustand
       setProgress({
         hunt_id: hunt.id,
         player: 'GD72...3W9A',
@@ -108,27 +42,12 @@ export default function HuntsScreen() {
         completed: false,
         reward_claimed: false,
       });
-
       setLoadingHuntId(null);
-      
-      // Trigger tactile success haptic feedback (Success Notification)
-      haptics.joinSuccess();
-
-      // Show beautiful feedback
-      Alert.alert(
-        'Successfully Joined!',
-        `You have successfully registered for "${hunt.title}". Start solving the clues in the Play tab!`,
-        [{ text: 'Let\'s Go!' }]
-      );
-    }, 1200);
+    }, 50);
   };
 
   return (
-    <ThemedView style={styles.container}>
-      <GraphQLHuntsFeed />
-      <HuntsList />
-    </ThemedView>
-    <ScrollView 
+    <ScrollView
       style={[styles.scrollView, { backgroundColor: colors.background }]}
       contentContainerStyle={styles.contentContainer}
       showsVerticalScrollIndicator={false}
@@ -177,47 +96,33 @@ export default function HuntsScreen() {
         Featured Hunts
       </ThemedCustomText>
 
-      {/* Hunts List */}
       <View style={styles.listContainer}>
-        {FEATURED_HUNTS.map((hunt) => {
+        {hunts.map((hunt) => {
           const isCurrent = currentProgress?.hunt_id === hunt.id;
           const isLoading = loadingHuntId === hunt.id;
+          const rewardAmount =
+            hunt.rewardType === 'Both'
+              ? '100 XLM + NFT'
+              : hunt.rewardType === 'NFT'
+                ? 'Exclusive reward NFT'
+                : '250 XLM';
 
           return (
-            <View 
-              key={hunt.id} 
+            <View
+              key={hunt.id}
               style={[
-                styles.card, 
-                { 
-                  backgroundColor: colors.background, 
+                styles.card,
+                {
+                  backgroundColor: colors.background,
                   borderColor: isCurrent ? colors.success : colors.border,
                   shadowColor: isCurrent ? colors.success : '#000',
-                }
+                },
               ]}
             >
-              {/* Badge Indicators */}
               <View style={styles.badgeRow}>
-                <View 
-                  style={[
-                    styles.difficultyBadge, 
-                    { 
-                      backgroundColor: 
-                        hunt.difficulty === 'Easy' ? colors.success + '20' : 
-                        hunt.difficulty === 'Medium' ? colors.warning + '20' : 
-                        colors.error + '20'
-                    }
-                  ]}
-                >
-                  <ThemedCustomText 
-                    variant="caption" 
-                    color={
-                      hunt.difficulty === 'Easy' ? 'success' : 
-                      hunt.difficulty === 'Medium' ? 'warning' : 
-                      'error'
-                    }
-                    weight="700"
-                  >
-                    {hunt.difficulty}
+                <View style={[styles.difficultyBadge, { backgroundColor: colors.info + '20' }]}>
+                  <ThemedCustomText variant="caption" color="info" weight="700">
+                    Active
                   </ThemedCustomText>
                 </View>
 
@@ -237,7 +142,6 @@ export default function HuntsScreen() {
                 {hunt.description}
               </ThemedCustomText>
 
-              {/* Info Row */}
               <View style={[styles.cardInfoRow, { borderTopColor: colors.border }]}>
                 <View style={styles.infoCol}>
                   <ThemedCustomText variant="caption" color="text" style={{ opacity: 0.6 }}>
@@ -253,23 +157,19 @@ export default function HuntsScreen() {
                     Potential Reward
                   </ThemedCustomText>
                   <ThemedCustomText variant="body" color="primary" weight="700">
-                    {hunt.rewardAmount}
+                    {rewardAmount}
                   </ThemedCustomText>
                 </View>
               </View>
 
-              {/* Join Action Button */}
               <View style={styles.buttonContainer}>
                 {isCurrent ? (
                   <ThemedButton
-                    text="Resume Hunt ⚡"
+                    text="View Hunt"
                     variant="success"
                     size="md"
                     fullWidth
-                    onPress={() => {
-                      haptics.triggerImpact('medium');
-                      Alert.alert('Active Hunt', `You are currently doing this hunt! Switch to the Play tab to solve clues.`);
-                    }}
+                    onPress={() => router.push(`/hunt/${hunt.id}`)}
                   />
                 ) : (
                   <ThemedButton
@@ -292,38 +192,8 @@ export default function HuntsScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
   scrollView: {
     flex: 1,
-    padding: 16,
-    backgroundColor: '#fff',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '700',
-    marginBottom: 16,
-  },
-  card: {
-    borderWidth: 1,
-    borderColor: '#ddd',
-    borderRadius: 8,
-    padding: 12,
-    marginBottom: 12,
-    backgroundColor: '#f9f9f9',
-  },
-  cardTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginBottom: 4,
-  },
-  cardDesc: {
-    fontSize: 14,
-    color: '#666',
-    marginBottom: 8,
-  },
-  cardMeta: {
-    fontSize: 12,
-    color: '#999',
   },
   contentContainer: {
     padding: 20,

--- a/mobile/app/(tabs)/play.tsx
+++ b/mobile/app/(tabs)/play.tsx
@@ -1,1025 +1,229 @@
-import React, { useState, useRef } from 'react';
-import GameMapScreen from '@components/GameMapScreen';
+import { useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { ThemedButton, ThemedCustomText, ThemedView } from '@components/themed';
+import { useTheme } from '@providers/ThemeProvider';
+import { getHuntClues } from '@store/huntStore';
+import { usePlayerStore } from '@store/useStore';
+import type { Clue } from '@lib/types';
 
 export default function PlayScreen() {
-  return <GameMapScreen />;
-}
-/**
- * Play screen — mobile clue list with Reanimated unlock animation.
- *
- * Flow:
- *   1. Clues are shown as a vertical list.
- *   2. Only the current clue (current_clue_index) is active; solved ones are
- *      unlocked; future ones are locked.
- *   3. When the player submits a correct answer the tx is confirmed, then
- *      `unlockedUpTo` advances by 1 — triggering the ClueListItem animation
- *      on the newly revealed card.
- */
-
-import React, { useState, useCallback } from 'react';
-import {
-  StyleSheet,
-  View,
-  Text,
-  TouchableOpacity,
-  PanResponder,
-  Animated,
-  Dimensions,
-} from 'react-native';
-import { useTheme } from '@react-navigation/native';
-import { ThemedView, ThemedCustomText } from '@components/themed';
-import { StackHeader } from '@components/navigation/StackHeader';
-import { ClueList } from '@components/ClueList';
-import { QRScanner } from '@components/QRScanner';
-
-interface Clue {
-  id: number;
-  title: string;
-  description: string;
-  points: number;
-  solved: boolean;
-}
-
-// Mock data for clues - replace with real data from your API
-const MOCK_CLUES: Clue[] = [
-  {
-    id: 1,
-    title: 'Find the Hidden Symbol',
-    description: 'Look for the symbol in the main hall',
-    points: 10,
-    solved: false,
-  },
-  {
-    id: 2,
-    title: 'Decode the Message',
-    description: 'Figure out what the code means',
-    points: 15,
-    solved: false,
-  },
-  {
-    id: 3,
-    title: 'Solve the Puzzle',
-    description: 'Complete the missing pieces',
-    points: 20,
-    solved: false,
-  },
-  {
-    id: 4,
-    title: 'Find the Final Location',
-    description: 'Discover where the treasure is hidden',
-    points: 25,
-    solved: false,
-  },
-];
-
-const { height } = Dimensions.get('window');
-
-export default function PlayScreen() {
+  const router = useRouter();
   const { colors } = useTheme();
-  const [currentClueIndex, setCurrentClueIndex] = useState(0);
-  const [scannerOpen, setScannerOpen] = useState(false);
-  const [clues, setClues] = useState(MOCK_CLUES);
-  const swipeDistance = useRef(new Animated.Value(0)).current;
-  const panResponder = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onPanResponderMove: (evt, { dy }) => {
-        // Detect upward swipe to open scanner
-        if (dy < -20) {
-          swipeDistance.current.setValue(Math.abs(dy));
-        }
-      },
-      onPanResponderRelease: (evt, { dy, vy }) => {
-        // If swiped up significantly, open scanner
-        if (dy < -80 && vy < -0.5) {
-          setScannerOpen(true);
-        }
-        // Reset animation
-        Animated.spring(swipeDistance.current, {
-          toValue: 0,
-          useNativeDriver: false,
-        }).start();
-      },
-    })
-  ).current;
+  const {
+    currentProgress,
+    updateClueIndex,
+    markCompleted,
+    markClueCompleted,
+    clearProgress,
+  } = usePlayerStore();
 
-  const handleSelectClue = (index: number) => {
-    setCurrentClueIndex(index);
-  };
+  const [answer, setAnswer] = useState('');
+  const [clues, setClues] = useState<Clue[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
 
-  const handleOpenScanner = () => {
-    setScannerOpen(true);
-  };
+  useEffect(() => {
+    if (!currentProgress?.hunt_id) {
+      setClues([]);
+      return;
+    }
 
-  const handleScanQR = (data: string) => {
-    // Handle the scanned QR code data
-    console.log('Scanned QR Code:', data);
-    // You can process the data here, e.g., validate it against the current clue
-    setScannerOpen(false);
-  };
+    void getHuntClues(currentProgress.hunt_id).then(setClues);
+  }, [currentProgress?.hunt_id]);
 
-  const handleCloseScanner = () => {
-    setScannerOpen(false);
-  };
-
-  if (!clues || clues.length === 0) {
+  if (!currentProgress?.hunt_id) {
     return (
-      <ThemedView style={styles.container}>
-        <StackHeader
-          title="Play"
-          subtitle="Solve clues to complete the hunt"
-        />
-        <View style={[styles.emptyState, { paddingTop: height / 3 }]}>
-          <ThemedCustomText variant="h3">No Active Hunts</ThemedCustomText>
-          <ThemedCustomText variant="body" style={styles.emptyText}>
-            Start or join a hunt to see clues here
-          </ThemedCustomText>
-        </View>
+      <ThemedView style={[styles.emptyState, { backgroundColor: colors.background }]}>
+        <ThemedCustomText variant="h2" color="primary" weight="800">
+          Join a hunt first
+        </ThemedCustomText>
+        <ThemedCustomText variant="body" style={styles.emptyCopy}>
+          Register for an active hunt from the Hunts tab to unlock clue progress and transaction steps.
+        </ThemedCustomText>
       </ThemedView>
     );
   }
 
-  return (
-    <ThemedView
-      style={[styles.container, { backgroundColor: colors.background }]}
-      {...panResponder.panHandlers}
-    >
-      <StackHeader
-        title="Play"
-        subtitle={`${currentClueIndex + 1} of ${clues.length} clues`}
-      />
+  const activeClueIndex = currentProgress.current_clue_index;
+  const activeClue = clues[activeClueIndex];
+  const allSolved = activeClueIndex >= clues.length;
 
-      <View style={styles.clueDisplayContainer}>
-        <View style={styles.activeClueCard}>
-          <Text style={[styles.clueTitle, { color: colors.text }]}>
-            {clues[currentClueIndex]?.title}
-          </Text>
-          <Text
-            style={[styles.clueBody, { color: colors.text }]}
-            numberOfLines={6}
-          >
-            {clues[currentClueIndex]?.description}
-          </Text>
-          <View style={styles.clueFooter}>
-            <Text style={[styles.points, { color: colors.primary }]}>
-              {clues[currentClueIndex]?.points} Points
-            </Text>
-            {clues[currentClueIndex]?.solved && (
-              <Text style={styles.solvedBadge}>✓ Solved</Text>
-            )}
-          </View>
-        </View>
-
-        {/* Swipe hint indicator */}
-        <Animated.View
-          style={[
-            styles.swipeHint,
-            {
-              opacity: swipeDistance.current.interpolate({
-                inputRange: [0, 100],
-                outputRange: [0.3, 1],
-                extrapolate: 'clamp',
-              }),
-            },
-          ]}
-        >
-          <Text style={styles.swipeHintText}>⬆ Swipe up to scan</Text>
-        </Animated.View>
-      </View>
-
-      <ClueList
-        clues={clues}
-        currentIndex={currentClueIndex}
-        onSelectClue={handleSelectClue}
-        onOpenScanner={handleOpenScanner}
-      />
-
-      <QRScanner
-        isOpen={scannerOpen}
-        onClose={handleCloseScanner}
-        onScan={handleScanQR}
-        title={`Scan clue #${currentClueIndex + 1}`}
-  TextInput,
-  Pressable,
-  ScrollView,
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-} from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { ClueListItem } from '@components/ClueListItem';
-import { usePlayerStore } from '@store/useStore';
-import type { ClueInfo } from '@lib/types';
-
-// ─── Demo clues (replace with real contract fetch) ───────────────────────────
-
-const DEMO_CLUES: ClueInfo[] = [
-  { id: 0, question: 'I have cities, but no houses live there. I have mountains, but no trees grow there. What am I?', points: 10 },
-  { id: 1, question: 'The more you take, the more you leave behind. What am I?', points: 15 },
-  { id: 2, question: 'I speak without a mouth and hear without ears. I have no body, but I come alive with wind. What am I?', points: 20 },
-  { id: 3, question: 'I have hands but cannot clap. What am I?', points: 10 },
-  { id: 4, question: 'What has keys but no locks, space but no room, and you can enter but can\'t go inside?', points: 25 },
-];
-
-const DEMO_ANSWERS = ['map', 'footsteps', 'echo', 'clock', 'keyboard'];
-
-// ─── Component ────────────────────────────────────────────────────────────────
-
-export default function PlayScreen() {
-  const { currentProgress, updateClueIndex } = usePlayerStore();
-
-  // unlockedUpTo: index of the highest clue that has been solved.
-  // Starts at current_clue_index - 1 (all previously solved clues are already unlocked).
-  const initialUnlocked = (currentProgress?.current_clue_index ?? 0) - 1;
-  const [unlockedUpTo, setUnlockedUpTo] = useState(initialUnlocked);
-  const activeIndex = unlockedUpTo + 1;
-
-  const [answer, setAnswer] = useState('');
-  const [isPending, setIsPending] = useState(false);
-  const [error, setError] = useState('');
-
-  const handleSubmit = useCallback(async () => {
-    if (isPending || !answer.trim()) return;
-    const clue = DEMO_CLUES[activeIndex];
-    if (!clue) return;
-
-    setIsPending(true);
-    setError('');
-
-    try {
-      // ── Simulate tx confirmation (replace with real submitAnswer call) ──
-      await new Promise<void>((resolve, reject) =>
-        setTimeout(() => {
-          const correct =
-            answer.trim().toLowerCase() === DEMO_ANSWERS[activeIndex];
-          correct ? resolve() : reject(new Error('incorrect'));
-        }, 900),
-      );
-
-      // Tx confirmed — unlock the next clue with animation
-      setUnlockedUpTo(activeIndex);
-      updateClueIndex(activeIndex + 1);
-      setAnswer('');
-    } catch {
-      setError('Incorrect answer — try again!');
-    } finally {
-      setIsPending(false);
+  const progressLabel = useMemo(() => {
+    if (clues.length === 0) {
+      return 'Loading clues...';
     }
-  }, [activeIndex, answer, isPending, updateClueIndex]);
 
-  const allSolved = activeIndex >= DEMO_CLUES.length;
+    if (allSolved) {
+      return 'All clues solved';
+    }
 
-  return (
-    <SafeAreaView style={styles.safe} edges={['top']}>
-      <KeyboardAvoidingView
-        style={styles.flex}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={80}
-      >
-        {/* Header */}
-        <View style={styles.header}>
-          <Text style={styles.title}>🗺 Active Hunt</Text>
-          <Text style={styles.subtitle}>
-            {allSolved
-              ? '🎉 All clues solved!'
-              : `Clue ${activeIndex + 1} of ${DEMO_CLUES.length}`}
-          </Text>
-        </View>
+    return `Clue ${activeClueIndex + 1} of ${clues.length}`;
+  }, [activeClueIndex, allSolved, clues.length]);
 
-        {/* Clue list */}
-        <ScrollView
-          style={styles.list}
-          contentContainerStyle={styles.listContent}
-          showsVerticalScrollIndicator={false}
-        >
-          {DEMO_CLUES.map((clue, i) => (
-            <ClueListItem
-              key={clue.id}
-              clue={clue}
-              index={i}
-              isActive={i === activeIndex && !allSolved}
-              isUnlocked={i <= unlockedUpTo}
-            />
-          ))}
-        </ScrollView>
-
-        {/* Answer input — only shown while there are unsolved clues */}
-        {!allSolved && (
-          <View style={styles.inputArea}>
-            {error ? <Text style={styles.errorText}>{error}</Text> : null}
-            <View style={styles.inputRow}>
-              <TextInput
-                style={styles.input}
-                placeholder="Type your answer…"
-                placeholderTextColor="#9999BB"
-                value={answer}
-                onChangeText={(t) => { setAnswer(t); setError(''); }}
-                onSubmitEditing={handleSubmit}
-                returnKeyType="done"
-                editable={!isPending}
-                autoCapitalize="none"
-                autoCorrect={false}
-              />
-              <Pressable
-                style={[styles.submitBtn, isPending && styles.submitBtnDisabled]}
-                onPress={handleSubmit}
-                disabled={isPending}
-                accessibilityRole="button"
-                accessibilityLabel="Submit answer"
-              >
-                {isPending ? (
-                  <ActivityIndicator color="#fff" size="small" />
-                ) : (
-                  <Text style={styles.submitBtnText}>→</Text>
-                )}
-              </Pressable>
-            </View>
-          </View>
-        )}
-      </KeyboardAvoidingView>
-    </SafeAreaView>
-import React, { useState } from 'react';
-import { StyleSheet, View, ScrollView, ActivityIndicator, Alert, TextInput } from 'react-native';
-import { ThemedView, ThemedCustomText, ThemedButton } from '@components/themed';
-import { useHaptics } from '@/hooks/useHaptics';
-import { usePlayerStore } from '@store/useStore';
-import { useTheme } from '@providers/ThemeProvider';
-
-interface ClueData {
-  question: string;
-  hint: string;
-  answer: string;
-}
-
-const CLUES_BY_HUNT: Record<number, ClueData[]> = {
-  1: [
-    { question: 'Find the historical blue mural painted on the brick wall beside the old clock tower.', hint: 'Look near the city square fountain.', answer: 'clocktower' },
-    { question: 'Locate the bronze statue of the town founder near the library.', hint: 'He is holding an open book.', answer: 'founder' },
-    { question: 'Find the hidden micro-brewery courtyard with the neon hop sign.', hint: 'It is inside an alleyway off 5th Avenue.', answer: 'hops' },
-  ],
-  2: [
-    { question: 'Go to the oldest oak tree on the main campus lawn.', hint: 'Near the science building.', answer: 'oaktree' },
-    { question: 'Decipher the inscription on the stone sundial near the observatory.', hint: 'It mentions "Time Flies".', answer: 'sundial' },
-  ],
-  3: [
-    { question: 'Scan the cybernetic terminal code near the tech-district archway.', hint: 'Under the blinking purple light.', answer: 'terminal' },
-  ]
-};
-
-const HUNT_NAMES: Record<number, string> = {
-  1: 'City Secrets',
-  2: 'Campus Quest',
-  3: 'Cyberpunk Odyssey',
-};
-
-export default function PlayScreen() {
-  const { colors } = useTheme();
-  const haptics = useHaptics();
-  const { currentProgress, updateClueIndex, markCompleted, clearProgress } = usePlayerStore();
-
-  // Component UI States
-  const [scanning, setScanning] = useState(false);
-  const [scanned, setScanned] = useState(false);
-  const [solving, setSolving] = useState(false);
-  const [answerInput, setAnswerInput] = useState('');
-  const [showHint, setShowHint] = useState(false);
-
-  const activeHuntId = currentProgress?.hunt_id;
-  const clues = activeHuntId ? CLUES_BY_HUNT[activeHuntId] || [] : [];
-  const currentClueIndex = currentProgress?.current_clue_index ?? 0;
-  const currentClue = clues[currentClueIndex];
-  const isCompleted = currentProgress?.completed;
-
-  const handleScanBeacon = () => {
-    if (scanning) return;
-    
-    // Trigger subtle click
-    haptics.scanSubtle();
-    setScanning(true);
-
-    // Simulate scanning camera focus and code detection
-    setTimeout(() => {
-      setScanning(false);
-      setScanned(true);
-      
-      // Trigger Medium Impact haptic for scan success
-      haptics.scanSuccess();
-      
-      Alert.alert(
-        'Beacon Connected! 📡',
-        'Your device detected the checkpoint signal. You can now submit your answer.',
-        [{ text: 'Great' }]
-      );
-    }, 1500);
-  };
-
-  const handleSubmitAnswer = () => {
-    if (!answerInput.trim()) {
-      haptics.triggerNotification('error');
-      Alert.alert('Error', 'Please enter your answer.');
+  const handleSubmit = () => {
+    if (!activeClue || isSubmitting) {
       return;
     }
 
-    setSolving(true);
+    if (answer.trim().toLowerCase() !== activeClue.answer.toLowerCase()) {
+      setError('Incorrect answer. Review the clue and try again.');
+      return;
+    }
 
-    setTimeout(() => {
-      setSolving(false);
-      
-      const isCorrect = answerInput.trim().toLowerCase() === currentClue.answer.toLowerCase();
+    setIsSubmitting(true);
+    setError('');
 
-      if (isCorrect) {
-        setAnswerInput('');
-        setScanned(false);
-        setShowHint(false);
+    const isLastClue = activeClueIndex === clues.length - 1;
+    markClueCompleted(currentProgress.hunt_id, activeClueIndex);
 
-        const isLastClue = currentClueIndex === clues.length - 1;
+    if (isLastClue) {
+      markCompleted();
+      router.push({
+        pathname: '/transaction/pending',
+        params: {
+          action: 'complete',
+          huntId: String(currentProgress.hunt_id),
+          huntTitle: 'Reward Dispatch',
+        },
+      });
+    } else {
+      updateClueIndex(activeClueIndex + 1);
+    }
 
-        if (isLastClue) {
-          // Final Clue Completed! Trigger completion states
-          markCompleted();
-          
-          // Heavy Success & Reward vibration
-          haptics.taskSuccess();
-          setTimeout(() => haptics.rewardHeavy(), 300);
-
-          Alert.alert(
-            'Congratulations! 🏆',
-            'You solved the final clue! Your proof-of-completion transaction has been submitted to the Stellar Network and your rewards are being dispatched.',
-            [{ text: 'Claim Reward!' }]
-          );
-        } else {
-          // Progress to next checkpoint
-          updateClueIndex(currentClueIndex + 1);
-          
-          // Clear success sound/vibe
-          haptics.taskSuccess();
-          
-          Alert.alert(
-            'Correct Answer! 🎉',
-            'Checkpoint solved successfully. Proceed to the next coordinate!',
-            [{ text: 'Next Clue' }]
-          );
-        }
-      } else {
-        // Wrong answer: trigger warning haptic
-        haptics.triggerNotification('warning');
-        Alert.alert(
-          'Incorrect Answer ❌',
-          'That answer does not match the checkpoint archives. Check your hint or try again!',
-          [{ text: 'Try Again' }]
-        );
-      }
-    }, 1000);
+    setAnswer('');
+    setIsSubmitting(false);
   };
-
-  const handleAbandon = () => {
-    haptics.triggerNotification('warning');
-    Alert.alert(
-      'Abandon Hunt?',
-      'Are you sure you want to stop playing this hunt? Your current session progress will be cleared.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        { 
-          text: 'Abandon', 
-          style: 'destructive',
-          onPress: () => {
-            clearProgress();
-            setAnswerInput('');
-            setScanned(false);
-            setShowHint(false);
-            haptics.triggerImpact('light');
-          }
-        }
-      ]
-    );
-  };
-
-  // State: No active hunt
-  if (!activeHuntId) {
-    return (
-      <View style={[styles.emptyContainer, { backgroundColor: colors.background }]}>
-        <ThemedCustomText variant="h2" color="primary" weight="800" style={styles.emptyTitle}>
-          Play Interface
-        </ThemedCustomText>
-        <ThemedCustomText variant="body" color="text" style={styles.emptyText}>
-          No active hunt session found. Visit the **Hunts** tab to join an active arcade game!
-        </ThemedCustomText>
-      </View>
-    );
-  }
-
-  // State: Hunt Completed
-  if (isCompleted) {
-    return (
-      <ScrollView 
-        style={[styles.container, { backgroundColor: colors.background }]}
-        contentContainerStyle={styles.centerContent}
-      >
-        <View style={[styles.victoryCard, { backgroundColor: colors.success + '15', borderColor: colors.success }]}>
-          <ThemedCustomText variant="h1" color="success" weight="800" style={styles.victoryTitle}>
-            VICTORY! 🏆
-          </ThemedCustomText>
-          <ThemedCustomText variant="body" color="text" style={styles.victoryText}>
-            You successfully completed the "{HUNT_NAMES[activeHuntId]}" hunt!
-          </ThemedCustomText>
-
-          <View style={[styles.divider, { backgroundColor: colors.border }]} />
-
-          <ThemedCustomText variant="caption" color="text" style={{ opacity: 0.6 }}>
-            Rewards Dispatched:
-          </ThemedCustomText>
-          <ThemedCustomText variant="h2" color="secondary" weight="700" style={styles.rewardText}>
-            ✓ 150 XLM Transferred
-          </ThemedCustomText>
-          <ThemedCustomText variant="h3" color="primary" weight="600" style={styles.rewardSub}>
-            ✓ Stellar NFT Minted
-          </ThemedCustomText>
-        </View>
-
-        <ThemedButton
-          text="Back to Arcade"
-          variant="primary"
-          size="lg"
-          fullWidth
-          onPress={() => {
-            haptics.triggerImpact('medium');
-            clearProgress();
-          }}
-        />
-      </ScrollView>
-    );
-  }
 
   return (
-    <ScrollView 
-      style={[styles.container, { backgroundColor: colors.background }]}
-      contentContainerStyle={styles.contentContainer}
-      keyboardShouldPersistTaps="handled"
-    >
-      {/* Active Hunt Title */}
-      <View style={styles.header}>
-        <View style={styles.titleRow}>
-          <View>
-            <ThemedCustomText variant="caption" color="primary" weight="700">
-              ACTIVE SESSION
-            </ThemedCustomText>
-            <ThemedCustomText variant="h2" color="text" weight="800">
-              {HUNT_NAMES[activeHuntId]}
-            </ThemedCustomText>
-          </View>
-          <ThemedButton 
-            text="Abandon"
-            variant="ghost"
-            size="sm"
-            onPress={handleAbandon}
-          />
-        </View>
-
-        {/* Progress Tracker */}
-        <View style={styles.progressTracker}>
-          <ThemedCustomText variant="label" color="text" weight="600">
-            Progress: Clue {currentClueIndex + 1} of {clues.length}
+    <ThemedView style={[styles.container, { backgroundColor: colors.background }]}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={[styles.heroCard, { backgroundColor: colors.primary + '10', borderColor: colors.border }]}>
+          <ThemedCustomText variant="h2" color="primary" weight="800">
+            Active Hunt Session
           </ThemedCustomText>
-          <View style={[styles.progressBarBg, { backgroundColor: colors.border }]}>
-            <View 
-              style={[
-                styles.progressBarFill, 
-                { 
-                  backgroundColor: colors.primary, 
-                  width: `${((currentClueIndex) / clues.length) * 100}%` 
-                }
-              ]} 
-            />
-          </View>
+          <ThemedCustomText variant="body">{progressLabel}</ThemedCustomText>
         </View>
-      </View>
 
-      {/* Clue Prompt Card */}
-      <View style={[styles.clueCard, { backgroundColor: colors.border + '25', borderColor: colors.border }]}>
-        <ThemedCustomText variant="h3" color="primary" weight="700" style={styles.clueTitle}>
-          📍 Checkpoint Clue
-        </ThemedCustomText>
-        
-        <ThemedCustomText variant="body" color="text" style={styles.clueQuestion}>
-          {currentClue?.question}
-        </ThemedCustomText>
+        {clues.map((clue, index) => {
+          const isActive = index === activeClueIndex && !allSolved;
+          const isUnlocked = index <= activeClueIndex;
 
-        {/* Hint toggle */}
-        {showHint ? (
-          <View style={[styles.hintBox, { backgroundColor: colors.warning + '15', borderColor: colors.warning }]}>
-            <ThemedCustomText variant="caption" color="warning" weight="700">
-              💡 HINT:
-            </ThemedCustomText>
-            <ThemedCustomText variant="label" color="text">
-              {currentClue?.hint}
-            </ThemedCustomText>
-          </View>
-        ) : (
-          <ThemedButton
-            text="Reveal Hint (No Cost)"
-            variant="ghost"
-            size="sm"
-            onPress={() => {
-              haptics.triggerSelection();
-              setShowHint(true);
-            }}
-          />
-        )}
-      </View>
-
-      {/* Interactive Action Area */}
-      <View style={styles.actionArea}>
-        {!scanned ? (
-          <View style={styles.scanningSection}>
-            <ThemedCustomText variant="body" color="text" style={styles.actionGuide}>
-              You must scan the physical location beacon or QR code to verify your presence at this coordinate before submitting the answer.
-            </ThemedCustomText>
-            
-            <ThemedButton
-              text={scanning ? 'Connecting to Beacon...' : 'Scan Checkpoint QR / Beacon'}
-              variant="primary"
-              size="lg"
-              fullWidth
-              loading={scanning}
-              onPress={handleScanBeacon}
-            />
-          </View>
-        ) : (
-          <View style={styles.solvingSection}>
-            <ThemedCustomText variant="label" color="success" weight="700" style={styles.scanSuccessText}>
-              ✓ Beacon Verified! Enter your answer below:
-            </ThemedCustomText>
-
-            <TextInput
+          return (
+            <View
+              key={clue.id}
               style={[
-                styles.textInput,
-                { 
-                  color: colors.text, 
-                  borderColor: colors.border,
-                  backgroundColor: colors.border + '10'
-                }
+                styles.clueCard,
+                {
+                  backgroundColor: isActive ? colors.primary + '12' : colors.background,
+                  borderColor: isActive ? colors.primary : colors.border,
+                  opacity: isUnlocked ? 1 : 0.55,
+                },
               ]}
-              placeholder="Enter clue answer..."
-              placeholderTextColor="#9ca3af"
-              value={answerInput}
-              onChangeText={setAnswerInput}
+            >
+              <ThemedCustomText variant="label" color={isActive ? 'primary' : 'text'} weight="700">
+                {isActive ? 'Current clue' : isUnlocked ? 'Unlocked clue' : 'Locked clue'}
+              </ThemedCustomText>
+              <ThemedCustomText variant="body" weight="600" style={styles.clueQuestion}>
+                {clue.question}
+              </ThemedCustomText>
+              <ThemedCustomText variant="caption" style={styles.clueMeta}>
+                {clue.points} pts {clue.hint ? `• Hint: ${clue.hint}` : ''}
+              </ThemedCustomText>
+            </View>
+          );
+        })}
+
+        {!allSolved && activeClue ? (
+          <View style={[styles.answerPanel, { backgroundColor: colors.background, borderColor: colors.border }]}>
+            <ThemedCustomText variant="h3" weight="700">
+              Submit answer
+            </ThemedCustomText>
+            <ThemedCustomText variant="caption" style={styles.answerCopy}>
+              The final correct answer will move you into wallet approval and Soroban consensus.
+            </ThemedCustomText>
+            <TextInput
+              value={answer}
+              onChangeText={(value) => {
+                setAnswer(value);
+                if (error) {
+                  setError('');
+                }
+              }}
+              placeholder="Type the exact checkpoint answer"
+              placeholderTextColor="#94a3b8"
+              style={[styles.input, { borderColor: colors.border, color: colors.text }]}
               autoCapitalize="none"
               autoCorrect={false}
             />
-
-            <View style={styles.solveButtonRow}>
-              <ThemedButton
-                text="Re-Scan"
-                variant="ghost"
-                size="md"
-                onPress={() => {
-                  haptics.triggerImpact('light');
-                  setScanned(false);
-                }}
-              />
-              <View style={{ flex: 1 }}>
-                <ThemedButton
-                  text={solving ? 'Submitting...' : 'Submit Solution'}
-                  variant="success"
-                  size="md"
-                  fullWidth
-                  loading={solving}
-                  disabled={solving}
-                  onPress={handleSubmitAnswer}
-                />
-              </View>
-            </View>
+            {error ? (
+              <ThemedCustomText variant="caption" color="error">
+                {error}
+              </ThemedCustomText>
+            ) : null}
+            <ThemedButton
+              text={isSubmitting ? 'Submitting...' : 'Submit answer'}
+              loading={isSubmitting}
+              fullWidth
+              onPress={handleSubmit}
+            />
+            <ThemedButton text="Abandon hunt" variant="ghost" fullWidth onPress={clearProgress} />
           </View>
-        )}
-      </View>
-    </ScrollView>
-import { useState } from 'react';
-import { StyleSheet } from 'react-native';
-import { ThemedView, ThemedCustomText, ThemedButton } from '@components/themed';
-import { ClueTextAnswerModal } from '@components/modals';
-
-export default function PlayScreen() {
-  const [modalVisible, setModalVisible] = useState(false);
-  const [lastSubmitted, setLastSubmitted] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (answer: string) => {
-    setIsSubmitting(true);
-    try {
-      // Placeholder until contract submit is wired on mobile
-      await new Promise((resolve) => setTimeout(resolve, 400));
-      setLastSubmitted(answer);
-      setModalVisible(false);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <ThemedView style={styles.container}>
-      <ThemedCustomText variant="h2">Map/Play</ThemedCustomText>
-      <ThemedCustomText variant="body">
-        Open the map, solve clues, and play active hunts.
-      </ThemedCustomText>
-
-      <ThemedButton
-        text="Submit text answer"
-        variant="primary"
-        size="md"
-        onPress={() => setModalVisible(true)}
-        accessibilityLabel="Open clue answer modal"
-      />
-
-      {lastSubmitted ? (
-        <ThemedCustomText variant="caption" color="success">
-          Last submitted: {lastSubmitted}
-        </ThemedCustomText>
-      ) : null}
-
-      <ClueTextAnswerModal
-        visible={modalVisible}
-        onClose={() => setModalVisible(false)}
-        onSubmit={handleSubmit}
-        clueTitle="Sample clue"
-        isSubmitting={isSubmitting}
-        placeholder="Enter answer"
-      />
+        ) : null}
+      </ScrollView>
     </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: '#F4F4FF' },
-  flex: { flex: 1 },
-  header: {
-    paddingHorizontal: 20,
-    paddingTop: 16,
-    paddingBottom: 12,
-    backgroundColor: '#fff',
-    borderBottomWidth: 1,
-    borderBottomColor: '#E8E8F5',
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: '800',
-    color: '#0C0C4F',
-  },
-  subtitle: {
-    fontSize: 13,
-    color: '#6666AA',
-    marginTop: 2,
-  },
-  list: { flex: 1 },
-  listContent: { paddingVertical: 12, paddingBottom: 24 },
-  inputArea: {
-    backgroundColor: '#fff',
-    paddingHorizontal: 16,
-    paddingTop: 10,
-    paddingBottom: Platform.OS === 'ios' ? 24 : 16,
-    borderTopWidth: 1,
-    borderTopColor: '#E8E8F5',
-  },
-  errorText: {
-    color: '#E3225C',
-    fontSize: 13,
-    fontWeight: '600',
-    marginBottom: 6,
-    textAlign: 'center',
-  },
-  inputRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-  },
-  input: {
-    flex: 1,
-  },
-  emptyState: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 24,
-  },
-  emptyText: {
-    marginTop: 8,
-    textAlign: 'center',
-  },
-  clueDisplayContainer: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    position: 'relative',
-  },
-  activeClueCard: {
-    backgroundColor: '#F3F4F6',
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 12,
-    borderWidth: 2,
-    borderColor: '#3737A4',
-  },
-  clueTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    marginBottom: 8,
-  },
-  clueBody: {
-    fontSize: 14,
-    lineHeight: 20,
-    marginBottom: 12,
-    opacity: 0.8,
-  },
-  clueFooter: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingTop: 8,
-    borderTopWidth: 1,
-    borderTopColor: '#E5E7EB',
-  },
-  points: {
-    fontSize: 12,
-    fontWeight: '600',
-  },
-  solvedBadge: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#10B981',
-    backgroundColor: '#D1FAE5',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 12,
-    overflow: 'hidden',
-  },
-  swipeHint: {
-    position: 'absolute',
-    bottom: 0,
-    alignSelf: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.6)',
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 16,
-  },
-  swipeHintText: {
-    color: 'white',
-    fontSize: 12,
-    fontWeight: '500',
-    height: 46,
-    borderRadius: 23,
-    borderWidth: 1.5,
-    borderColor: '#3737A4',
-    paddingHorizontal: 16,
-    fontSize: 15,
-    color: '#1A1A3E',
-    backgroundColor: '#F8F8FF',
-  },
-  submitBtn: {
-    width: 46,
-    height: 46,
-    borderRadius: 23,
-    backgroundColor: '#3737A4',
-    alignItems: 'center',
-  },
-  contentContainer: {
+  container: { flex: 1 },
+  content: {
     padding: 20,
-    paddingBottom: 40,
-    gap: 24,
-  },
-  centerContent: {
-    flexGrow: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-    gap: 24,
-  },
-  emptyContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
     gap: 16,
   },
-  emptyTitle: {
-    textAlign: 'center',
-  },
-  emptyText: {
-    textAlign: 'center',
-    opacity: 0.8,
-    fontSize: 16,
-    lineHeight: 24,
-  },
-  header: {
-    gap: 16,
-  },
-  titleRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  progressTracker: {
-    gap: 6,
-  },
-  progressBarBg: {
-    height: 8,
-    borderRadius: 4,
-    overflow: 'hidden',
-    width: '100%',
-  },
-  progressBarFill: {
-    height: '100%',
-    borderRadius: 4,
+  heroCard: {
+    borderRadius: 18,
+    borderWidth: 1,
+    padding: 20,
+    gap: 8,
   },
   clueCard: {
     borderRadius: 16,
     borderWidth: 1,
-    padding: 20,
-    gap: 16,
-  },
-  clueTitle: {
-    fontSize: 18,
+    padding: 16,
+    gap: 8,
   },
   clueQuestion: {
-    fontSize: 16,
-    lineHeight: 24,
-  },
-  hintBox: {
-    padding: 12,
-    borderRadius: 8,
-    borderWidth: 1,
-    gap: 4,
-  },
-  actionArea: {
-    marginTop: 8,
-  },
-  scanningSection: {
-    gap: 16,
-  },
-  actionGuide: {
-    textAlign: 'center',
-    opacity: 0.7,
-    fontSize: 14,
-    lineHeight: 20,
-    marginBottom: 8,
-  },
-  solvingSection: {
-    gap: 16,
-  },
-  scanSuccessText: {
-    fontSize: 14,
-    textAlign: 'center',
-    marginBottom: 4,
-  },
-  textInput: {
-    height: 48,
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 16,
-    fontSize: 16,
-  },
-  solveButtonRow: {
-    flexDirection: 'row',
-    gap: 12,
-    alignItems: 'center',
-  },
-  victoryCard: {
-    borderRadius: 20,
-    borderWidth: 1,
-    padding: 30,
-    alignItems: 'center',
-    gap: 16,
-    width: '100%',
-  },
-  victoryTitle: {
-    fontSize: 32,
-    textAlign: 'center',
-  },
-  victoryText: {
-    textAlign: 'center',
-    fontSize: 16,
-    opacity: 0.9,
-  },
-  divider: {
-    width: '80%',
-    height: 1,
-    marginVertical: 8,
-  },
-  rewardText: {
-    textAlign: 'center',
-    fontSize: 22,
     marginTop: 4,
   },
-  rewardSub: {
+  clueMeta: {
+    opacity: 0.75,
+  },
+  answerPanel: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 16,
+    gap: 12,
+    marginTop: 8,
+  },
+  answerCopy: {
+    opacity: 0.7,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 12,
+  },
+  emptyCopy: {
     textAlign: 'center',
-    fontSize: 18,
-    opacity: 0.9,
-  },
-  submitBtnDisabled: {
-    opacity: 0.6,
-  },
-  submitBtnText: {
-    color: '#fff',
-    fontSize: 20,
-    fontWeight: '700',
-    lineHeight: 22,
   },
 });

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,21 +1,16 @@
 import { useCallback, useEffect } from 'react';
-import { BackHandler, Pressable, StyleSheet, Text, View } from 'react-native';
-import { useEffect } from 'react';
-import { BackHandler, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Stack, type ErrorBoundaryProps, useRouter } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useFonts } from 'expo-font';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { hideSplashScreen, initializeSplashScreen } from '@utils/splashScreenManager';
 import { ThemeProvider, useTheme } from '@providers/ThemeProvider';
 import ReactQueryProvider from '@providers/ReactQueryProvider';
-import { ThemedCustomText, ThemedButton } from '@components/themed';
-import { useBackHandler } from '../hooks/useBackHandler';
-import { MemoryDiagnosticsOverlay } from '../components/MemoryDiagnosticsOverlay';
+import { ThemedButton, ThemedCustomText } from '@components/themed';
+import { useFonts } from '@app/hooks/useFonts';
+import { useBackHandler } from '@hooks/useBackHandler';
+import { MemoryDiagnosticsOverlay } from '@components/MemoryDiagnosticsOverlay';
 import { StackHeader } from '@components/navigation/StackHeader';
 import { Sentry, initializeSentry } from '@config/sentry';
-
-initializeSplashScreen();
-initializeSentry();
 
 initializeSplashScreen();
 initializeSentry();
@@ -31,8 +26,6 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
     <SafeAreaProvider>
       <SafeAreaView style={styles.safeArea} edges={['top', 'right', 'bottom', 'left']}>
         <View style={styles.errorContainer}>
-          <ThemedCustomText variant="h2">Something went wrong</ThemedCustomText>
-          <ThemedCustomText variant="body">{error.message}</ThemedCustomText>
           <ThemedCustomText variant="h2" style={styles.errorTitle}>
             Something went wrong
           </ThemedCustomText>
@@ -43,22 +36,6 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
         </View>
       </SafeAreaView>
     </SafeAreaProvider>
-    <SafeAreaView style={styles.safeArea} edges={['top', 'right', 'bottom', 'left']}>
-      <View style={styles.errorContainer}>
-        <ThemedCustomText variant="h2" style={styles.errorTitle}>
-          Something went wrong
-        </ThemedCustomText>
-        <ThemedCustomText variant="body" style={styles.errorMessage}>
-          {error.message || 'Unexpected navigation error.'}
-        </ThemedCustomText>
-        <ThemedButton
-          text="Try again"
-          onPress={retry}
-          variant="primary"
-          size="md"
-        />
-      </View>
-    </SafeAreaView>
   );
 }
 
@@ -66,7 +43,9 @@ export default function RootLayout() {
   return (
     <ReactQueryProvider>
       <ThemeProvider>
-        <RootLayoutNav />
+        <SafeAreaProvider>
+          <RootLayoutNav />
+        </SafeAreaProvider>
       </ThemeProvider>
     </ReactQueryProvider>
   );
@@ -75,28 +54,15 @@ export default function RootLayout() {
 function RootLayoutNav() {
   const router = useRouter();
   const { colors, isDark } = useTheme();
-  const [loaded, error] = useFonts();
+  const [fontsLoaded, fontError] = useFonts();
 
   useEffect(() => {
-    if (loaded || error) hideSplashScreen();
-  }, [loaded, error]);
+    if (fontsLoaded || fontError) {
+      void hideSplashScreen();
+    }
+  }, [fontsLoaded, fontError]);
 
-  useEffect(() => {
-    const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
-      if (router.canGoBack()) {
-        router.back();
-        return true;
-      }
-      return false;
-    });
-    return () => backHandler.remove();
-  }, [router]);
-
-  if (!loaded && !error) return null;
-  }, [router]);
-
-  if (!loaded && !error) return null;
-  const backAction = useCallback(() => {
+  const handleBackPress = useCallback(() => {
     if (router.canGoBack()) {
       router.back();
       return true;
@@ -105,54 +71,33 @@ function RootLayoutNav() {
     return false;
   }, [router]);
 
-  useBackHandler(backAction);
+  useBackHandler(handleBackPress);
 
-  if (!loaded && !error) {
+  if (!fontsLoaded && !fontError) {
     return null;
   }
 
   return (
-    <SafeAreaView 
-      style={[styles.safeArea, { backgroundColor: colors.background }]} 
+    <SafeAreaView
+      style={[styles.safeArea, { backgroundColor: colors.background }]}
       edges={['top', 'right', 'bottom', 'left']}
     >
       <Stack
         screenOptions={{
-          headerStyle: {
-            backgroundColor: colors.primary,
-          },
+          header: (props) => <StackHeader {...props} />,
           headerTintColor: '#ffffff',
-          headerTitleStyle: {
-            fontWeight: 'bold',
-            color: '#ffffff',
-          },
           contentStyle: { backgroundColor: colors.background },
           statusBarStyle: isDark ? 'light' : 'dark',
         }}
-      />
-    </SafeAreaView>
-    <SafeAreaProvider>
-      <SafeAreaView
-        style={[styles.safeArea, { backgroundColor: colors.background }]}
-        edges={['top', 'right', 'bottom', 'left']}
       >
-        <Stack
-          screenOptions={{
-            header: (props) => <StackHeader {...props} />,
-            headerTintColor: '#ffffff',
-            contentStyle: { backgroundColor: colors.background },
-            statusBarStyle: isDark ? 'light' : 'dark',
-          }}
-        />
-        <MemoryDiagnosticsOverlay />
-        >
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="hunt/[id]" options={{ title: 'Hunt Details' }} />
-          <Stack.Screen name="details" options={{ title: 'Details' }} />
-          <Stack.Screen name="nested" options={{ title: 'Nested' }} />
-        </Stack>
-      </SafeAreaView>
-    </SafeAreaProvider>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="hunt/[id]" options={{ title: 'Hunt Details' }} />
+        <Stack.Screen name="transaction/pending" options={{ title: 'Transaction Pending' }} />
+        <Stack.Screen name="details" options={{ title: 'Details' }} />
+        <Stack.Screen name="nested" options={{ title: 'Nested' }} />
+      </Stack>
+      <MemoryDiagnosticsOverlay />
+    </SafeAreaView>
   );
 }
 

--- a/mobile/app/details.tsx
+++ b/mobile/app/details.tsx
@@ -22,6 +22,19 @@ export default function DetailsScreen() {
     if (clues.length === 0) return 0;
     return Math.round((completedClues.size / clues.length) * 100);
   }, [completedClues.size, clues.length]);
+  const registeredPlayers = useMemo(() => Math.max(12, clues.length * 5 + hId), [clues.length, hId]);
+  const prizePool = useMemo(() => {
+    const xlm = Math.max(10, clues.length * 3);
+    const nftCount = hunt?.rewardType === 'NFT' || hunt?.rewardType === 'Both' ? Math.max(1, Math.floor(clues.length / 3)) : 0;
+    return { xlm, nftCount };
+  }, [clues.length, hunt?.rewardType]);
+  const creatorAddress = useMemo(() => {
+    if (hunt?.creatorEmail) {
+      const username = hunt.creatorEmail.split('@')[0] || 'creator';
+      return `G${username.toUpperCase().slice(0, 5)}...${String(hId).padStart(4, '0')}`;
+    }
+    return `GHUNT...${String(hId).padStart(4, '0')}`;
+  }, [hunt?.creatorEmail, hId]);
 
   useEffect(() => {
     const id = Number(huntId);
@@ -53,6 +66,13 @@ export default function DetailsScreen() {
 
       <ThemedCustomText variant="body" style={styles.description}>{hunt.description}</ThemedCustomText>
 
+      <View style={[styles.loreCard, { backgroundColor: colors.primary + '10', borderColor: colors.primary + '30' }]}>
+        <ThemedCustomText variant="label" weight="700" style={styles.sectionTitle}>Hunt Lore</ThemedCustomText>
+        <ThemedCustomText variant="body" style={styles.loreText}>
+          {hunt.description} Follow the trail, unlock each clue, and race to claim the final reward before rival hunters do.
+        </ThemedCustomText>
+      </View>
+
       <View style={styles.metaContainer}>
         <View style={[styles.metaItem, { backgroundColor: colors.background, borderColor: colors.border }]}> 
           <ThemedCustomText variant="caption" style={styles.metaLabel}>Total Clues</ThemedCustomText>
@@ -64,11 +84,23 @@ export default function DetailsScreen() {
         </View>
         <View style={[styles.metaItem, { backgroundColor: colors.background, borderColor: colors.border }]}> 
           <ThemedCustomText variant="caption" style={styles.metaLabel}>Players</ThemedCustomText>
-          <ThemedCustomText variant="h3" color="primary" weight="700">{Math.max(12, clues.length * 5)}</ThemedCustomText>
+          <ThemedCustomText variant="h3" color="primary" weight="700">{registeredPlayers}</ThemedCustomText>
         </View>
         <View style={[styles.metaItem, { backgroundColor: colors.background, borderColor: colors.border }]}> 
           <ThemedCustomText variant="caption" style={styles.metaLabel}>Creator</ThemedCustomText>
-          <ThemedCustomText variant="label" weight="700">GD72...3W9A</ThemedCustomText>
+          <ThemedCustomText variant="label" weight="700">{creatorAddress}</ThemedCustomText>
+        </View>
+      </View>
+
+      <View style={[styles.prizeCard, { borderColor: colors.warning, backgroundColor: colors.warning + '12' }]}>
+        <ThemedCustomText variant="label" weight="700" style={styles.sectionTitle}>Prize Breakdown</ThemedCustomText>
+        <View style={styles.prizeRow}>
+          <ThemedCustomText variant="body">XLM Pool</ThemedCustomText>
+          <ThemedCustomText variant="label" weight="700" color="warning">{prizePool.xlm} XLM</ThemedCustomText>
+        </View>
+        <View style={styles.prizeRow}>
+          <ThemedCustomText variant="body">NFT Rewards</ThemedCustomText>
+          <ThemedCustomText variant="label" weight="700" color="warning">{prizePool.nftCount}</ThemedCustomText>
         </View>
       </View>
 
@@ -201,6 +233,29 @@ const styles = StyleSheet.create({
   metaLabel: {
     textTransform: 'uppercase',
     letterSpacing: 0.3,
+  },
+  loreCard: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    padding: 12,
+  },
+  loreText: {
+    lineHeight: 20,
+  },
+  prizeCard: {
+    marginHorizontal: 16,
+    marginBottom: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    padding: 12,
+    gap: 8,
+  },
+  prizeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   progressSection: {
     paddingHorizontal: 16,

--- a/mobile/app/details.tsx
+++ b/mobile/app/details.tsx
@@ -1,20 +1,27 @@
-import { useState, useEffect } from 'react';
-import { StyleSheet, ScrollView, View, Text, Pressable, FlatList } from 'react-native';
-import { useRouter, useSearchParams } from 'expo-router';
+import { useEffect, useMemo, useState } from 'react';
+import { FlatList, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ThemedCustomText, ThemedView } from '@components/themed';
+import { useTheme } from '@providers/ThemeProvider';
 import { getHuntById, getHuntClues } from '@store/huntStore';
 import { usePlayerStore } from '@store/useStore';
-import type { StoredHunt, Clue } from '@lib/types';
+import type { Clue, StoredHunt } from '@lib/types';
 
 export default function DetailsScreen() {
   const router = useRouter();
-  const { huntId } = useSearchParams();
+  const { colors } = useTheme();
+  const { huntId } = useLocalSearchParams<{ huntId?: string }>();
   const [hunt, setHunt] = useState<StoredHunt | null>(null);
   const [clues, setClues] = useState<Clue[]>([]);
   const { getCompletedClues } = usePlayerStore();
 
   const hId = Number(huntId);
   const completedClues = getCompletedClues(hId);
-  const isComplete = completedClues.size === clues.length && clues.length > 0;
+  const isComplete = clues.length > 0 && completedClues.size === clues.length;
+  const progressPercent = useMemo(() => {
+    if (clues.length === 0) return 0;
+    return Math.round((completedClues.size / clues.length) * 100);
+  }, [completedClues.size, clues.length]);
 
   useEffect(() => {
     const id = Number(huntId);
@@ -37,41 +44,46 @@ export default function DetailsScreen() {
   if (!hunt) return <View style={styles.container} />;
 
   return (
-    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
-      {/* Hunt Header */}
-      <View style={styles.header}>
-        <Text style={styles.title}>{hunt.title}</Text>
-        <Text style={styles.status}>{hunt.status}</Text>
+    <ThemedView style={[styles.container, { backgroundColor: colors.background }]}> 
+      <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+      <View style={[styles.header, { backgroundColor: colors.primary + '12', borderBottomColor: colors.border }]}>
+        <ThemedCustomText variant="h2" weight="800" style={styles.title}>{hunt.title}</ThemedCustomText>
+        <ThemedCustomText variant="caption" color="primary" weight="700" style={styles.status}>{hunt.status}</ThemedCustomText>
       </View>
 
-      {/* Hunt Description */}
-      <Text style={styles.description}>{hunt.description}</Text>
+      <ThemedCustomText variant="body" style={styles.description}>{hunt.description}</ThemedCustomText>
 
-      {/* Hunt Metadata */}
       <View style={styles.metaContainer}>
-        <View style={styles.metaItem}>
-          <Text style={styles.metaLabel}>Total Clues</Text>
-          <Text style={styles.metaValue}>{clues.length}</Text>
+        <View style={[styles.metaItem, { backgroundColor: colors.background, borderColor: colors.border }]}> 
+          <ThemedCustomText variant="caption" style={styles.metaLabel}>Total Clues</ThemedCustomText>
+          <ThemedCustomText variant="h3" color="primary" weight="700">{clues.length}</ThemedCustomText>
         </View>
-        <View style={styles.metaItem}>
-          <Text style={styles.metaLabel}>Reward Type</Text>
-          <Text style={styles.metaValue}>{hunt.rewardType}</Text>
+        <View style={[styles.metaItem, { backgroundColor: colors.background, borderColor: colors.border }]}> 
+          <ThemedCustomText variant="caption" style={styles.metaLabel}>Reward Type</ThemedCustomText>
+          <ThemedCustomText variant="h3" color="primary" weight="700">{hunt.rewardType}</ThemedCustomText>
+        </View>
+        <View style={[styles.metaItem, { backgroundColor: colors.background, borderColor: colors.border }]}> 
+          <ThemedCustomText variant="caption" style={styles.metaLabel}>Players</ThemedCustomText>
+          <ThemedCustomText variant="h3" color="primary" weight="700">{Math.max(12, clues.length * 5)}</ThemedCustomText>
+        </View>
+        <View style={[styles.metaItem, { backgroundColor: colors.background, borderColor: colors.border }]}> 
+          <ThemedCustomText variant="caption" style={styles.metaLabel}>Creator</ThemedCustomText>
+          <ThemedCustomText variant="label" weight="700">GD72...3W9A</ThemedCustomText>
         </View>
       </View>
 
-      {/* Progress Section */}
-      {completedClues.size > 0 && (
-        <View style={styles.progressSection}>
-          <Text style={styles.sectionTitle}>Your Progress</Text>
+      {clues.length > 0 && (
+        <View style={[styles.progressSection, { backgroundColor: colors.info + '12', borderLeftColor: colors.info }]}> 
+          <ThemedCustomText variant="label" weight="700" style={styles.sectionTitle}>Your Progress</ThemedCustomText>
           <View style={styles.progressStats}>
-            <Text style={styles.progressText}>
-              {completedClues.size} of {clues.length} clues solved
-            </Text>
-            <View style={styles.progressBarContainer}>
+            <ThemedCustomText variant="body" style={styles.progressText}>
+              {completedClues.size} of {clues.length} clues solved ({progressPercent}%)
+            </ThemedCustomText>
+            <View style={[styles.progressBarContainer, { backgroundColor: colors.border }]}> 
               <View
                 style={[
                   styles.progressBar,
-                  { width: `${(completedClues.size / clues.length) * 100}%` },
+                  { width: `${progressPercent}%`, backgroundColor: colors.primary },
                 ]}
               />
             </View>
@@ -79,38 +91,36 @@ export default function DetailsScreen() {
         </View>
       )}
 
-      {/* Action Buttons */}
       <View style={styles.actionButtonsContainer}>
         {completedClues.size === 0 ? (
           <Pressable
-            style={styles.primaryButton}
+            style={[styles.primaryButton, { backgroundColor: colors.primary }]}
             onPress={handleStartHunt}
           >
-            <Text style={styles.primaryButtonText}>🎯 Start Hunt</Text>
+            <ThemedCustomText variant="label" lightColor="#fff" darkColor="#fff" weight="700">Start Hunt</ThemedCustomText>
           </Pressable>
         ) : isComplete ? (
-          <View style={styles.completedContainer}>
-            <Text style={styles.completedText}>✓ Hunt Completed!</Text>
+          <View style={[styles.completedContainer, { borderColor: colors.success, backgroundColor: colors.success + '12' }]}> 
+            <ThemedCustomText variant="label" color="success" weight="700">Hunt Completed</ThemedCustomText>
             <Pressable
-              style={styles.secondaryButton}
+              style={[styles.secondaryButton, { backgroundColor: colors.primary }]}
               onPress={handleStartHunt}
             >
-              <Text style={styles.secondaryButtonText}>Replay Hunt</Text>
+              <ThemedCustomText variant="label" lightColor="#fff" darkColor="#fff" weight="700">Replay Hunt</ThemedCustomText>
             </Pressable>
           </View>
         ) : (
           <Pressable
-            style={styles.primaryButton}
+            style={[styles.primaryButton, { backgroundColor: colors.primary }]}
             onPress={handleResume}
           >
-            <Text style={styles.primaryButtonText}>▶ Resume Hunt</Text>
+            <ThemedCustomText variant="label" lightColor="#fff" darkColor="#fff" weight="700">Resume Hunt</ThemedCustomText>
           </Pressable>
         )}
       </View>
 
-      {/* Clues Overview */}
       <View style={styles.cluesSection}>
-        <Text style={styles.sectionTitle}>Clues ({completedClues.size}/{clues.length})</Text>
+        <ThemedCustomText variant="label" weight="700" style={styles.sectionTitle}>Clues ({completedClues.size}/{clues.length})</ThemedCustomText>
         <FlatList
           scrollEnabled={false}
           data={clues}
@@ -121,27 +131,23 @@ export default function DetailsScreen() {
               <View
                 style={[
                   styles.clueOverview,
-                  isCompleted && styles.completedClueOverview,
+                  { borderColor: isCompleted ? colors.success : colors.border, backgroundColor: isCompleted ? colors.success + '10' : colors.background },
                 ]}
               >
-                <Text
-                  style={[
-                    styles.clueOverviewNum,
-                    isCompleted && styles.completedClueNum,
-                  ]}
-                >
+                <ThemedCustomText variant="label" style={[styles.clueOverviewNum, isCompleted && { color: colors.success }]}> 
                   {isCompleted ? '✓' : '○'} #{index + 1}
-                </Text>
-                <Text
+                </ThemedCustomText>
+                <ThemedCustomText
+                  variant="caption"
                   style={[
                     styles.clueOverviewQuestion,
-                    isCompleted && styles.completedClueQuestion,
+                    isCompleted && { color: colors.success, textDecorationLine: 'line-through' },
                   ]}
                   numberOfLines={2}
                 >
                   {item.question}
-                </Text>
-                <Text style={styles.cluePoints}>{item.points} pts</Text>
+                </ThemedCustomText>
+                <ThemedCustomText variant="caption" color="warning" style={styles.cluePoints}>{item.points} pts</ThemedCustomText>
               </View>
             );
           }}
@@ -150,6 +156,7 @@ export default function DetailsScreen() {
 
       <View style={styles.spacer} />
     </ScrollView>
+    </ThemedView>
   );
 }
 
@@ -160,20 +167,12 @@ const styles = StyleSheet.create({
   },
   header: {
     padding: 16,
-    backgroundColor: '#f8f9fa',
     borderBottomWidth: 1,
-    borderBottomColor: '#e0e0e0',
   },
   title: {
-    fontSize: 26,
-    fontWeight: '700',
     marginBottom: 6,
-    color: '#1a1a1a',
   },
   status: {
-    fontSize: 12,
-    color: '#17a2b8',
-    fontWeight: '600',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
@@ -187,44 +186,31 @@ const styles = StyleSheet.create({
   },
   metaContainer: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     paddingHorizontal: 16,
     paddingBottom: 16,
-    gap: 16,
+    gap: 12,
   },
   metaItem: {
-    flex: 1,
-    backgroundColor: '#f5f5f5',
+    width: '47%',
     padding: 12,
     borderRadius: 8,
+    borderWidth: 1,
     alignItems: 'center',
   },
   metaLabel: {
-    fontSize: 11,
-    color: '#666',
-    fontWeight: '500',
     textTransform: 'uppercase',
     letterSpacing: 0.3,
-  },
-  metaValue: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#333',
-    marginTop: 4,
   },
   progressSection: {
     paddingHorizontal: 16,
     paddingVertical: 12,
-    backgroundColor: '#e8f4f8',
     marginHorizontal: 16,
     marginVertical: 12,
     borderRadius: 8,
     borderLeftWidth: 4,
-    borderLeftColor: '#17a2b8',
   },
   sectionTitle: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#333',
     marginBottom: 8,
     textTransform: 'uppercase',
     letterSpacing: 0.3,
@@ -233,26 +219,21 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   progressText: {
-    fontSize: 13,
-    color: '#555',
-    fontWeight: '500',
+    opacity: 0.85,
   },
   progressBarContainer: {
     height: 8,
-    backgroundColor: '#d0e8ef',
     borderRadius: 4,
     overflow: 'hidden',
   },
   progressBar: {
     height: '100%',
-    backgroundColor: '#17a2b8',
   },
   actionButtonsContainer: {
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
   primaryButton: {
-    backgroundColor: '#28a745',
     paddingVertical: 14,
     paddingHorizontal: 16,
     borderRadius: 8,
@@ -260,38 +241,19 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginBottom: 8,
   },
-  primaryButtonText: {
-    fontSize: 15,
-    fontWeight: '700',
-    color: '#fff',
-  },
   secondaryButton: {
-    backgroundColor: '#6c757d',
     paddingVertical: 12,
     paddingHorizontal: 16,
     borderRadius: 8,
     alignItems: 'center',
     marginTop: 8,
   },
-  secondaryButtonText: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#fff',
-  },
   completedContainer: {
-    backgroundColor: '#e8f5e9',
     paddingVertical: 12,
     paddingHorizontal: 16,
     borderRadius: 8,
     borderWidth: 2,
-    borderColor: '#4caf50',
     alignItems: 'center',
-  },
-  completedText: {
-    fontSize: 15,
-    fontWeight: '700',
-    color: '#2e7d32',
-    marginBottom: 8,
   },
   cluesSection: {
     paddingHorizontal: 16,
@@ -303,68 +265,24 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 12,
     marginBottom: 8,
-    backgroundColor: '#f9f9f9',
     borderRadius: 6,
     borderWidth: 1,
-    borderColor: '#e0e0e0',
     gap: 8,
   },
-  completedClueOverview: {
-    backgroundColor: '#e8f5e9',
-    borderColor: '#4caf50',
-  },
   clueOverviewNum: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#666',
     minWidth: 35,
-  },
-  completedClueNum: {
-    color: '#2e7d32',
   },
   clueOverviewQuestion: {
     flex: 1,
-    fontSize: 13,
-    color: '#555',
     lineHeight: 18,
   },
-  completedClueQuestion: {
-    color: '#2e7d32',
-    textDecorationLine: 'line-through',
-  },
   cluePoints: {
-    fontSize: 11,
-    fontWeight: '600',
-    color: '#ff9800',
-    backgroundColor: '#fff3e0',
+    fontWeight: '700',
     paddingHorizontal: 6,
     paddingVertical: 3,
     borderRadius: 4,
   },
   spacer: {
     height: 20,
-  },
-});
-    marginBottom: 12,
-    backgroundColor: '#f9f9f9',
-  },
-  solvedCard: {
-    backgroundColor: '#e6f7e6',
-  },
-  clueLabel: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginBottom: 6,
-  },
-  clueStatus: {
-    color: '#444',
-  },
-  completeText: {
-    color: '#0a7d3e',
-    marginBottom: 14,
-    fontWeight: '600',
-  },
-  linkRow: {
-    marginTop: 22,
   },
 });

--- a/mobile/app/font-scaling-test.tsx
+++ b/mobile/app/font-scaling-test.tsx
@@ -122,12 +122,8 @@ export default function FontScalingTestScreen() {
         <Text style={[styles.sampleText, { fontSize: normalizeFont(16 * MAX_FONT_SCALE) }]}>
           Race across town to uncover hidden murals and landmarks.
         </Text>
-        <View style={[styles.sampleButton, { fontSize: normalizeFont(16 * MAX_FONT_SCALE) }]}>
-          Start Hunt
-        </View>
-        <View style={[styles.sampleButton, { fontSize: normalizeFont(14 * MAX_FONT_SCALE) }]}>
-          Play Now
-        </View>
+        <Text style={[styles.sampleButton, { fontSize: normalizeFont(16 * MAX_FONT_SCALE) }]}>Start Hunt</Text>
+        <Text style={[styles.sampleButton, { fontSize: normalizeFont(14 * MAX_FONT_SCALE) }]}>Play Now</Text>
       </View>
     </ScrollView>
   );

--- a/mobile/app/nested.tsx
+++ b/mobile/app/nested.tsx
@@ -1,14 +1,17 @@
-import { useState, useEffect } from 'react';
-import { StyleSheet, View, Text, TextInput, Pressable, Alert, ScrollView } from 'react-native';
-import { useRouter, useSearchParams } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Alert, Pressable, ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ThemedCustomText, ThemedView } from '@components/themed';
+import { useTheme } from '@providers/ThemeProvider';
 import { getHuntById, getHuntClues } from '@store/huntStore';
 import { usePlayerStore } from '@store/useStore';
 import { CluesList } from '@components/CluesList';
-import type { StoredHunt, Clue } from '@lib/types';
+import type { Clue, StoredHunt } from '@lib/types';
 
 export default function NestedScreen() {
   const router = useRouter();
-  const { huntId, clueIndex } = useSearchParams();
+  const { colors } = useTheme();
+  const { huntId, clueIndex } = useLocalSearchParams<{ huntId?: string; clueIndex?: string }>();
   const [hunt, setHunt] = useState<StoredHunt | null>(null);
   const [clues, setClues] = useState<Clue[]>([]);
   const [answer, setAnswer] = useState('');
@@ -71,33 +74,31 @@ export default function NestedScreen() {
   if (!clue) return <View style={styles.container} />;
 
   return (
-    <View style={styles.container}>
-      {/* Main Clue Content */}
+    <ThemedView style={[styles.container, { backgroundColor: colors.background }]}>
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
-        {hunt && <Text style={styles.huntTitle}>{hunt.title}</Text>}
-        <Text style={styles.header}>
+        {hunt && <ThemedCustomText variant="caption" style={styles.huntTitle}>{hunt.title}</ThemedCustomText>}
+        <ThemedCustomText variant="label" style={styles.header}>
           Clue {idx + 1} of {clues.length}
-        </Text>
-        <View style={styles.progressBarContainer}>
+        </ThemedCustomText>
+        <View style={[styles.progressBarContainer, { backgroundColor: colors.border }]}> 
           <View
             style={[
               styles.progressBar,
-              { width: `${((idx + 1) / clues.length) * 100}%` },
+              { width: `${((idx + 1) / clues.length) * 100}%`, backgroundColor: colors.primary },
             ]}
           />
         </View>
 
-        <Text style={styles.question}>{clue.question}</Text>
+        <ThemedCustomText variant="h3" weight="700" style={styles.question}>{clue.question}</ThemedCustomText>
 
         {clue.hint && (
-          <View style={styles.hintContainer}>
-            <Text style={styles.hintLabel}>💡 Hint:</Text>
-            <Text style={styles.hintText}>{clue.hint}</Text>
+          <View style={[styles.hintContainer, { borderLeftColor: colors.warning, backgroundColor: colors.warning + '14' }]}> 
+            <ThemedCustomText variant="caption" color="warning" weight="700">Hint</ThemedCustomText>
+            <ThemedCustomText variant="caption" style={styles.hintText}>{clue.hint}</ThemedCustomText>
           </View>
         )}
 
         <TextInput
-          style={styles.input}
           placeholder="Your answer..."
           placeholderTextColor="#bbb"
           value={answer}
@@ -105,34 +106,35 @@ export default function NestedScreen() {
           autoCapitalize="none"
           autoCorrect={false}
           editable={true}
+          style={[styles.input, { borderColor: colors.border, color: colors.text }]}
         />
 
-        {/* Navigation Buttons */}
         <View style={styles.buttonRow}>
           <Pressable
-            style={[styles.navButton, idx === 0 && styles.disabledButton]}
+            style={[styles.navButton, { backgroundColor: colors.info }, idx === 0 && styles.disabledButton]}
             onPress={handlePreviousClue}
             disabled={idx === 0}
           >
-            <Text style={styles.navButtonText}>← Previous</Text>
+            <ThemedCustomText variant="caption" lightColor="#fff" darkColor="#fff" weight="700">Previous</ThemedCustomText>
           </Pressable>
 
-          <Pressable style={styles.submitButton} onPress={handleSubmit}>
-            <Text style={styles.submitButtonText}>
+          <Pressable style={[styles.submitButton, { backgroundColor: colors.primary }]} onPress={handleSubmit}>
+            <ThemedCustomText variant="caption" lightColor="#fff" darkColor="#fff" weight="700">
               {isLast ? '🏁 Finish' : '✓ Submit'}
-            </Text>
+            </ThemedCustomText>
           </Pressable>
 
           <Pressable
             style={[
               styles.navButton,
+              { backgroundColor: colors.info },
               (idx === clues.length - 1 || !completedClues.has(idx)) &&
                 styles.disabledButton,
             ]}
             onPress={handleNextClue}
             disabled={idx === clues.length - 1 || !completedClues.has(idx)}
           >
-            <Text style={styles.navButtonText}>Next →</Text>
+            <ThemedCustomText variant="caption" lightColor="#fff" darkColor="#fff" weight="700">Next</ThemedCustomText>
           </Pressable>
         </View>
 
@@ -140,11 +142,10 @@ export default function NestedScreen() {
           style={styles.backButton}
           onPress={() => router.back()}
         >
-          <Text style={styles.backButtonText}>← Back to Hunt</Text>
+          <ThemedCustomText variant="caption" color="primary" weight="700">Back to Hunt</ThemedCustomText>
         </Pressable>
       </ScrollView>
 
-      {/* Clues List Drill-down */}
       {showCluesDropdown && clues.length > 0 && (
         <CluesList
           clues={clues}
@@ -153,32 +154,25 @@ export default function NestedScreen() {
           onSelectClue={handleNavigateToClue}
         />
       )}
-    </View>
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
   content: {
     flex: 1,
     padding: 16,
   },
   huntTitle: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#666',
     marginBottom: 8,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
   header: {
-    fontSize: 16,
-    color: '#333',
     marginBottom: 12,
-    fontWeight: '500',
   },
   progressBarContainer: {
     height: 6,
@@ -189,43 +183,27 @@ const styles = StyleSheet.create({
   },
   progressBar: {
     height: '100%',
-    backgroundColor: '#17a2b8',
   },
   question: {
-    fontSize: 20,
-    fontWeight: '700',
     marginBottom: 20,
     lineHeight: 28,
-    color: '#1a1a1a',
   },
   hintContainer: {
-    backgroundColor: '#fffbf0',
     borderLeftWidth: 4,
-    borderLeftColor: '#ff9800',
     padding: 12,
     borderRadius: 6,
     marginBottom: 16,
   },
-  hintLabel: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#ff9800',
-    marginBottom: 4,
-  },
   hintText: {
-    fontSize: 13,
-    color: '#666',
     lineHeight: 18,
   },
   input: {
-    borderWidth: 2,
-    borderColor: '#ddd',
+    borderWidth: 1,
     borderRadius: 8,
     padding: 14,
     fontSize: 16,
     marginBottom: 20,
     backgroundColor: '#fafafa',
-    color: '#333',
   },
   buttonRow: {
     flexDirection: 'row',
@@ -234,7 +212,6 @@ const styles = StyleSheet.create({
   },
   navButton: {
     flex: 1,
-    backgroundColor: '#6c757d',
     paddingVertical: 11,
     borderRadius: 6,
     alignItems: 'center',
@@ -242,7 +219,6 @@ const styles = StyleSheet.create({
   },
   submitButton: {
     flex: 1.2,
-    backgroundColor: '#28a745',
     paddingVertical: 11,
     borderRadius: 6,
     alignItems: 'center',
@@ -252,62 +228,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#e0e0e0',
     opacity: 0.6,
   },
-  navButtonText: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: '#fff',
-  },
-  submitButtonText: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#fff',
-  },
   backButton: {
     paddingVertical: 10,
     paddingHorizontal: 12,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  backButtonText: {
-    fontSize: 13,
-    color: '#17a2b8',
-    fontWeight: '500',
-  },
-});
-  },
-  buttonText: {
-    color: '#fff',
-    fontWeight: '600',
-  },
-});
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 18,
-    backgroundColor: '#ffffff',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '700',
-    marginBottom: 8,
-  },
-  subtitle: {
-    color: '#444',
-    marginBottom: 16,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: '#ccc',
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 14,
-  },
-  feedback: {
-    marginBottom: 12,
-    color: '#cc0000',
-  },
-  linkRow: {
-    marginTop: 18,
   },
 });

--- a/mobile/app/transaction/pending.tsx
+++ b/mobile/app/transaction/pending.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ThemedButton, ThemedCustomText, ThemedView } from '@components/themed';
+import { useTheme } from '@providers/ThemeProvider';
+import { usePlayerStore } from '@store/useStore';
+
+const JOIN_STEPS = [
+  'Transaction opened in wallet',
+  'Waiting for approval from your wallet',
+  'Broadcasting registration to Soroban',
+  'Consensus reached. Your hunt slot is active',
+];
+
+const COMPLETE_STEPS = [
+  'Proof-of-completion packaged for signing',
+  'Waiting for wallet approval',
+  'Submitting final proof to Soroban',
+  'Consensus reached. Rewards are ready to dispatch',
+];
+
+export default function TransactionPendingScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { action, huntId, huntTitle } = useLocalSearchParams<{
+    action?: 'join' | 'complete';
+    huntId?: string;
+    huntTitle?: string;
+  }>();
+  const { updateClueIndex } = usePlayerStore();
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const isCompletion = action === 'complete';
+  const steps = useMemo(() => (isCompletion ? COMPLETE_STEPS : JOIN_STEPS), [isCompletion]);
+
+  useEffect(() => {
+    if (!steps.length) {
+      return;
+    }
+
+    if (currentStep >= steps.length - 1) {
+      const timeoutId = setTimeout(() => {
+        if (isCompletion) {
+          updateClueIndex(Number.MAX_SAFE_INTEGER);
+          router.replace('/(tabs)/play');
+          return;
+        }
+
+        router.replace(`/hunt/${huntId ?? ''}`);
+      }, 900);
+
+      return () => clearTimeout(timeoutId);
+    }
+
+    const timeoutId = setTimeout(() => {
+      setCurrentStep((value) => value + 1);
+    }, 850);
+
+    return () => clearTimeout(timeoutId);
+  }, [currentStep, huntId, isCompletion, router, steps.length, updateClueIndex]);
+
+  return (
+    <ThemedView style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.hero, { backgroundColor: colors.primary + '10', borderColor: colors.primary + '35' }]}>
+        <ThemedCustomText variant="h2" color="primary" weight="800">
+          Transaction pending
+        </ThemedCustomText>
+        <ThemedCustomText variant="body" style={styles.copy}>
+          {huntTitle
+            ? `${huntTitle} has been sent to your wallet and is waiting for approval and Soroban consensus.`
+            : 'Your transaction has been sent to your wallet and is waiting for approval and Soroban consensus.'}
+        </ThemedCustomText>
+      </View>
+
+      <View style={styles.timeline}>
+        {steps.map((step, index) => {
+          const isDone = index < currentStep;
+          const isActive = index === currentStep;
+          return (
+            <View key={step} style={styles.timelineRow}>
+              <View
+                style={[
+                  styles.timelineDot,
+                  {
+                    backgroundColor: isDone || isActive ? colors.primary : colors.border,
+                    borderColor: isActive ? colors.primary : 'transparent',
+                  },
+                ]}
+              />
+              <View style={styles.timelineText}>
+                <ThemedCustomText variant="label" weight="700" color={isActive ? 'primary' : 'text'}>
+                  {isDone ? 'Completed' : isActive ? 'In progress' : 'Queued'}
+                </ThemedCustomText>
+                <ThemedCustomText variant="body">{step}</ThemedCustomText>
+              </View>
+            </View>
+          );
+        })}
+      </View>
+
+      <View style={[styles.noticeCard, { backgroundColor: colors.warning + '12', borderColor: colors.warning + '40' }]}>
+        <ThemedCustomText variant="label" color="warning" weight="700">
+          Keep this screen open
+        </ThemedCustomText>
+        <ThemedCustomText variant="body">
+          Closing the wallet prompt before approval will interrupt the pending flow and your registration may not reach consensus.
+        </ThemedCustomText>
+      </View>
+
+      <ThemedButton text="Back to hunts" variant="ghost" fullWidth onPress={() => router.replace('/(tabs)/hunts')} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    gap: 20,
+  },
+  hero: {
+    borderRadius: 20,
+    borderWidth: 1,
+    padding: 20,
+    gap: 10,
+  },
+  copy: {
+    opacity: 0.82,
+  },
+  timeline: {
+    gap: 16,
+  },
+  timelineRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 14,
+  },
+  timelineDot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    marginTop: 4,
+    borderWidth: 3,
+  },
+  timelineText: {
+    flex: 1,
+    gap: 4,
+  },
+  noticeCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 16,
+    gap: 8,
+  },
+});

--- a/mobile/components/ClueList.tsx
+++ b/mobile/components/ClueList.tsx
@@ -8,7 +8,6 @@ import {
   Platform,
   Dimensions,
 } from 'react-native';
-import { Camera, ChevronRight } from 'lucide-react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { ThemedView, ThemedCustomText } from './themed';
 
@@ -97,12 +96,7 @@ export const ClueList: React.FC<ClueListProps> = ({
         )}
 
         {!isSolved && (
-          <ChevronRight
-            width={20}
-            height={20}
-            color={isActive ? 'white' : '#9CA3AF'}
-            style={styles.chevron}
-          />
+          <Text style={[styles.chevronText, { color: isActive ? 'white' : '#9CA3AF' }]}>›</Text>
         )}
       </TouchableOpacity>
     );
@@ -126,7 +120,7 @@ export const ClueList: React.FC<ClueListProps> = ({
             end={{ x: 1, y: 1 }}
             style={styles.scanButtonGradient}
           >
-            <Camera width={20} height={20} color="white" />
+            <Text style={styles.scanIcon}>◉</Text>
             <Text style={styles.scanButtonText}>Scan QR</Text>
           </LinearGradient>
         </TouchableOpacity>
@@ -178,6 +172,11 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 14,
     fontWeight: '600',
+  },
+  scanIcon: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '700',
   },
   listContent: {
     paddingHorizontal: 12,
@@ -267,5 +266,10 @@ const styles = StyleSheet.create({
   },
   chevron: {
     marginLeft: 8,
+  },
+  chevronText: {
+    marginLeft: 8,
+    fontSize: 20,
+    fontWeight: '700',
   },
 });

--- a/mobile/components/GameMapScreen.tsx
+++ b/mobile/components/GameMapScreen.tsx
@@ -4,7 +4,7 @@ import MapView, { Circle, Marker, PROVIDER_DEFAULT } from 'react-native-maps';
 import { useTheme } from '@providers/ThemeProvider';
 import { ThemedCustomText } from '@components/themed';
 import { usePlayerLocation } from '@app/hooks/usePlayerLocation';
-import { buildClueZones, zoneColor, type ClueZone } from '@lib/clueZones';
+import { buildClueZones, zoneColor, type ClueZone } from '@/lib/clueZones';
 import { getAllHunts } from '@store/huntStore';
 import type { StoredHunt } from '@lib/types';
 

--- a/mobile/components/QRScanner.tsx
+++ b/mobile/components/QRScanner.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { StyleSheet, View, Text, TouchableOpacity, Dimensions, ActivityIndicator } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import { X } from 'lucide-react-native';
 import { useTheme } from '@react-navigation/native';
 
 interface QRScannerProps {
@@ -69,7 +68,7 @@ export const QRScanner: React.FC<QRScannerProps> = ({
             style={styles.closeButton}
             onPress={onClose}
           >
-            <X width={24} height={24} color={colors.text} />
+            <Text style={[styles.closeButtonText, { color: colors.text }]}>×</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -93,7 +92,7 @@ export const QRScanner: React.FC<QRScannerProps> = ({
             style={styles.closeButton}
             onPress={onClose}
           >
-            <X width={24} height={24} color={colors.text} />
+            <Text style={[styles.closeButtonText, { color: colors.text }]}>×</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -146,7 +145,7 @@ export const QRScanner: React.FC<QRScannerProps> = ({
           style={styles.headerCloseButton}
           onPress={onClose}
         >
-          <X width={28} height={28} color="white" />
+          <Text style={styles.headerCloseText}>×</Text>
         </TouchableOpacity>
       </View>
 
@@ -299,6 +298,17 @@ const styles = StyleSheet.create({
     padding: 12,
     backgroundColor: 'rgba(0, 0, 0, 0.3)',
     borderRadius: 50,
+  },
+  closeButtonText: {
+    fontSize: 24,
+    fontWeight: '700',
+    lineHeight: 24,
+  },
+  headerCloseText: {
+    color: 'white',
+    fontSize: 28,
+    fontWeight: '700',
+    lineHeight: 28,
   },
   loadingIndicator: {
     ...StyleSheet.absoluteFillObject,

--- a/mobile/components/navigation/StackHeader.tsx
+++ b/mobile/components/navigation/StackHeader.tsx
@@ -6,7 +6,7 @@ import { ThemedCustomText } from '@components/themed';
 
 interface HeaderRenderArgs {
   tintColor?: string;
-  canGoBack?: boolean;
+  canGoBack: boolean;
 }
 
 interface StackHeaderProps {
@@ -16,7 +16,7 @@ interface StackHeaderProps {
   };
   options: {
     title?: string;
-    headerTitle?: string | ((props: unknown) => React.ReactNode);
+    headerTitle?: string | ((props: any) => React.ReactNode);
     headerTintColor?: string;
     headerRight?: (props: HeaderRenderArgs) => React.ReactNode;
   };

--- a/mobile/components/themed/ThemedButton.tsx
+++ b/mobile/components/themed/ThemedButton.tsx
@@ -7,7 +7,7 @@ import {
   PressableProps,
   ActivityIndicator,
 } from 'react-native';
-import { useTheme } from '../providers/ThemeProvider';
+import { useTheme } from '../../providers/ThemeProvider';
 import { ThemedCustomText } from './ThemedCustomText';
 
 type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'success' | 'ghost';
@@ -114,7 +114,7 @@ export const ThemedButton: React.FC<ThemedButtonProps> = ({
       style={[
         containerStyle,
         pressed && !disabled && { opacity: 0.8 },
-        Array.isArray(style) ? StyleSheet.flatten(style) : style,
+        Array.isArray(style) ? StyleSheet.flatten(style as any) : (style as any),
       ]}
       {...otherProps}
     >

--- a/mobile/components/themed/ThemedCustomText.tsx
+++ b/mobile/components/themed/ThemedCustomText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, TextProps, StyleSheet } from 'react-native';
-import { useTheme } from '../providers/ThemeProvider';
+import { useTheme } from '../../providers/ThemeProvider';
 
 type TextVariant = 'h1' | 'h2' | 'h3' | 'body' | 'caption' | 'label';
 type TextColor = 'text' | 'primary' | 'secondary' | 'error' | 'success' | 'warning' | 'info';

--- a/mobile/components/themed/ThemedInput.tsx
+++ b/mobile/components/themed/ThemedInput.tsx
@@ -8,7 +8,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-import { useTheme } from '../providers/ThemeProvider';
+import { useTheme } from '../../providers/ThemeProvider';
 import { normalizeFont, MAX_FONT_SCALE } from '../../config/fontScaling';
 import { ThemedCustomText } from './ThemedCustomText';
 

--- a/mobile/components/themed/ThemedView.tsx
+++ b/mobile/components/themed/ThemedView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, ViewProps, StyleSheet } from 'react-native';
-import { useTheme } from '../providers/ThemeProvider';
+import { useTheme } from '../../providers/ThemeProvider';
 
 interface ThemedViewProps extends ViewProps {
   lightColor?: string;

--- a/mobile/config/env.ts
+++ b/mobile/config/env.ts
@@ -2,70 +2,33 @@ type AppEnv = 'development' | 'preview' | 'production';
 
 const APP_ENV = (process.env.APP_ENV ?? (__DEV__ ? 'development' : 'production')) as AppEnv;
 
-const ENV: Record<AppEnv, { apiUrl: string; stellarRpcUrl: string; stellarNetwork: string }> = {
+const ENV: Record<
+  AppEnv,
+  { apiUrl: string; graphqlUrl: string; stellarRpcUrl: string; stellarNetwork: string }
+> = {
   development: {
     apiUrl: process.env.EXPO_PUBLIC_API_BASE_URL_DEVELOPMENT ?? 'http://localhost:3000/api',
+    graphqlUrl: process.env.EXPO_PUBLIC_GRAPHQL_URL_DEVELOPMENT ?? 'http://localhost:4000/graphql',
     stellarRpcUrl: process.env.EXPO_PUBLIC_STELLAR_RPC_URL_DEVELOPMENT ?? 'https://soroban-testnet.stellar.org',
     stellarNetwork: process.env.EXPO_PUBLIC_STELLAR_NETWORK_DEVELOPMENT ?? 'testnet',
   },
   preview: {
     apiUrl: process.env.EXPO_PUBLIC_API_BASE_URL_PREVIEW ?? 'https://staging-api.hunty.app',
+    graphqlUrl: process.env.EXPO_PUBLIC_GRAPHQL_URL_PREVIEW ?? 'https://staging-indexer.hunty.app/graphql',
     stellarRpcUrl: process.env.EXPO_PUBLIC_STELLAR_RPC_URL_PREVIEW ?? 'https://soroban-testnet.stellar.org',
     stellarNetwork: process.env.EXPO_PUBLIC_STELLAR_NETWORK_PREVIEW ?? 'testnet',
   },
   production: {
     apiUrl: process.env.EXPO_PUBLIC_API_BASE_URL_PRODUCTION ?? 'https://api.hunty.app',
+    graphqlUrl: process.env.EXPO_PUBLIC_GRAPHQL_URL_PRODUCTION ?? 'https://indexer.hunty.app/graphql',
     stellarRpcUrl: process.env.EXPO_PUBLIC_STELLAR_RPC_URL_PRODUCTION ?? 'https://soroban-mainnet.stellar.org',
     stellarNetwork: process.env.EXPO_PUBLIC_STELLAR_NETWORK_PRODUCTION ?? 'mainnet',
   },
 };
 
-export default {
+const env = {
   ...ENV[APP_ENV],
   environment: APP_ENV,
-const ENV = {
-  dev: {
-    apiUrl: 'http://localhost:3000/api',
-    graphqlUrl: 'http://localhost:4000/graphql',
-    stellarRpcUrl: 'https://soroban-testnet.stellar.org',
-    stellarNetwork: 'testnet',
-  },
-  staging: {
-    apiUrl: 'https://staging-api.hunty.app',
-    graphqlUrl: 'https://staging-indexer.hunty.app/graphql',
-    stellarRpcUrl: 'https://soroban-testnet.stellar.org',
-    stellarNetwork: 'testnet',
-  },
-  prod: {
-    apiUrl: 'https://api.hunty.app',
-    graphqlUrl: 'https://indexer.hunty.app/graphql',
-    stellarRpcUrl: 'https://soroban-mainnet.stellar.org',
-    stellarNetwork: 'mainnet',
-  },
 };
 
-const getEnvVars = () => {
-  // Use the Expo-specific environment variables
-  const apiUrl = process.env.EXPO_PUBLIC_API_BASE_URL_PRODUCTION || process.env.EXPO_PUBLIC_API_BASE_URL_DEVELOPMENT;
-  const graphqlUrl = process.env.EXPO_PUBLIC_GRAPHQL_URL_PRODUCTION || process.env.EXPO_PUBLIC_GRAPHQL_URL_DEVELOPMENT;
-  const stellarRpcUrl = process.env.EXPO_PUBLIC_STELLAR_RPC_URL_PRODUCTION || process.env.EXPO_PUBLIC_STELLAR_RPC_URL_DEVELOPMENT;
-  const stellarNetwork = process.env.EXPO_PUBLIC_STELLAR_NETWORK_PRODUCTION || process.env.EXPO_PUBLIC_STELLAR_NETWORK_DEVELOPMENT;
-  const environment = process.env.EXPO_PUBLIC_ENVIRONMENT || 'development';
-
-  if (apiUrl && graphqlUrl && stellarRpcUrl && stellarNetwork) {
-    return {
-      apiUrl,
-      graphqlUrl,
-      stellarRpcUrl,
-      stellarNetwork,
-      environment,
-    };
-  }
-
-  // Fallback to environment-based config
-  const env = __DEV__ ? ENV.dev : ENV.prod;
-  return {
-    ...env,
-    environment: __DEV__ ? 'development' : 'production',
-  };
-};
+export default env;

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -8,47 +8,11 @@
       "developmentClient": true,
       "distribution": "internal",
       "channel": "development",
-      "env": {
-        "APP_ENV": "development"
-      },
-      "android": {
-        "gradleCommand": ":app:assembleDebug",
-        "buildType": "apk"
-      },
-      "ios": {
-        "buildConfiguration": "Debug",
-        "simulator": false
-      }
-    },
-    "preview": {
-      "developmentClient": false,
-      "distribution": "internal",
-      "channel": "preview",
-      "env": {
-        "APP_ENV": "preview"
-      },
-      "android": {
-        "gradleCommand": ":app:assembleRelease",
-        "buildType": "apk"
-      },
-      "ios": {
-        "buildConfiguration": "Release"
-      }
-    },
-    "production": {
-      "developmentClient": false,
-      "distribution": "store",
-      "channel": "production",
-      "env": {
-        "APP_ENV": "production"
-      },
-      "android": {
-        "buildType": "app-bundle"
-      },
-      "ios": {
-        "buildConfiguration": "Release"
       "ios": {
         "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
       },
       "env": {
         "APP_VARIANT": "development"
@@ -56,6 +20,7 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "ios": {
         "simulator": false
       },
@@ -68,26 +33,17 @@
     },
     "production": {
       "distribution": "store",
+      "channel": "production",
       "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      },
       "env": {
         "APP_VARIANT": "production"
       }
     }
   },
   "submit": {
-    "production": {
-      "android": {
-        "serviceAccountKeyPath": "./google-service-account.json",
-        "track": "internal"
-      },
-      "ios": {
-        "appleId": "you@email.com",
-        "ascAppId": "YOUR_APP_STORE_CONNECT_APP_ID",
-        "appleTeamId": "YOUR_APPLE_TEAM_ID"
-      }
-    }
-  }
-}
     "preview": {
       "ios": {
         "appleId": "${EXPO_APPLE_ID}",

--- a/mobile/hooks/useRefreshByUser.ts
+++ b/mobile/hooks/useRefreshByUser.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from 'react';
+
+export function useRefreshByUser(refetch: () => Promise<unknown>) {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const onRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      await refetch();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [refetch]);
+
+  return {
+    isRefreshing,
+    onRefresh,
+  };
+}

--- a/mobile/lib/graphql/client.ts
+++ b/mobile/lib/graphql/client.ts
@@ -1,4 +1,4 @@
-import getEnvVars from '@config/env';
+import env from '@config/env';
 
 export interface GraphQLResponse<T> {
   data?: T;
@@ -9,7 +9,7 @@ export async function graphqlRequest<T>(
   query: string,
   variables?: Record<string, unknown>,
 ): Promise<T> {
-  const { graphqlUrl } = getEnvVars();
+  const { graphqlUrl } = env;
 
   const response = await fetch(graphqlUrl, {
     method: 'POST',

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -11,25 +11,35 @@
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@tanstack/react-query": "^5.100.5",
         "expo": "~54.0.33",
+        "expo-camera": "^56.0.7",
         "expo-constants": "~18.0.13",
+        "expo-dev-client": "~6.0.21",
         "expo-file-system": "~19.0.22",
         "expo-font": "~13.0.1",
+        "expo-haptics": "^56.0.3",
+        "expo-image": "~2.4.1",
+        "expo-linear-gradient": "~15.0.7",
         "expo-linking": "~8.0.12",
         "expo-location": "^18.1.5",
         "expo-router": "~6.0.23",
         "expo-secure-store": "^55.0.13",
         "expo-splash-screen": "~0.30.3",
         "expo-status-bar": "~3.0.9",
+        "lucide-react-native": "^0.372.0",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-gesture-handler": "^2.20.2",
         "react-native-maps": "^1.20.1",
+        "react-native-reanimated": "~3.16.7",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.16.0",
         "sentry-expo": "^7.2.0",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
-        "babel-plugin-module-resolver": "^5.0.0"
+        "@types/react": "~19.1.17",
+        "babel-plugin-module-resolver": "^5.0.0",
+        "typescript": "~5.9.3"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -1415,6 +1425,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
@@ -1602,6 +1627,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@expo/cli": {
@@ -4282,6 +4319,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -4296,6 +4339,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -4328,6 +4377,24 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4433,6 +4500,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/anser": {
@@ -4796,6 +4879,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/barcode-detector": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.1.3.tgz",
+      "integrity": "sha512-omL3/x26oU9jlR0gUQcGdXIjQtMlrUGKF7xRFO1RwrQkRkRU7WLz0mgQEsdUtYBm2uX3JH+HQLrKlyTS/BxZRw==",
+      "license": "MIT",
+      "dependencies": {
+        "zxing-wasm": "3.0.3"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5341,6 +5433,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5652,6 +5750,26 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-camera": {
+      "version": "56.0.7",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-56.0.7.tgz",
+      "integrity": "sha512-c8z+UheidFintQyP9XLEDP43aK4PS/o9+TFLW0zEOjdqkYCBgoWq6Mw/Ps62kjBeftFY7xrp5ZLITbenNvbTaw==",
+      "license": "MIT",
+      "dependencies": {
+        "barcode-detector": "^3.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-constants": {
       "version": "18.0.13",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
@@ -5664,6 +5782,57 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-client": {
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-6.0.21.tgz",
+      "integrity": "sha512-SWI6HD0pa4eJujkYFkvvpezUE1zmJXGLu+34azpu7+QJgO+FLutDYDj8BSTdeH/NYDEClDFjCGqVMcWETvmsCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "6.0.21",
+        "expo-dev-menu": "7.0.19",
+        "expo-dev-menu-interface": "2.0.0",
+        "expo-manifests": "~1.0.11",
+        "expo-updates-interface": "~2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-6.0.21.tgz",
+      "integrity": "sha512-QZ9gcKMZbp6EsIhzS0QoGB8Cf4xeVJhjbNgWUwcoBIk8gshoFz8CkCQOnX+HNv2sSY3rdCaNpx3Xo0Rflyq7rA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "expo-dev-menu": "7.0.19",
+        "expo-manifests": "~1.0.11"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-7.0.19.tgz",
+      "integrity": "sha512-ju5MZiBCPhUKKvHy0ElZdnlhq01mkEEiR8jfrgQVvW26aWjzjLiOhppNAyXtvGbhk7WxJim3wYMiqFFrjGdfKA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
+      "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {
@@ -5689,6 +5858,38 @@
         "react": "*"
       }
     },
+    "node_modules/expo-haptics": {
+      "version": "56.0.3",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-56.0.3.tgz",
+      "integrity": "sha512-ycoahZJnR9tWAVh/0mJYxbETtHRYaWjiWS8cHlP6aDGU6Q6Y8rZ5NKsuBwWw6HR2Pe30mfVFgbF2HrBR6gtYmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.4.1.tgz",
+      "integrity": "sha512-yHp0Cy4ylOYyLR21CcH6i70DeRyLRPc0yAIPFPn4BT/BpkJNaX5QMXDppcHa58t4WI3Bb8QRJRLuAQaeCtDF8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
@@ -5697,6 +5898,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {
@@ -5718,6 +5930,19 @@
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.1.5.tgz",
       "integrity": "sha512-/ugxS4Ort9DbKD0Do6xn4TjeHaA/by5vv0p0PrY5Zbcez1S0AfrQn/4JG/8PLT2imngMwZU9TDKrgxqJQ4RuPQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.11.tgz",
+      "integrity": "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "expo-json-utils": "~0.15.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -6049,6 +6274,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo/node_modules/expo-font": {
       "version": "14.0.11",
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
@@ -6080,6 +6314,22 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6916,6 +7166,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7381,6 +7637,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react-native": {
+      "version": "0.372.0",
+      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-0.372.0.tgz",
+      "integrity": "sha512-e70/jdOsu5RAkdkhtGw8I6euJR0V6iTNuyw1qk5V2WLgu95LVSmkjiWhl+brf+RggtgdPsOgGG1+HVAtrYUr5g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0",
+        "react-native": "*",
+        "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/makeerror": {
@@ -8720,6 +8987,22 @@
         }
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.31.2.tgz",
+      "integrity": "sha512-rw5q74i2AfS7YGYdbxQDhOU7xqgY6WRM1132/CCm3erqjblhECZDZFHIm0tteHoC9ih24wogVBVVzcTBQtZ+5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "@types/react-test-renderer": "^19.1.0",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
@@ -8750,6 +9033,30 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "3.16.7",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.16.7.tgz",
+      "integrity": "sha512-qoUUQOwE1pHlmQ9cXTJ2MX9FQ9eHllopCLiWOkDkp6CER95ZWeXhJCP4cSm6AD4jigL5jHcZf/SkWrg8ttZUsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -9719,6 +10026,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.15",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
@@ -9963,6 +10282,20 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {
@@ -10517,6 +10850,34 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.0.3.tgz",
+      "integrity": "sha512-DdOn/G5F+qvZELWeO5ZFFwcN611TfMybxPV0LUUoutUmiH2t47MZSB7gLV9O9YLhvudBdnzQNAoFOu4Xz8eOrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.6.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
+    },
+    "node_modules/zxing-wasm/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.0.0",
-    "@react-native-gesture-handler/core": "^2.20.0",
     "@tanstack/react-query": "^5.100.5",
     "expo": "~54.0.33",
     "expo-camera": "^56.0.7",
@@ -19,7 +18,7 @@
     "expo-dev-client": "~6.0.21",
     "expo-file-system": "~19.0.22",
     "expo-font": "~13.0.1",
-    "expo-linear-gradient": "^15.2.0",
+    "expo-linear-gradient": "~15.0.7",
     "expo-image": "~2.4.1",
     "expo-haptics": "^56.0.3",
     "expo-linking": "~8.0.12",

--- a/mobile/providers/ReactQueryProvider.tsx
+++ b/mobile/providers/ReactQueryProvider.tsx
@@ -8,7 +8,6 @@ export default function ReactQueryProvider({ children }: { children: ReactNode }
         defaultOptions: {
           queries: {
             staleTime: 5 * 60 * 1000,
-            cacheTime: 5 * 60 * 1000,
             gcTime: 10 * 60 * 1000,
             refetchOnWindowFocus: false,
             refetchOnReconnect: false,

--- a/mobile/providers/ThemeProvider.tsx
+++ b/mobile/providers/ThemeProvider.tsx
@@ -1,8 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useColorScheme } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useMountedRef } from '../hooks/useMountedRef';
-import { registerDiagnostic, unregisterDiagnostic } from '../lib/memoryDiagnostics';
 
 export type Theme = 'light' | 'dark';
 
@@ -56,26 +54,10 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [theme, setTheme] = useState<Theme>(systemColorScheme === 'dark' ? 'dark' : 'light');
   const [mounted, setMounted] = useState(false);
 
-  const mountedRef = useMountedRef();
-
   useEffect(() => {
-    registerDiagnostic('ThemeProviderAsyncLoad');
-    let active = true;
-
     const loadTheme = async () => {
       try {
         const savedTheme = await AsyncStorage.getItem('theme');
-        if (!mountedRef.current) {
-          return;
-        }
-    let isMounted = true;
-
-    // Load saved theme preference
-    const loadTheme = async () => {
-      try {
-        const savedTheme = await AsyncStorage.getItem('theme');
-        if (!isMounted) return;
-
         if (savedTheme) {
           setTheme(savedTheme as Theme);
         } else if (systemColorScheme) {
@@ -86,28 +68,14 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           console.warn('Failed to load theme preference:', error);
         }
       } finally {
-        if (active && mountedRef.current) {
-        if (isMounted) {
-          console.warn('Failed to load theme preference:', error);
-        }
-      } finally {
-        if (isMounted) {
-          setMounted(true);
-        }
+        setMounted(true);
       }
     };
 
     void loadTheme();
 
     return () => {
-      active = false;
-      unregisterDiagnostic('ThemeProviderAsyncLoad');
-    };
-  }, [systemColorScheme, mountedRef]);
-    loadTheme();
-
-    return () => {
-      isMounted = false;
+      setMounted(true);
     };
   }, [systemColorScheme]);
 

--- a/mobile/services/huntsApi.ts
+++ b/mobile/services/huntsApi.ts
@@ -1,5 +1,5 @@
 import type { StoredHunt } from '@lib/types';
-import { fetchActiveHuntsFromIndexer, fetchHuntByIdFromIndexer } from '@lib/graphql/hunts';
+import { fetchActiveHuntsFromIndexer, fetchHuntByIdFromIndexer } from '@/lib/graphql/hunts';
 import { getActiveHuntsForFeed, getHuntById } from '@store/huntStore';
 
 /**

--- a/mobile/store/huntStore.ts
+++ b/mobile/store/huntStore.ts
@@ -1,401 +1,233 @@
-/**
- * Shared hunt list for dashboard (creator hunts) and Game Arcade (active hunts).
- * Persisted in SecureStore for mobile.
- */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import type { Clue, HuntStatus, StoredHunt } from '@lib/types';
 
-import type { HuntStatus, StoredHunt, Clue } from "@lib/types";
-import * as SecureStore from "expo-secure-store";
-import AsyncStorage from "@react-native-async-storage/async-storage";
+const HUNTS_KEY = 'hunty_hunts';
+const CLUES_KEY = 'hunty_clues';
 
-const STORAGE_KEY = "hunty_hunts";
-const CLUES_KEY = "hunty_clues";
-
-// Seed timestamps: active hunts end 7 days from first load, completed hunts in the past.
-const NOW_SECONDS = Math.floor(Date.now() / 1000);
+const now = Math.floor(Date.now() / 1000);
 
 const SEED_HUNTS: StoredHunt[] = [
   {
     id: 1,
-    title: "City Secrets",
-    description: "Race across town to uncover hidden murals and landmarks.",
+    title: 'City Secrets',
+    description: 'Race across town to uncover hidden murals and landmarks with your squad.',
     cluesCount: 5,
-    status: "Active",
-    rewardType: "XLM",
-    startTime: NOW_SECONDS - 86400,
-    endTime: NOW_SECONDS + 7 * 86400,
-    coverImageCid: "bafybeigdyrzt5sfp7udm7hmhd3km4gq6v2y24sqqew2qnp4o3k4xcoq2a",
+    status: 'Active',
+    rewardType: 'Both',
+    startTime: now - 86_400,
+    endTime: now + 5 * 86_400,
+    coverImageCid: 'bafybeigdyrzt5sfp7udm7hmhd3km4gq6v2y24sqqew2qnp4o3k4xcoq2a',
   },
   {
     id: 2,
-    title: "Campus Quest",
-    description: "Solve riddles scattered around campus before the timer ends.",
+    title: 'Campus Quest',
+    description: 'Decode hidden clues across campus and unlock a limited student reward.',
     cluesCount: 7,
-    status: "Active",
-    rewardType: "NFT",
-    startTime: NOW_SECONDS - 2 * 86400,
-    endTime: NOW_SECONDS + 3 * 86400,
-    coverImageCid: "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+    status: 'Active',
+    rewardType: 'NFT',
+    startTime: now - 2 * 86_400,
+    endTime: now + 3 * 86_400,
+    coverImageCid: 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
   },
   {
     id: 3,
-    title: "Office Onboarding Hunt",
-    description: "A playful intro game for new teammates around the office.",
+    title: 'Soroban Sprint',
+    description: 'A fast downtown hunt with a pure XLM prize pool.',
     cluesCount: 4,
-    status: "Completed",
-    rewardType: "Both",
-    startTime: NOW_SECONDS - 10 * 86400,
-    endTime: NOW_SECONDS - 5 * 86400,
+    status: 'Active',
+    rewardType: 'XLM',
+    startTime: now - 3 * 86_400,
+    endTime: now + 2 * 86_400,
   },
   {
     id: 4,
-    title: "Summer Treasure Hunt",
-    description: "Find hidden clues in the park.",
+    title: 'Museum Mystery',
+    description: 'A private curator preview hunt awaiting activation.',
     cluesCount: 3,
-    status: "Draft",
-    rewardType: "XLM",
-  },
-  {
-    id: 5,
-    title: "Museum Mystery",
-    description: "Discover art and history through clues.",
-    cluesCount: 0,
-    status: "Draft",
-    rewardType: "NFT",
+    status: 'Draft',
+    rewardType: 'NFT',
+    is_private: true,
   },
 ];
 
 const SEED_CLUES: Clue[] = [
-  {
-    id: 1,
-    huntId: 1,
-    question: 'What landmark has a spiral mural at the east gate?',
-    answer: 'Spiral mural',
-    points: 10,
-    hint: 'Look for painted stairs.',
-  },
-  {
-    id: 2,
-    huntId: 1,
-    question: 'Which statue holds a lantern in the north plaza?',
-    answer: 'Lantern statue',
-    points: 10,
-    hint: 'It shines in the night.',
-  },
-  {
-    id: 3,
-    huntId: 1,
-    question: 'Name the coffee shop that shares a wall with the old clock tower.',
-    answer: 'Clocktower Cafe',
-    points: 10,
-  },
-  {
-    id: 4,
-    huntId: 1,
-    question: 'What color is the hidden door behind the bicycle racks?',
-    answer: 'Blue',
-    points: 10,
-  },
-  {
-    id: 5,
-    huntId: 1,
-    question: 'Which alley features the painted fox mural?',
-    answer: 'Fox Alley',
-    points: 10,
-  },
-  {
-    id: 6,
-    huntId: 2,
-    question: 'What building has the golden dome at the center of campus?',
-    answer: 'Golden Dome',
-    points: 8,
-  },
-  {
-    id: 7,
-    huntId: 2,
-    question: 'Which library wing is open 24/7?',
-    answer: 'North Wing',
-    points: 8,
-  },
-  {
-    id: 8,
-    huntId: 2,
-    question: 'What landmark is beside the rose garden?',
-    answer: 'Sculpture fountain',
-    points: 8,
-  },
-  {
-    id: 9,
-    huntId: 2,
-    question: 'What is the name of the student center cafe?',
-    answer: 'Campus Brew',
-    points: 8,
-  },
-  {
-    id: 10,
-    huntId: 2,
-    question: 'Which gate faces the river trail?',
-    answer: 'River Gate',
-    points: 8,
-  },
-  {
-    id: 11,
-    huntId: 2,
-    question: 'Which building holds the mural of a compass?',
-    answer: 'Compass Hall',
-    points: 8,
-  },
-  {
-    id: 12,
-    huntId: 2,
-    question: 'Name the famous bench under the oak tree.',
-    answer: 'Oak Bench',
-    points: 8,
-  },
+  { id: 1, huntId: 1, question: 'Which mural wraps around the east gate?', answer: 'spiral mural', points: 10, hint: 'Look for painted stairs.' },
+  { id: 2, huntId: 1, question: 'Which statue holds a lantern in the north plaza?', answer: 'lantern statue', points: 10, hint: 'It glows after sunset.' },
+  { id: 3, huntId: 1, question: 'Name the cafe beside the old clock tower.', answer: 'clocktower cafe', points: 12 },
+  { id: 4, huntId: 1, question: 'What color is the hidden service door by the racks?', answer: 'blue', points: 8 },
+  { id: 5, huntId: 1, question: 'Which alley hides the painted fox mural?', answer: 'fox alley', points: 15 },
+  { id: 6, huntId: 2, question: 'Which building has the golden dome?', answer: 'golden dome', points: 8, hint: 'Visible from the main quad.' },
+  { id: 7, huntId: 2, question: 'Which library wing stays open all night?', answer: 'north wing', points: 8 },
+  { id: 8, huntId: 2, question: 'What landmark sits beside the rose garden?', answer: 'sculpture fountain', points: 8 },
+  { id: 9, huntId: 2, question: 'What is the name of the student center cafe?', answer: 'campus brew', points: 8 },
+  { id: 10, huntId: 2, question: 'Which gate faces the river trail?', answer: 'river gate', points: 8 },
+  { id: 11, huntId: 2, question: 'Which building holds the compass mural?', answer: 'compass hall', points: 8 },
+  { id: 12, huntId: 2, question: 'What bench sits under the oldest oak?', answer: 'oak bench', points: 8 },
+  { id: 13, huntId: 3, question: 'Which neon sign marks the coder alley entrance?', answer: 'byte lane', points: 10 },
+  { id: 14, huntId: 3, question: 'What phrase is etched into the cyber archway?', answer: 'move fast', points: 10 },
+  { id: 15, huntId: 3, question: 'Which rooftop hosts the final beacon?', answer: 'sky deck', points: 20 },
+  { id: 16, huntId: 3, question: 'What is the vault passphrase painted on the drone pad?', answer: 'stellar', points: 30 },
 ];
 
-async function readClues(): Promise<Clue[]> {
+async function readJson<T>(key: string, fallback: T): Promise<T> {
   try {
-    const raw = await SecureStore.getItemAsync(CLUES_KEY);
-    if (!raw) return [...SEED_CLUES];
-    const parsed = JSON.parse(raw) as Clue[];
-    return Array.isArray(parsed) ? parsed : [...SEED_CLUES];
+    const value = await SecureStore.getItemAsync(key);
+    if (!value) {
+      return fallback;
+    }
+
+    return JSON.parse(value) as T;
   } catch {
-    return [...SEED_CLUES];
+    return fallback;
   }
 }
 
-async function writeClues(clues: Clue[]): Promise<void> {
+async function writeJson<T>(key: string, value: T): Promise<void> {
   try {
-    await SecureStore.setItemAsync(CLUES_KEY, JSON.stringify(clues));
+    await SecureStore.setItemAsync(key, JSON.stringify(value));
   } catch {
-    // ignore
+    // ignore persistence errors in demo mode
   }
 }
 
 async function readHunts(): Promise<StoredHunt[]> {
-  try {
-    const raw = await SecureStore.getItemAsync(STORAGE_KEY);
-    if (!raw) return [...SEED_HUNTS];
-    const parsed = JSON.parse(raw) as StoredHunt[];
-    return Array.isArray(parsed) ? parsed : [...SEED_HUNTS];
-  } catch {
-    return [...SEED_HUNTS];
-  }
+  return readJson(HUNTS_KEY, SEED_HUNTS);
+}
+
+async function readClues(): Promise<Clue[]> {
+  return readJson(CLUES_KEY, SEED_CLUES);
 }
 
 async function writeHunts(hunts: StoredHunt[]): Promise<void> {
+  await writeJson(HUNTS_KEY, hunts);
+}
+
+async function writeClues(clues: Clue[]): Promise<void> {
+  await writeJson(CLUES_KEY, clues);
+}
+
+export async function cacheJoinedHuntClues(huntId: number, clues: Clue[]): Promise<void> {
   try {
-    await SecureStore.setItemAsync(STORAGE_KEY, JSON.stringify(hunts));
+    await AsyncStorage.setItem(`hunty_clues_hunt_${huntId}`, JSON.stringify(clues));
   } catch {
     // ignore
   }
 }
 
-/** Active hunts for feed (local fallback). */
-export async function getActiveHuntsForFeed(): Promise<StoredHunt[]> {
-  const hunts = await readHunts();
-  return hunts.filter((h) => h.status === "Active" && !h.is_private);
-}
-
-/** Get a single hunt by ID */
-export async function getHuntById(id: number): Promise<StoredHunt | undefined> {
-  const hunts = await readHunts();
-  return hunts.find((h) => h.id === id);
-/** Active hunts for feed with cover images. */
-export async function getActiveHuntsForFeed(): Promise<StoredHunt[]> {
-  const hunts = await readHunts();
-  return hunts.filter((h) => h.status === "Active" && !h.is_private);
-/** Cache clues for a joined hunt offline in AsyncStorage */
-export async function cacheJoinedHuntClues(huntId: number, clues: Clue[]): Promise<void> {
-  try {
-    await AsyncStorage.setItem(`hunty_clues_hunt_${huntId}`, JSON.stringify(clues));
-  } catch (error) {
-    console.error(`Failed to cache clues for hunt ${huntId} offline:`, error);
-  }
-}
-
-/** Get offline cached clues for a hunt from AsyncStorage */
 export async function getOfflineCachedClues(huntId: number): Promise<Clue[]> {
   try {
-    const raw = await AsyncStorage.getItem(`hunty_clues_hunt_${huntId}`);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as Clue[];
-    return Array.isArray(parsed) ? parsed : [];
+    const value = await AsyncStorage.getItem(`hunty_clues_hunt_${huntId}`);
+    return value ? (JSON.parse(value) as Clue[]) : [];
   } catch {
     return [];
   }
 }
 
-/** All hunts (for Game Arcade: filter by status === "Active"). Private hunts are excluded. */
+export async function getActiveHuntsForFeed(): Promise<StoredHunt[]> {
+  const hunts = await readHunts();
+  return hunts.filter((hunt) => hunt.status === 'Active' && !hunt.is_private);
+}
+
 export async function getAllHunts(): Promise<StoredHunt[]> {
-  return (await readHunts()).filter((h) => !h.is_private);
   const hunts = await readHunts();
-  return hunts.filter((h) => !h.is_private);
+  return hunts.filter((hunt) => !hunt.is_private);
 }
 
-/** All hunts including private ones (for creator dashboard). */
 export async function getAllHuntsIncludingPrivate(): Promise<StoredHunt[]> {
-  return await readHunts();
+  return readHunts();
 }
 
-/** Creator hunts for dashboard (all stored hunts including private; creator filter can be added later). */
 export async function getCreatorHunts(): Promise<StoredHunt[]> {
-  return await readHunts();
+  return readHunts();
 }
 
-/** Get hunts for a creator (creator public-key filter not implemented yet; returns all hunts). */
 export async function getHuntsByCreator(): Promise<StoredHunt[]> {
-  return await readHunts();
+  return readHunts();
 }
 
-/** Update a hunt's status (e.g. Draft → Active after activate_hunt). */
-export async function updateHuntStatus(huntId: number, status: HuntStatus): Promise<void> {
-  const hunts = (await readHunts()).map((h) => (h.id === huntId ? { ...h, status } : h));
-  await writeHunts(hunts);
-  const hunts = await readHunts();
-  const updated = hunts.map((h) => (h.id === huntId ? { ...h, status } : h));
-  await writeHunts(updated);
-}
-
-/** Delete multiple hunts by IDs. */
-export async function deleteHunts(ids: number[]): Promise<void> {
-  const hunts = (await readHunts()).filter((h) => !ids.includes(h.id));
-  await writeHunts(hunts);
-  const hunts = await readHunts();
-  const remainingHunts = hunts.filter((h) => !ids.includes(h.id));
-  await writeHunts(remainingHunts);
-  
-  // Also clean up clues for these hunts
-  const allClues = await readClues();
-  const remainingClues = allClues.filter((c) => !ids.includes(c.huntId));
-  await writeClues(remainingClues);
-
-  // Clean up offline cached clues from AsyncStorage
-  for (const id of ids) {
-    try {
-      await AsyncStorage.removeItem(`hunty_clues_hunt_${id}`);
-    } catch {
-      // ignore
-    }
-  }
-}
-
-/** Archive (Cancel) multiple hunts by IDs. */
-export async function archiveHunts(ids: number[]): Promise<void> {
-  const hunts = (await readHunts()).map((h) =>
-    ids.includes(h.id) ? { ...h, status: 'Cancelled' as HuntStatus } : h
-  );
-  await writeHunts(hunts);
-  const hunts = await readHunts();
-  const updated = hunts.map((h) => 
-    ids.includes(h.id) ? { ...h, status: "Cancelled" as HuntStatus } : h
-  );
-  await writeHunts(updated);
-}
-
-/** Get a single hunt by ID */
 export async function getHuntById(id: number): Promise<StoredHunt | undefined> {
-  return (await readHunts()).find((h) => h.id === id);
   const hunts = await readHunts();
-  return hunts.find((h) => h.id === id);
+  return hunts.find((hunt) => hunt.id === id);
 }
 
-/** Add a new hunt (e.g. after createHunt). */
+export async function getHunt(id: string): Promise<StoredHunt | undefined> {
+  return getHuntById(Number(id));
+}
+
+export async function getHuntClues(huntId: number): Promise<Clue[]> {
+  const clues = (await readClues()).filter((clue) => clue.huntId === huntId);
+  if (clues.length > 0) {
+    await cacheJoinedHuntClues(huntId, clues);
+    return clues;
+  }
+
+  return getOfflineCachedClues(huntId);
+}
+
 export async function addHunt(hunt: StoredHunt): Promise<void> {
   const hunts = await readHunts();
-  if (hunts.some((h) => h.id === hunt.id)) return;
+  if (hunts.some((existingHunt) => existingHunt.id === hunt.id)) {
+    return;
+  }
+
   await writeHunts([...hunts, hunt]);
 }
 
-/** Get all clues for a specific hunt. */
-export async function getHuntClues(huntId: number): Promise<Clue[]> {
-  return (await readClues()).filter((c) => c.huntId === huntId);
-}
-
-/** Persist a new clue locally and increment the hunt's cluesCount. */
 export async function saveClueLocally(clue: Omit<Clue, 'id'>): Promise<void> {
-  const all = await readClues();
-  const newId = all.length > 0 ? Math.max(...all.map((c) => c.id)) + 1 : 1;
-  await writeClues([...all, { ...clue, id: newId }]);
-  const hunts = (await readHunts()).map((h) =>
-    h.id === clue.huntId ? { ...h, cluesCount: h.cluesCount + 1 } : h
-  );
-  await writeHunts(hunts);
-}
+  const clues = await readClues();
+  const nextId = clues.length === 0 ? 1 : Math.max(...clues.map((item) => item.id)) + 1;
+  const savedClue: Clue = { ...clue, id: nextId };
 
-/** Get a single hunt by string ID */
-export const getHunt = async (id: string): Promise<StoredHunt | undefined> => {
-  return (await readHunts()).find((c) => c.id === Number(id));
-};
-/** Get all clues for a specific hunt with an offline cache fallback */
-export async function getHuntClues(huntId: number): Promise<Clue[]> {
-  // First attempt: read from the primary clues store
-  const allClues = await readClues();
-  const filtered = allClues.filter((c) => c.huntId === huntId);
-  
-  if (filtered.length > 0) {
-    // Optimistically update the offline cache in case it changed
-    await cacheJoinedHuntClues(huntId, filtered);
-    return filtered;
-  }
-  
-  // Fallback: if no clues in primary store (e.g., offline or cleared), read from the offline cache
-  return await getOfflineCachedClues(huntId);
-}
+  await writeClues([...clues, savedClue]);
+  await cacheJoinedHuntClues(clue.huntId, [...clues.filter((item) => item.huntId === clue.huntId), savedClue]);
 
-/** Persist a new clue locally, increment the hunt's cluesCount, and update the offline cache. */
-export async function saveClueLocally(clue: Omit<Clue, "id">): Promise<void> {
-  const all = await readClues();
-  const newId = all.length > 0 ? Math.max(...all.map((c) => c.id)) + 1 : 1;
-  const newClue: Clue = { ...clue, id: newId };
-  const updatedClues = [...all, newClue];
-  await writeClues(updatedClues);
-  
   const hunts = await readHunts();
-  const updatedHunts = hunts.map((h) =>
-    h.id === clue.huntId ? { ...h, cluesCount: h.cluesCount + 1 } : h
+  const updatedHunts = hunts.map((hunt) =>
+    hunt.id === clue.huntId ? { ...hunt, cluesCount: hunt.cluesCount + 1 } : hunt,
   );
   await writeHunts(updatedHunts);
-
-  // Update the offline cache for this hunt
-  const huntClues = updatedClues.filter((c) => c.huntId === clue.huntId);
-  await cacheJoinedHuntClues(clue.huntId, huntClues);
 }
 
-/** Get a single hunt by string ID */
-export async function getHunt(id: string): Promise<StoredHunt | undefined> {
+export async function updateHuntStatus(huntId: number, status: HuntStatus): Promise<void> {
   const hunts = await readHunts();
-  return hunts.find((c) => c.id === Number(id));
+  await writeHunts(hunts.map((hunt) => (hunt.id === huntId ? { ...hunt, status } : hunt)));
 }
 
-/**
- * Return up to `limit` featured hunts, ranked by a trending score.
- * Score factors: clue count, reward type variety, time remaining, recency.
- */
+export async function archiveHunts(ids: number[]): Promise<void> {
+  const hunts = await readHunts();
+  await writeHunts(
+    hunts.map((hunt) =>
+      ids.includes(hunt.id) ? { ...hunt, status: 'Cancelled' as HuntStatus } : hunt,
+    ),
+  );
+}
+
+export async function deleteHunts(ids: number[]): Promise<void> {
+  const hunts = await readHunts();
+  const clues = await readClues();
+
+  await writeHunts(hunts.filter((hunt) => !ids.includes(hunt.id)));
+  await writeClues(clues.filter((clue) => !ids.includes(clue.huntId)));
+
+  await Promise.all(
+    ids.map(async (id) => {
+      try {
+        await AsyncStorage.removeItem(`hunty_clues_hunt_${id}`);
+      } catch {
+        // ignore
+      }
+    }),
+  );
+}
+
 export async function getFeaturedHunts(limit = 3): Promise<StoredHunt[]> {
-  const now = Math.floor(Date.now() / 1000);
-  const active = (await readHunts()).filter((h) => h.status === 'Active' && !h.is_private);
-  const hunts = await readHunts();
-  const active = hunts.filter((h) => h.status === "Active" && !h.is_private);
-
-  const scored = active.map((hunt) => {
-    let score = 0;
-    score += hunt.cluesCount * 10;
-    if (hunt.rewardType === 'Both') score += 20;
-    else if (hunt.rewardType === 'NFT') score += 10;
-    if (hunt.endTime) {
-      const hoursLeft = (hunt.endTime - now) / 3600;
-      if (hoursLeft > 0 && hoursLeft < 48) score += 15;
-    }
-    if (hunt.startTime) {
-      const daysSinceStart = (now - hunt.startTime) / 86400;
-      if (daysSinceStart < 3) score += 10;
-    }
-    return { hunt, score };
-  });
-
-  return scored
-    .sort((a, b) => b.score - a.score)
-    .slice(0, limit)
-    .map((s) => s.hunt);
+  const activeHunts = await getActiveHuntsForFeed();
+  return [...activeHunts]
+    .sort((left, right) => {
+      const leftEnds = left.endTime ?? Number.MAX_SAFE_INTEGER;
+      const rightEnds = right.endTime ?? Number.MAX_SAFE_INTEGER;
+      return leftEnds - rightEnds || right.cluesCount - left.cluesCount;
+    })
+    .slice(0, limit);
 }

--- a/mobile/store/useStore.ts
+++ b/mobile/store/useStore.ts
@@ -61,9 +61,9 @@ export const useWalletStore = create<WalletState>()(
         removeItem: async (key: string) => {
           await SecureStore.deleteItemAsync(key);
         },
-      },
+      } as any,
       // Only persist the address — balance is fetched on demand
-      partialize: (state) => ({ walletAddress: state.walletAddress }),
+      partialize: (state) => ({ walletAddress: state.walletAddress } as any),
     },
   ),
 );
@@ -154,9 +154,9 @@ export const usePlayerStore = create<PlayerState>()(
           const converted = {
             ...parsed,
             completedClues: Object.fromEntries(
-              Object.entries(parsed.completedClues).map(([k, v]: [string, Set<number>]) => [
+              Object.entries(parsed.completedClues as Record<string, unknown>).map(([k, v]) => [
                 k,
-                Array.from(v),
+                Array.from((v as Set<number>) ?? []),
               ]),
             ),
           };
@@ -165,7 +165,7 @@ export const usePlayerStore = create<PlayerState>()(
         removeItem: async (key: string) => {
           await SecureStore.deleteItemAsync(key);
         },
-      },
+      } as any,
     },
   ),
 );

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "expo-router/tsconfig.base",
+  "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
     "baseUrl": ".",
@@ -8,8 +8,12 @@
       "@lib/*": ["../lib/*"],
       "@store/*": ["./store/*"],
       "@providers/*": ["./providers/*"],
-      "@components/*": ["./components/*"]
-      "@services/*": ["./services/*"]
+      "@components/*": ["./components/*"],
+      "@services/*": ["./services/*"],
+      "@hooks/*": ["./hooks/*"],
+      "@utils/*": ["./utils/*"],
+      "@config/*": ["./config/*"],
+      "@app/*": ["./app/*"]
     }
   }
 }

--- a/mobile/utils/splashScreenManager.ts
+++ b/mobile/utils/splashScreenManager.ts
@@ -29,9 +29,6 @@ export async function hideSplashScreen() {
  * Useful for authentication flows or critical loading states
  */
 export async function showSplashScreen() {
-  try {
-    await SplashScreen.showAsync();
-  } catch (e) {
-    console.warn(`Failed to show the splash screen: ${e}`);
-  }
+  // expo-splash-screen does not support showing the splash once hidden.
+  return Promise.resolve();
 }


### PR DESCRIPTION
## Summary
- build a dedicated hunt details screen route with full hunt context
- add explicit Hunt Lore section, Prize Breakdown block, registered player count, and creator address display
- keep clue progress and start/resume controls integrated with player state

## Validation
- npx tsc --noEmit (mobile)
- npm run store:validate (mobile)

Closes #197