### PR TITLE
feat: add per-clue difficulty indicator for creators

### DIFF
--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -201,6 +201,16 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           {points != null && (
             <span className="bg-white/20 px-2 py-0.5 rounded-full text-xs font-semibold print:bg-transparent print:border print:border-gray-300 print:text-black">{points} pts</span>
           )}
+          {hunt.difficulty && (
+            <span className={cn(
+              "px-2 py-0.5 rounded-full text-xs font-semibold ml-2 print:border print:text-black",
+              hunt.difficulty === "Easy" && "bg-green-500/30 text-green-200 print:border-green-500",
+              hunt.difficulty === "Medium" && "bg-yellow-500/30 text-yellow-200 print:border-yellow-500",
+              hunt.difficulty === "Hard" && "bg-red-500/30 text-red-200 print:border-red-500",
+            )}>
+              {hunt.difficulty}
+            </span>
+          )}
           <span className="text-[#B3B3E5] ml-auto print:text-black text-xs sm:text-sm">{currentIndex}/{totalHunts}</span>
         </div>
         <h3 className="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2 print:text-3xl print:mb-4">

--- a/components/HuntForm.tsx
+++ b/components/HuntForm.tsx
@@ -31,6 +31,7 @@ const clueSchema = z.object({
   points: z.number().min(1, "Points must be at least 1"),
   hint: z.string(),
   hintCost: z.number().min(0),
+  difficulty: z.enum(["Easy", "Medium", "Hard"]).optional(),
 })
 
 const cluesFormSchema = z.object({
@@ -111,6 +112,7 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
           points: row.points,
           hint: row.hint?.trim() || undefined,
           hintCost: row.hintCost,
+          difficulty: row.difficulty,
         })
 
         const salt = `${huntId}_${newId}`
@@ -120,7 +122,7 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
           async (setStage) => {
             setStage("approving")
             // Submit the hashed answer to the contract (expected scheme: sha256(answer + salt))
-            return addClue(huntId, row.question.trim(), hashed, row.points, row.hint?.trim() || undefined, row.hintCost)
+            return addClue(huntId, row.question.trim(), hashed, row.points, row.hint?.trim() || undefined, row.hintCost, row.difficulty)
           },
           {
             pending:   "Pending — preparing clue…",
@@ -366,6 +368,23 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
                       ref={f.ref}
                       className="w-24 pl-3 py-2 text-sm"
                     />
+                  )}
+                />
+                <Controller
+                  control={control}
+                  name={`clues.${index}.difficulty`}
+                  render={({ field: f }) => (
+                    <select
+                      aria-label={`Clue ${index + 1} Difficulty`}
+                      value={f.value ?? ""}
+                      onChange={(e) => f.onChange(e.target.value || undefined)}
+                      className="w-28 pl-3 py-2 text-sm rounded-md border border-input bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value="">Difficulty</option>
+                      <option value="Easy">Easy</option>
+                      <option value="Medium">Medium</option>
+                      <option value="Hard">Hard</option>
+                    </select>
                   )}
                 />
               </div>

--- a/components/PlayGame.tsx
+++ b/components/PlayGame.tsx
@@ -66,6 +66,7 @@ export function PlayGame({
           points: clue.points,
           hint: clue.hint,
           hintCost: clue.hintCost,
+          difficulty: clue.difficulty,
         });
       }
       return { clues, huntInfo };

--- a/lib/contracts/hunt.ts
+++ b/lib/contracts/hunt.ts
@@ -127,7 +127,8 @@ export async function addClue(
   answer: string,
   points: number,
   hint?: string,
-  hintCost?: number
+  hintCost?: number,
+  difficulty?: import("@/lib/types").ClueDifficulty
 ): Promise<AddClueResult> {
   if (typeof window === "undefined") throw new Error("Browser environment required")
 
@@ -150,6 +151,7 @@ export async function addClue(
     points,
     ...(hint ? { hint } : {}),
     ...(hintCost ? { hint_cost: hintCost } : {}),
+    ...(difficulty ? { difficulty } : {}),
   })
   const key = `add_clue:${Date.now()}`
   const op = Operation.manageData({ name: key, value: payload })
@@ -365,6 +367,7 @@ export async function get_clue_info(huntId: number, clueId: number): Promise<Clu
       points: clue.points,
       hint: clue.hint,
       hintCost: clue.hintCost,
+      difficulty: clue.difficulty,
     }
   } catch (error) {
     throw normalizeNetworkError(error, "Failed to fetch clue")

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,6 +50,8 @@ export type HuntInfo = {
 
 // ─── Clue ────────────────────────────────────────────────────────────────────
 
+export type ClueDifficulty = "Easy" | "Medium" | "Hard"
+
 export interface Clue {
   id: number
   huntId: number
@@ -58,6 +60,8 @@ export interface Clue {
   points: number
   hint?: string
   hintCost?: number
+  /** Optional difficulty tag set by the creator. */
+  difficulty?: ClueDifficulty
   /** Center latitude for the clue's answer geofence. */
   latitude?: number
   /** Center longitude for the clue's answer geofence. */
@@ -72,6 +76,7 @@ export type ClueInfo = {
   points: number
   hint?: string
   hintCost?: number
+  difficulty?: ClueDifficulty
 }
 
 export interface ClueRow {
@@ -81,6 +86,7 @@ export interface ClueRow {
   points: number
   hint?: string
   hintCost?: number
+  difficulty?: ClueDifficulty
 }
 
 // ─── Transaction Results ─────────────────────────────────────────────────────
@@ -201,6 +207,7 @@ export interface HuntCard {
   hint?: string
   hintCost?: number
   points?: number
+  difficulty?: ClueDifficulty
 }
 
 export interface HuntDraft {


### PR DESCRIPTION
- Add ClueDifficulty type (Easy | Medium | Hard) to lib/types.ts
- Extend Clue, ClueInfo, ClueRow, and HuntCard interfaces with optional difficulty field
- Add difficulty dropdown selector to each clue row in HuntForm.tsx
- Pass difficulty through saveClueLocally and addClue metadata payload
- Return difficulty from get_clue_info and map it in PlayGame.tsx
- Display colour-coded badge in HuntCards (green/yellow/red) next to points

No on-chain storage — difficulty is stored in metadata/localStorage only.

Closes #356