### PR TITLE
feat: add XLM/USD price display for hunt rewards

### DIFF
--- a/components/GameCompleteModal.tsx
+++ b/components/GameCompleteModal.tsx
@@ -12,6 +12,7 @@ import { RewardsPanel } from "@/components/RewardsPanel"
 import { useQuery } from "@tanstack/react-query"
 import { checkRegistrationStatus } from "@/lib/contracts/player-registration"
 import { useRef, useState } from "react"
+import { useXlmUsdPrice } from "@/hooks/useXlmUsdPrice"
 import { AchievementCertificate } from "@/components/AchievementCertificate"
 import { downloadElementAsImage, shareOnTwitter, shareOnFarcaster } from "@/lib/downloadAsImage"
 import { Share2, Twitter, Download } from "lucide-react"
@@ -47,6 +48,17 @@ export function GameCompleteModal({
   huntId,
   playerAddress,
 }: GameCompleteModalProps) {
+  const { price: xlmUsdPrice } = useXlmUsdPrice();
+
+  const currencyFormatter = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const usdEquivalent =
+    xlmUsdPrice != null ? currencyFormatter.format(reward * xlmUsdPrice) : null;
+
   const certificateRef = useRef<HTMLDivElement>(null)
   const [isGenerating, setIsGenerating] = useState(false)
   const [newAchievements, setNewAchievements] = useState<string[]>([])
@@ -139,13 +151,18 @@ export function GameCompleteModal({
           <div className="flex items-center justify-center gap-2 text-2xl">
             <span>🥇</span>
             <span className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-transparent text-2xl font-bold">1st Place</span>
-          </div>
-
-          <div className="flex items-center justify-center gap-2 w-full">
+          </div>            <div className="flex items-center justify-center gap-2 w-full">
             <p className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-transparent text-xl font-normal  mb-2">You won</p>
-            <div className="flex items-center justify-center gap-2 bg-[#e5e5eb] p-2 rounded-xl w-[230px]">
-              <Coin />
-              <span className="font-bold text-lg">{reward}</span>
+            <div className="flex flex-col items-center gap-1">
+              <div className="flex items-center justify-center gap-2 bg-[#e5e5eb] p-2 rounded-xl w-[230px]">
+                <Coin />
+                <span className="font-bold text-lg">{reward}</span>
+              </div>
+              {usdEquivalent && (
+                <span className="text-sm text-slate-500">
+                  ≈ {usdEquivalent}
+                </span>
+              )}
             </div>
           </div>
 

--- a/components/HuntCompleted.tsx
+++ b/components/HuntCompleted.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import Lottie from 'lottie-react';
+import { useXlmUsdPrice } from "@/hooks/useXlmUsdPrice";
 
 type NFT = {
   id: string;
@@ -19,6 +20,16 @@ const FIREWORK_URL_1 = "https://assets10.lottiefiles.com/packages/lf20_jhu1lmks.
 const FIREWORK_URL_2 = "https://assets2.lottiefiles.com/packages/lf20_xlky4kvh.json";
 
 export default function HuntCompleted({ xlmEarned, nftsEarned, onClaim }: HuntCompletedProps) {
+  const { price: xlmUsdPrice } = useXlmUsdPrice();
+
+  const currencyFormatter = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const usdEquivalent =
+    xlmUsdPrice != null ? currencyFormatter.format(xlmEarned * xlmUsdPrice) : null;
   const [animatedXlm, setAnimatedXlm] = React.useState(0);
   const [lottie1Loaded, setLottie1Loaded] = React.useState(false);
   const [lottie2Loaded, setLottie2Loaded] = React.useState(false);
@@ -286,6 +297,17 @@ export default function HuntCompleted({ xlmEarned, nftsEarned, onClaim }: HuntCo
               >
                 ✦ {animatedXlm.toFixed(1)}
               </div>
+              {usdEquivalent && (
+                <div
+                  style={{
+                    fontSize: '16px',
+                    color: '#a0a0b0',
+                    marginTop: '4px',
+                  }}
+                >
+                  ≈ {usdEquivalent}
+                </div>
+              )}
             </div>
           </div>
 

--- a/components/RewardsPanel.tsx
+++ b/components/RewardsPanel.tsx
@@ -66,7 +66,7 @@ export function RewardsPanel({ rewards, onUpdateReward, onAddReward, onDeleteRew
           <p className="text-sm font-medium text-blue-900">Total Prize Pool</p>
           <p className="text-lg font-semibold text-blue-950">
             {totalRewardXlm.toFixed(2)} XLM
-            {totalRewardUsd ? ` (${totalRewardUsd})` : ""}
+            {totalRewardUsd ? ` (≈ ${totalRewardUsd})` : ""}
           </p>
         </div>
       )}
@@ -96,10 +96,9 @@ export function RewardsPanel({ rewards, onUpdateReward, onAddReward, onDeleteRew
                 <div className="flex flex-col">
                   <span className="text-[16px] font-medium bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-transparent bg-clip-text">
                     {reward.amount.toPrecision(3)} XLM
-                  </span>
-                  {xlmUsdPrice != null && (
+                  </span>                    {xlmUsdPrice != null && (
                     <span className="text-[11px] text-slate-500">
-                      {currencyFormatter.format(reward.amount * xlmUsdPrice)}
+                      ≈ {currencyFormatter.format(reward.amount * xlmUsdPrice)}
                     </span>
                   )}
                 </div>

--- a/hooks/useXlmUsdPrice.ts
+++ b/hooks/useXlmUsdPrice.ts
@@ -9,7 +9,8 @@ type XlmUsdPriceState = {
   lastUpdated: number | null
 }
 
-const DEFAULT_POLLING_MS = 30000
+// 5-minute polling to respect free-tier API rate limits
+const DEFAULT_POLLING_MS = 300_000
 
 async function fetchFromCoinbase(): Promise<number> {
   const res = await fetch("https://api.coinbase.com/v2/prices/XLM-USD/spot", {


### PR DESCRIPTION
Closes #384

## Changes
- **useXlmUsdPrice hook**: Changed polling interval from 30s → 5 minutes to respect free-tier API rate limits
- **RewardsPanel**: Added "≈" prefix to USD amounts for total prize pool and individual rewards
- **HuntCompleted overlay**: Added USD equivalent display below XLM earned amount
- **GameCompleteModal**: Added USD equivalent display below reward amount

## Acceptance Criteria
- ✅ Hunt cards show USD equivalent for XLM rewards
- ✅ Rate is fetched and cached every 5 minutes
- ✅ USD display hidden gracefully if API is unavailable
- ✅ "≈" prefix indicates approximate value

## Testing
- All USD displays conditionally render based on price availability
- USD amounts use Intl.NumberFormat for proper locale formatting
- Polling reduced to 5 minutes to stay within free-tier rate limits