### PR TITLE
refactor: consolidate contract addresses into single config

### DIFF
--- a/lib/contracts/config.ts
+++ b/lib/contracts/config.ts
@@ -2,13 +2,33 @@ import { getSorobanRpcUrl, getSorobanNetworkPassphrase } from "../soroban/client
 
 export const SOROBAN_RPC_URL = getSorobanRpcUrl()
 export const NETWORK_PASSPHRASE = getSorobanNetworkPassphrase()
-export const REWARD_MANAGER_ADDRESS = process.env.NEXT_PUBLIC_REWARD_MANAGER_ADDRESS ?? ""
 
-export function getRequiredRewardManagerAddress(): string {
-  if (!REWARD_MANAGER_ADDRESS) {
+export const CONTRACTS = {
+  HUNTY_CORE: process.env.NEXT_PUBLIC_HUNTY_CORE_ADDRESS ?? "",
+  REWARD_MANAGER: process.env.NEXT_PUBLIC_REWARD_MANAGER_ADDRESS ?? "",
+  NFT_REWARD: process.env.NEXT_PUBLIC_NFT_REWARD_ADDRESS ?? "",
+} as const
+
+/** Backward-compat alias — prefer CONTRACTS.REWARD_MANAGER in new code. */
+export const REWARD_MANAGER_ADDRESS = CONTRACTS.REWARD_MANAGER
+
+const ENV_VAR_NAMES: Record<keyof typeof CONTRACTS, string> = {
+  HUNTY_CORE: "NEXT_PUBLIC_HUNTY_CORE_ADDRESS",
+  REWARD_MANAGER: "NEXT_PUBLIC_REWARD_MANAGER_ADDRESS",
+  NFT_REWARD: "NEXT_PUBLIC_NFT_REWARD_ADDRESS",
+}
+
+export function getRequiredAddress(key: keyof typeof CONTRACTS): string {
+  const address = CONTRACTS[key]
+  if (!address) {
     throw new Error(
-      "Missing RewardManager address. Set NEXT_PUBLIC_REWARD_MANAGER_ADDRESS in your environment.",
+      `Missing ${key} address. Set ${ENV_VAR_NAMES[key]} in your environment.`,
     )
   }
-  return REWARD_MANAGER_ADDRESS
+  return address
+}
+
+/** Backward-compat helper — prefer getRequiredAddress("REWARD_MANAGER") in new code. */
+export function getRequiredRewardManagerAddress(): string {
+  return getRequiredAddress("REWARD_MANAGER")
 }

--- a/lib/contracts/player-registration.ts
+++ b/lib/contracts/player-registration.ts
@@ -1,5 +1,5 @@
 import Server, { TransactionBuilder, Operation } from "@stellar/stellar-sdk"
-import { getSorobanNetworkPassphrase, getSorobanRpcUrl } from "../soroban/client"
+import { SOROBAN_RPC_URL, NETWORK_PASSPHRASE } from "./config"
 import { withSorobanRpcRetry } from "../soroban/rpcRetry"
 import { RegistrationError } from "@/lib/contracts/errors"
 
@@ -274,9 +274,8 @@ export async function getPlayerProgress(
 
   return withRetry(async () => {
     try {
-      const rpcUrl = getSorobanRpcUrl()
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const server = new Server(rpcUrl)
+      const server = new Server(SOROBAN_RPC_URL)
 
       // In a real implementation, this would query the contract's get_player_progress function
       // For now, we simulate the contract call using the manageData pattern
@@ -455,8 +454,7 @@ export async function registerPlayer(
     }
 
     return await withRetry(async () => {
-      const rpcUrl = getSorobanRpcUrl()
-      const server = new Server(rpcUrl)
+      const server = new Server(SOROBAN_RPC_URL)
       const wallet = getWallet()
       const publicKey = await getPublicKey(wallet)
 
@@ -499,7 +497,7 @@ export async function registerPlayer(
       // Build transaction
       const tx = new TransactionBuilder(account, {
         fee: "100",
-        networkPassphrase: getSorobanNetworkPassphrase(),
+        networkPassphrase: NETWORK_PASSPHRASE,
       })
         .addOperation(op)
         .setTimeout(180)


### PR DESCRIPTION
## Summary

- Introduces a `CONTRACTS` object in `lib/contracts/config.ts` with named keys `HUNTY_CORE`, `REWARD_MANAGER`, and `NFT_REWARD`, each driven by a `NEXT_PUBLIC_*` environment variable
- Adds a generic `getRequiredAddress(key)` helper that throws a descriptive error (including the env var name) when an address is missing at runtime
- Fixes `player-registration.ts` to import `SOROBAN_RPC_URL` and `NETWORK_PASSPHRASE` from `./config` instead of calling `getSorobanRpcUrl()`/`getSorobanNetworkPassphrase()` directly from `../soroban/client`
- Backward-compat aliases (`REWARD_MANAGER_ADDRESS`, `getRequiredRewardManagerAddress()`) are preserved so existing consumers require no changes

## Acceptance criteria

- [x] Zero hardcoded contract addresses outside `config.ts`
- [x] `CONTRACTS` object exported with `HUNTY_CORE`, `REWARD_MANAGER`, `NFT_REWARD` keys
- [x] All contract interaction files (`hunt.ts`, `rewardManager.ts`, `player-registration.ts`) import from `lib/contracts/config.ts`
- [x] Config is driven by env vars (`NEXT_PUBLIC_HUNTY_CORE_ADDRESS`, `NEXT_PUBLIC_REWARD_MANAGER_ADDRESS`, `NEXT_PUBLIC_NFT_REWARD_ADDRESS`) with empty-string fallbacks (no compile-time failures; runtime throws only when an address is actually used)

Closes #368