### PR TITLE
closes #179 closes #189: skeleton loaders and wallet session persistence

### DIFF
--- a/mobile/components/HuntsList.tsx
+++ b/mobile/components/HuntsList.tsx
@@ -1,8 +1,9 @@
-import { ActivityIndicator, FlatList, StyleSheet } from 'react-native';
+import { FlatList, StyleSheet } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
 import { getActiveHuntsForFeed } from '@store/huntStore';
-import { ThemedCustomText, ThemedView } from '@components/themed';
+import { ThemedCustomText } from '@components/themed';
 import { HuntCard } from '@components/HuntCard';
+import { HuntsListSkeleton } from '@components/skeletons';
 
 export function HuntsList() {
   const { data: hunts = [], isLoading } = useQuery({
@@ -10,12 +11,9 @@ export function HuntsList() {
     queryFn: getActiveHuntsForFeed,
   });
 
+  // #179 — Animated skeleton placeholders while data loads
   if (isLoading) {
-    return (
-      <ThemedView style={styles.centered}>
-        <ActivityIndicator size="large" />
-      </ThemedView>
-    );
+    return <HuntsListSkeleton />;
   }
 
   return (
@@ -37,5 +35,4 @@ export function HuntsList() {
 const styles = StyleSheet.create({
   list: { padding: 16, gap: 12 },
   heading: { marginBottom: 8 },
-  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
 });

--- a/mobile/components/skeletons/HuntCardSkeleton.tsx
+++ b/mobile/components/skeletons/HuntCardSkeleton.tsx
@@ -1,0 +1,52 @@
+/**
+ * HuntCardSkeleton — Issue #179
+ *
+ * Skeleton placeholder matching the exact layout of HuntCard:
+ *   - Cover image area
+ *   - Title line (h3)
+ *   - Two body-text lines
+ *
+ * Rendered by HuntsList while data loads.
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from '@providers/ThemeProvider';
+import { SkeletonBase } from './SkeletonBase';
+
+export function HuntCardSkeleton() {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[styles.card, { borderColor: colors.border }]}
+      accessible={true}
+      accessibilityLabel="Loading hunt"
+      accessibilityRole="none"
+    >
+      {/* Cover image placeholder */}
+      <SkeletonBase width="100%" height={140} borderRadius={8} />
+
+      {/* Title line */}
+      <SkeletonBase width="70%" height={18} borderRadius={4} style={styles.gap} />
+
+      {/* Body line 1 */}
+      <SkeletonBase width="100%" height={14} borderRadius={4} />
+
+      {/* Body line 2 (shorter — mirrors numberOfLines={2} truncation) */}
+      <SkeletonBase width="55%" height={14} borderRadius={4} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    gap: 10,
+  },
+  gap: {
+    marginTop: 2,
+  },
+});

--- a/mobile/components/skeletons/HuntsListSkeleton.tsx
+++ b/mobile/components/skeletons/HuntsListSkeleton.tsx
@@ -1,0 +1,37 @@
+/**
+ * HuntsListSkeleton — Issue #179
+ *
+ * Renders a column of HuntCardSkeleton placeholders to fill the screen while
+ * the hunts list is loading, preserving the same layout as the real HuntsList.
+ */
+
+import React from 'react';
+import { ScrollView, StyleSheet } from 'react-native';
+import { ThemedView } from '@components/themed';
+import { HuntCardSkeleton } from './HuntCardSkeleton';
+import { SkeletonBase } from './SkeletonBase';
+
+const SKELETON_COUNT = 4;
+
+export function HuntsListSkeleton() {
+  return (
+    <ScrollView
+      contentContainerStyle={styles.list}
+      scrollEnabled={false}
+      accessible={true}
+      accessibilityLabel="Loading hunts"
+    >
+      {/* Heading skeleton matching the ListHeaderComponent h2 */}
+      <SkeletonBase width={140} height={22} borderRadius={6} style={styles.heading} />
+
+      {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+        <HuntCardSkeleton key={i} />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: { padding: 16, gap: 12 },
+  heading: { marginBottom: 8 },
+});

--- a/mobile/components/skeletons/ProfileSkeleton.tsx
+++ b/mobile/components/skeletons/ProfileSkeleton.tsx
@@ -1,0 +1,61 @@
+/**
+ * ProfileSkeleton — Issue #179
+ *
+ * Skeleton for a user profile card:
+ *   - Avatar circle
+ *   - Name line
+ *   - Subtitle / address line
+ *   - Two stat chips
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { SkeletonBase } from './SkeletonBase';
+import { useTheme } from '@providers/ThemeProvider';
+
+export function ProfileSkeleton() {
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, { borderColor: colors.border }]}>
+      {/* Avatar */}
+      <SkeletonBase width={64} height={64} borderRadius={32} />
+
+      <View style={styles.info}>
+        {/* Name */}
+        <SkeletonBase width={160} height={20} borderRadius={4} />
+        {/* Address / subtitle */}
+        <SkeletonBase width={220} height={14} borderRadius={4} style={styles.sub} />
+
+        {/* Stats row */}
+        <View style={styles.stats}>
+          <SkeletonBase width={72} height={28} borderRadius={8} />
+          <SkeletonBase width={72} height={28} borderRadius={8} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    gap: 16,
+  },
+  info: {
+    flex: 1,
+    gap: 8,
+  },
+  sub: {
+    marginTop: 2,
+  },
+  stats: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 4,
+  },
+});

--- a/mobile/components/skeletons/SkeletonBase.tsx
+++ b/mobile/components/skeletons/SkeletonBase.tsx
@@ -1,0 +1,73 @@
+/**
+ * SkeletonBase — Issue #179
+ *
+ * A single shimmer-animated rectangle used to compose skeleton screens.
+ * Built with react-native-reanimated's withRepeat / withSequence so there
+ * are no extra dependencies beyond what is already in package.json.
+ *
+ * Usage:
+ *   <SkeletonBase width={200} height={16} borderRadius={4} />
+ */
+
+import React, { useEffect } from 'react';
+import { StyleSheet, View, ViewStyle } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withSequence,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated';
+import { useTheme } from '@providers/ThemeProvider';
+
+interface SkeletonBaseProps {
+  width: number | `${number}%`;
+  height: number;
+  borderRadius?: number;
+  style?: ViewStyle;
+}
+
+const DURATION = 900;
+
+export function SkeletonBase({ width, height, borderRadius = 6, style }: SkeletonBaseProps) {
+  const { isDark } = useTheme();
+
+  const baseColor = isDark ? '#374151' : '#e5e7eb';
+  const highlightColor = isDark ? '#4b5563' : '#f3f4f6';
+
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(0.4, { duration: DURATION, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1, { duration: DURATION, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+  }, [opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Animated.View
+      accessible={false}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        {
+          width,
+          height,
+          borderRadius,
+          backgroundColor: baseColor,
+        },
+        animatedStyle,
+        style,
+      ]}
+    />
+  );
+}

--- a/mobile/components/skeletons/index.ts
+++ b/mobile/components/skeletons/index.ts
@@ -1,0 +1,4 @@
+export { SkeletonBase } from './SkeletonBase';
+export { HuntCardSkeleton } from './HuntCardSkeleton';
+export { HuntsListSkeleton } from './HuntsListSkeleton';
+export { ProfileSkeleton } from './ProfileSkeleton';

--- a/mobile/providers/Web3Provider.tsx
+++ b/mobile/providers/Web3Provider.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useRef, useSt
 import SignClient from '@walletconnect/sign-client';
 import Constants from 'expo-constants';
 import { useWalletStore } from '@store/useStore';
+import { saveSession, loadSession, clearSession } from '@services/walletSession';
 
 type SessionInfo = {
   topic: string;
@@ -48,6 +49,22 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
     };
   }, []);
 
+  // #189 — Restore persisted session from SecureStore immediately on mount so
+  // the UI reflects the connected state before the WalletConnect SDK hydrates.
+  useEffect(() => {
+    let isCancelled = false;
+    const restorePersistedSession = async () => {
+      const persisted = await loadSession();
+      if (!isCancelled && mountedRef.current && persisted) {
+        setSession({ topic: persisted.topic, publicKey: persisted.publicKey, network: persisted.network });
+        setWallet(persisted.publicKey);
+        setNetwork(persisted.network.includes('main') ? 'mainnet' : 'testnet');
+      }
+    };
+    void restorePersistedSession();
+    return () => { isCancelled = true; };
+  }, [setWallet, setNetwork]);
+
   useEffect(() => {
     const projectId = getProjectId();
     if (!projectId) {
@@ -78,6 +95,7 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
           if (mountedRef.current) {
             setSession(null);
             clearWallet();
+            void clearSession();
           }
         });
 
@@ -85,6 +103,7 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
           if (mountedRef.current) {
             setSession(null);
             clearWallet();
+            void clearSession();
           }
         });
 
@@ -98,9 +117,12 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
             const net = parts.length >= 2 ? parts[1] : 'testnet';
 
             if (mountedRef.current) {
-              setSession({ topic: last.topic, publicKey: pubKey, network: net });
+              const sessionInfo: SessionInfo = { topic: last.topic, publicKey: pubKey, network: net };
+              setSession(sessionInfo);
               setWallet(pubKey);
               setNetwork(net.includes('main') ? 'mainnet' : 'testnet');
+              // Keep SecureStore in sync with the SDK-recovered session
+              void saveSession(sessionInfo);
             }
           }
         }
@@ -154,9 +176,12 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
       const net = parts.length >= 2 ? parts[1] : 'testnet';
 
       if (mountedRef.current) {
-        setSession({ topic: approvedSession.topic, publicKey: pubKey, network: net });
+        const sessionInfo: SessionInfo = { topic: approvedSession.topic, publicKey: pubKey, network: net };
+        setSession(sessionInfo);
         setWallet(pubKey);
         setNetwork(net.includes('main') ? 'mainnet' : 'testnet');
+        // #189 — Persist new session so it survives app restarts
+        void saveSession(sessionInfo);
       }
     } finally {
       if (mountedRef.current) {
@@ -183,6 +208,8 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
     if (mountedRef.current) {
       setSession(null);
       clearWallet();
+      // #189 — Remove persisted session on explicit user disconnect
+      void clearSession();
     }
   }, [session, clearWallet]);
 

--- a/mobile/services/walletSession.ts
+++ b/mobile/services/walletSession.ts
@@ -1,0 +1,66 @@
+/**
+ * Wallet session persistence helpers — Issue #189
+ *
+ * Persists the active WalletConnect SessionInfo to expo-secure-store so that:
+ *   1. The UI can restore the last-known session immediately on boot (before the
+ *      WalletConnect SDK finishes hydrating its own internal cache).
+ *   2. Users are not forced to reconnect after a hard app restart.
+ *
+ * The persisted payload is intentionally minimal: we only store the topic,
+ * publicKey, and network.  The full WalletConnect session (including signing
+ * keys) lives in the SDK's own secure storage; we hold no private material.
+ *
+ * Usage:
+ *   import { saveSession, loadSession, clearSession } from '@services/walletSession';
+ */
+
+import * as SecureStore from 'expo-secure-store';
+
+const SESSION_KEY = 'hunty_wc_session';
+
+export interface PersistedSession {
+  topic: string;
+  publicKey: string;
+  network: string;
+}
+
+/**
+ * Persist a WalletConnect session to secure storage.
+ * Silently no-ops on error so a storage failure never breaks the connect flow.
+ */
+export async function saveSession(session: PersistedSession): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(SESSION_KEY, JSON.stringify(session));
+  } catch {
+    if (__DEV__) console.warn('[WalletSession] saveSession failed');
+  }
+}
+
+/**
+ * Load the last persisted session from secure storage.
+ * Returns `null` when nothing is stored or the stored value is malformed.
+ */
+export async function loadSession(): Promise<PersistedSession | null> {
+  try {
+    const raw = await SecureStore.getItemAsync(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedSession;
+    if (!parsed.topic || !parsed.publicKey) return null;
+    return parsed;
+  } catch {
+    if (__DEV__) console.warn('[WalletSession] loadSession failed');
+    return null;
+  }
+}
+
+/**
+ * Remove the persisted session from secure storage (call on disconnect).
+ * Silently no-ops on error.
+ */
+export async function clearSession(): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(SESSION_KEY);
+  } catch {
+    if (__DEV__) console.warn('[WalletSession] clearSession failed');
+  }
+}


### PR DESCRIPTION
closes #179
closes #189

## Summary

### closes #189 — Session Storage for Wallets
Adds `mobile/services/walletSession.ts` with `saveSession`, `loadSession`, and `clearSession` helpers backed by `expo-secure-store`. Updates `Web3Provider` to:
- Restore the persisted session **immediately on mount** (before WalletConnect SDK async init) so the UI shows the correct connected state without a visible flash on app restart.
- Call `saveSession` after every successful connect and after SDK-recovered sessions are applied.
- Call `clearSession` in the disconnect handler and in `session_delete` / `session_expire` event listeners.

Only the minimal session identifiers (topic, publicKey, network) are stored — no private keys.

### closes #179 — Skeleton Loaders
Adds `mobile/components/skeletons/`:
- **`SkeletonBase`** — generic animated rectangle using `withRepeat` / `withSequence` from `react-native-reanimated`. Pulses opacity 1→0.4→1, adapts colors to light/dark theme, hidden from accessibility tree.
- **`HuntCardSkeleton`** — exact layout match to `HuntCard` (cover image, title, two body lines).
- **`HuntsListSkeleton`** — 4 `HuntCardSkeleton` cards + heading placeholder, filling the screen while hunts load.
- **`ProfileSkeleton`** — avatar circle, name line, address line, two stat chips.
- `index.ts` barrel export.

Updates `HuntsList` to render `HuntsListSkeleton` instead of `ActivityIndicator` while loading. No new dependencies — `react-native-reanimated` 4.2.1 is already installed.

## Test plan
- [ ] Kill and reopen the app while connected to a wallet — connection should restore without re-scanning QR
- [ ] Disconnect wallet — SecureStore entry cleared, app shows disconnected on next restart
- [ ] Navigate to the hunts list with a slow network — skeleton cards animate while data loads
- [ ] Toggle dark mode — skeleton base color updates correctly
- [ ] VoiceOver / TalkBack: skeleton is hidden from screen reader, does not announce "Loading hunt" repeatedly