### PR TITLE
feat: add tests for HuntCards component and player count hooks(#358)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import { GlobalActivityFeed } from "@/components/GlobalActivityFeed"
 import { FeaturedHunts } from "@/components/FeaturedHunts"
 import { HuntCoverImage } from "@/components/HuntCoverImage"
 import { Footer } from "@/components/Footer"
+import { usePlayerCounts } from "@/hooks/usePlayerCounts"
 
 interface WalletOption {
   id: string
@@ -72,6 +73,17 @@ export default function GameArcade() {
     queryKey: ["activeHunts"],
     queryFn: async () => fetchAllHunts(),
   })
+
+  // Fetch player counts for all visible hunts. refetch is called on mount via
+  // useEffect below to ensure counts are fresh on each arcade page load.
+  const allHuntIds = hunts.map((h) => String(h.id))
+  const { counts: playerCounts, refetch: refetchPlayerCounts } = usePlayerCounts(allHuntIds)
+
+  // Refresh player counts whenever the hunt list loads/changes.
+  useEffect(() => {
+    if (hunts.length > 0) refetchPlayerCounts()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hunts.length])
 
   const visibleInactiveHunts = useMemo(
     () => inactiveHunts.slice(0, visibleInactiveCount),
@@ -410,7 +422,9 @@ export default function GameArcade() {
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {filteredHunts.map((hunt) => (
+              {filteredHunts.map((hunt) => {
+                const pc = playerCounts.get(String(hunt.id))
+                return (
                 <Card
                   key={hunt.id}
                   className="overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm hover:shadow-md transition-shadow"
@@ -421,14 +435,24 @@ export default function GameArcade() {
                     className="relative w-full h-40 bg-slate-100"
                   />
                   <div className="p-5">
-                    <CardTitle className="text-lg font-semibold mb-2 line-clamp-2 dark:text-slate-100">
-                      {hunt.title}
-                    </CardTitle>
+                    <div className="flex items-center gap-2 mb-1">
+                      <CardTitle className="text-lg font-semibold line-clamp-2 dark:text-slate-100 flex-1">
+                        {hunt.title}
+                      </CardTitle>
+                      {pc?.isTrending && (
+                        <span
+                          className="shrink-0 inline-flex items-center gap-1 rounded-full bg-orange-100 px-2 py-0.5 text-[10px] font-semibold text-orange-700"
+                          aria-label="Trending hunt"
+                        >
+                          🔥 Trending
+                        </span>
+                      )}
+                    </div>
                     <CardDescription className="text-sm text-slate-600 dark:text-slate-400 mb-4 line-clamp-3">
                       {hunt.description}
                     </CardDescription>
                     <div className="flex items-center justify-between mt-4">
-                      <div className="flex gap-2 items-center">
+                      <div className="flex gap-2 items-center flex-wrap">
                         <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-[11px] font-medium text-[#3737A4]">
                           {hunt.cluesCount} {hunt.cluesCount === 1 ? "Clue" : "Clues"}
                         </span>
@@ -439,6 +463,14 @@ export default function GameArcade() {
                         }`}>
                           {hunt.rewardType} Reward
                         </span>
+                        {pc && !pc.isLoading && !pc.error && (
+                          <span
+                            className="player-count inline-flex items-center gap-1 rounded-full bg-slate-100 dark:bg-slate-700 px-3 py-1 text-[11px] font-medium text-slate-600 dark:text-slate-300"
+                            aria-label={`${pc.count} player${pc.count !== 1 ? "s" : ""} registered`}
+                          >
+                            👥 {pc.count} player{pc.count !== 1 ? "s" : ""}
+                          </span>
+                        )}
                       </div>
                       <div className="flex gap-2 mt-2 w-full justify-between">
                         <Button
@@ -465,7 +497,8 @@ export default function GameArcade() {
                     </div>
                   </div>
                 </Card>
-              ))}
+                )
+              })}
             </div>
           )}
         </div>

--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -11,6 +11,7 @@ import sanitizeHtml from "@/lib/sanitizeHtml";
 import { submitAnswer, AnswerIncorrectError, pollTransaction } from "@/lib/contracts/hunt";
 import { resolveImageSrc, GATEWAY_COUNT } from "@/lib/ipfs";
 import type { HuntCard as Hunt } from "@/lib/types";
+import { usePlayerCount } from "@/hooks/usePlayerCount";
 
 export type { Hunt };
 
@@ -32,6 +33,15 @@ interface HuntCardsProps {
   solved?: boolean;
   /** Whether the hunt has ended. */
   huntEnded?: boolean;
+  /**
+   * Pre-fetched player count from the arcade page (via usePlayerCounts).
+   * When omitted, the component fetches its own count via usePlayerCount.
+   * Passing from the parent avoids N individual fetches when many cards render.
+   */
+  playerCount?: number;
+  playerCountLoading?: boolean;
+  playerCountError?: string | null;
+  isTrending?: boolean;
 }
 
 const DEFAULT_POINTS = 10;
@@ -49,8 +59,23 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
   points,
   solved = false,
   huntEnded = false,
+  playerCount: playerCountProp,
+  playerCountLoading: playerCountLoadingProp,
+  playerCountError: playerCountErrorProp,
+  isTrending: isTrendingProp,
 }) => {
   const hunt = hunts && hunts.length > 0 ? hunts[0] : {} as Hunt;
+
+  // If the parent pre-fetched counts (arcade page), use those.
+  // Otherwise fall back to the per-card hook (play flow).
+  // Using String(huntId ?? hunt.id) as the key — both are numeric IDs.
+  const fallbackId = String(huntId ?? hunt.id ?? "");
+  const ownCount = usePlayerCount(playerCountProp !== undefined ? "" : fallbackId);
+
+  const count = playerCountProp !== undefined ? playerCountProp : ownCount.count;
+  const countIsLoading = playerCountProp !== undefined ? (playerCountLoadingProp ?? false) : ownCount.isLoading;
+  const countError = playerCountProp !== undefined ? (playerCountErrorProp ?? null) : ownCount.error;
+  const trending = playerCountProp !== undefined ? (isTrendingProp ?? false) : ownCount.isTrending;
   const [input, setInput] = useState("");
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
@@ -201,8 +226,29 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           {points != null && (
             <span className="bg-white/20 px-2 py-0.5 rounded-full text-xs font-semibold print:bg-transparent print:border print:border-gray-300 print:text-black">{points} pts</span>
           )}
-          <span className="text-[#B3B3E5] ml-auto print:text-black text-xs sm:text-sm">{currentIndex}/{totalHunts}</span>
+          <div className="ml-auto flex items-center gap-2">
+            {trending && (
+              <span
+                className="trending-badge bg-orange-500/80 text-white px-2 py-0.5 rounded-full text-xs font-semibold print:hidden"
+                aria-label="Trending hunt"
+              >
+                🔥 Trending
+              </span>
+            )}
+            <span className="text-[#B3B3E5] print:text-black text-xs sm:text-sm">{currentIndex}/{totalHunts}</span>
+          </div>
         </div>
+        {/* Player count — shown below the title row, above description */}
+        <span
+          className="player-count block text-xs text-white/60 mb-2 print:hidden"
+          aria-label={countIsLoading ? "Loading player count" : countError ? undefined : `${count} player${count !== 1 ? "s" : ""} registered`}
+        >
+          {countIsLoading ? (
+            <span className="player-count--loading" aria-hidden="true">—</span>
+          ) : countError ? null : (
+            `${count} player${count !== 1 ? "s" : ""} registered`
+          )}
+        </span>
         <h3 className="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2 print:text-3xl print:mb-4">
           {hunt.title || "Untitled Hunt"}
         </h3>

--- a/components/__tests__/HuntCards.test.tsx
+++ b/components/__tests__/HuntCards.test.tsx
@@ -1,0 +1,190 @@
+import React from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { HuntCards } from "../HuntCards"
+import type { HuntCard } from "@/lib/types"
+import * as usePlayerCountModule from "@/hooks/usePlayerCount"
+
+// Mock the contract call used inside HuntCards (submitAnswer)
+vi.mock("@/lib/contracts/hunt", () => ({
+  submitAnswer: vi.fn(),
+  pollTransaction: vi.fn(),
+  AnswerIncorrectError: class AnswerIncorrectError extends Error {
+    constructor() { super("Incorrect"); this.name = "AnswerIncorrectError" }
+  },
+}))
+
+// Mock canvas-confetti (not available in jsdom)
+vi.mock("canvas-confetti", () => ({ default: vi.fn() }))
+
+// Mock usePlayerCount so HuntCards tests are isolated from localStorage
+vi.mock("@/hooks/usePlayerCount", () => ({
+  usePlayerCount: vi.fn(() => ({
+    huntId: "1",
+    count: 0,
+    isTrending: false,
+    fetchedAt: 0,
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const baseHunt: HuntCard = {
+  id: 1,
+  title: "Test Hunt",
+  description: "A test hunt description",
+  code: "answer",
+}
+
+const defaultProps = {
+  hunts: [baseHunt],
+  isActive: true,
+}
+
+// ── player count display ──────────────────────────────────────────────────────
+
+describe("HuntCards — player count display", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders player count when provided via props", () => {
+    render(<HuntCards {...defaultProps} playerCount={7} playerCountLoading={false} playerCountError={null} isTrending={false} />)
+    expect(screen.getByText("7 players registered")).toBeInTheDocument()
+  })
+
+  it("renders singular 'player' when count is 1", () => {
+    render(<HuntCards {...defaultProps} playerCount={1} playerCountLoading={false} playerCountError={null} isTrending={false} />)
+    expect(screen.getByText("1 player registered")).toBeInTheDocument()
+  })
+
+  it("renders loading dash when playerCountLoading is true", () => {
+    // playerCount must be defined (non-undefined) to use the prop path;
+    // passing 0 with loading=true triggers the loading branch.
+    render(<HuntCards {...defaultProps} playerCount={0} playerCountLoading={true} playerCountError={null} isTrending={false} />)
+    expect(document.querySelector(".player-count--loading")).toBeInTheDocument()
+  })
+
+  it("renders nothing for count when there is an error", () => {
+    render(<HuntCards {...defaultProps} playerCount={0} playerCountLoading={false} playerCountError="Network error" isTrending={false} />)
+    expect(screen.queryByText(/registered/)).not.toBeInTheDocument()
+  })
+
+  it("falls back to usePlayerCount hook when no playerCount prop is passed", () => {
+    vi.mocked(usePlayerCountModule.usePlayerCount).mockReturnValueOnce({
+      huntId: "1", count: 12, isTrending: false, fetchedAt: 0, isLoading: false, error: null,
+    })
+    render(<HuntCards {...defaultProps} />)
+    expect(screen.getByText("12 players registered")).toBeInTheDocument()
+  })
+
+  it("shows trending badge from fallback hook when isTrending is true", () => {
+    vi.mocked(usePlayerCountModule.usePlayerCount).mockReturnValueOnce({
+      huntId: "1", count: 60, isTrending: true, fetchedAt: 0, isLoading: false, error: null,
+    })
+    render(<HuntCards {...defaultProps} />)
+    expect(screen.getByLabelText("Trending hunt")).toBeInTheDocument()
+  })
+})
+
+// ── trending badge ────────────────────────────────────────────────────────────
+
+describe("HuntCards — trending badge", () => {
+  it("shows trending badge when isTrending is true", () => {
+    render(<HuntCards {...defaultProps} playerCount={60} playerCountLoading={false} playerCountError={null} isTrending={true} />)
+    expect(screen.getByLabelText("Trending hunt")).toBeInTheDocument()
+    expect(screen.getByText(/Trending/)).toBeInTheDocument()
+  })
+
+  it("does not show trending badge when isTrending is false", () => {
+    render(<HuntCards {...defaultProps} playerCount={10} playerCountLoading={false} playerCountError={null} isTrending={false} />)
+    expect(screen.queryByLabelText("Trending hunt")).not.toBeInTheDocument()
+  })
+})
+
+// ── accessibility ─────────────────────────────────────────────────────────────
+
+describe("HuntCards — accessibility", () => {
+  it("player count span has aria-label with count text", () => {
+    render(<HuntCards {...defaultProps} playerCount={5} playerCountLoading={false} playerCountError={null} isTrending={false} />)
+    expect(screen.getByLabelText("5 players registered")).toBeInTheDocument()
+  })
+
+  it("trending badge has aria-label", () => {
+    render(<HuntCards {...defaultProps} playerCount={60} playerCountLoading={false} playerCountError={null} isTrending={true} />)
+    expect(screen.getByLabelText("Trending hunt")).toBeInTheDocument()
+  })
+
+  it("player count is readable text — not only an icon", () => {
+    render(<HuntCards {...defaultProps} playerCount={3} playerCountLoading={false} playerCountError={null} isTrending={false} />)
+    // Visible text must be present alongside any badge
+    expect(screen.getByText("3 players registered")).toBeInTheDocument()
+  })
+})
+
+// ── card rendering ────────────────────────────────────────────────────────────
+
+describe("HuntCards — card rendering", () => {
+  it("renders hunt title and description", () => {
+    render(<HuntCards {...defaultProps} />)
+    expect(screen.getByText("Test Hunt")).toBeInTheDocument()
+    expect(screen.getByText("A test hunt description")).toBeInTheDocument()
+  })
+
+  it("renders clue counter", () => {
+    render(<HuntCards {...defaultProps} currentIndex={2} totalHunts={5} />)
+    expect(screen.getByText("2/5")).toBeInTheDocument()
+  })
+
+  it("renders points badge when points prop is provided", () => {
+    render(<HuntCards {...defaultProps} points={20} />)
+    expect(screen.getByText("20 pts")).toBeInTheDocument()
+  })
+
+  it("renders skeleton when isLoading is true", () => {
+    render(<HuntCards {...defaultProps} isLoading={true} />)
+    // Input and submit button are absent during loading
+    expect(screen.queryByPlaceholderText("Enter answer")).not.toBeInTheDocument()
+  })
+
+  it("shows solved overlay and disables input when solved is true", () => {
+    render(<HuntCards {...defaultProps} solved={true} />)
+    // The green overlay is rendered
+    expect(document.querySelector(".bg-green-500\\/10")).toBeInTheDocument()
+    // Input is disabled (isLocked = true when solved)
+    expect(screen.getByPlaceholderText("Enter answer")).toBeDisabled()
+  })
+
+  it("shows Hunt Ended message when huntEnded is true", () => {
+    render(<HuntCards {...defaultProps} huntEnded={true} />)
+    expect(screen.getByText("Hunt Ended")).toBeInTheDocument()
+  })
+})
+
+// ── local answer submission ───────────────────────────────────────────────────
+
+describe("HuntCards — local answer submission (no huntId)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("shows Try Again on wrong answer", () => {
+    render(<HuntCards {...defaultProps} />)
+    fireEvent.change(screen.getByPlaceholderText("Enter answer"), { target: { value: "wrong" } })
+    fireEvent.click(screen.getByRole("button", { name: "" })) // ArrowRight button
+    expect(screen.getByText("Try Again")).toBeInTheDocument()
+  })
+
+  it("calls onUnlock after correct answer", async () => {
+    const onUnlock = vi.fn()
+    render(<HuntCards {...defaultProps} onUnlock={onUnlock} />)
+    fireEvent.change(screen.getByPlaceholderText("Enter answer"), { target: { value: "answer" } })
+    fireEvent.click(screen.getByRole("button", { name: "" }))
+    await waitFor(() => expect(onUnlock).toHaveBeenCalled(), { timeout: 2000 })
+  })
+
+  it("clears error when input changes after wrong answer", () => {
+    render(<HuntCards {...defaultProps} />)
+    fireEvent.change(screen.getByPlaceholderText("Enter answer"), { target: { value: "wrong" } })
+    fireEvent.click(screen.getByRole("button", { name: "" }))
+    expect(screen.getByText("Try Again")).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText("Enter answer"), { target: { value: "a" } })
+    expect(screen.queryByText("Try Again")).not.toBeInTheDocument()
+  })
+})

--- a/hooks/usePlayerCount.test.ts
+++ b/hooks/usePlayerCount.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { usePlayerCount, getPlayerCountFromStorage, playerCountCache } from "./usePlayerCount"
+import { TRENDING_PLAYER_THRESHOLD, PLAYER_COUNT_CACHE_TTL_MS } from "@/lib/types"
+
+// ── localStorage mock ─────────────────────────────────────────────────────────
+
+function makeLocalStorageMock() {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    get length() { return Object.keys(store).length },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  }
+}
+
+const localStorageMock = makeLocalStorageMock()
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", localStorageMock)
+  localStorageMock.clear()
+  playerCountCache.clear()
+  seedCounter = 0
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+let seedCounter = 0
+
+function seedRegistrations(huntId: string, count: number) {
+  for (let i = 0; i < count; i++) {
+    const unique = String(seedCounter++)
+    localStorage.setItem(`hunt_registered_${huntId}_G${"X".repeat(54 - unique.length)}${unique}`, "true")
+  }
+}
+
+// ── getPlayerCountFromStorage ─────────────────────────────────────────────────
+
+describe("getPlayerCountFromStorage", () => {
+  it("returns 0 when no registrations exist", () => {
+    expect(getPlayerCountFromStorage("1")).toBe(0)
+  })
+
+  it("counts only keys for the given huntId", () => {
+    seedRegistrations("1", 3)
+    seedRegistrations("2", 5)
+    expect(getPlayerCountFromStorage("1")).toBe(3)
+    expect(getPlayerCountFromStorage("2")).toBe(5)
+  })
+
+  it("ignores keys with value !== 'true'", () => {
+    localStorage.setItem("hunt_registered_1_GABC", "false")
+    localStorage.setItem("hunt_registered_1_GDEF", "true")
+    expect(getPlayerCountFromStorage("1")).toBe(1)
+  })
+})
+
+// ── usePlayerCount ────────────────────────────────────────────────────────────
+
+describe("usePlayerCount", () => {
+  it("resolves count from localStorage", async () => {
+    seedRegistrations("42", 3)
+    const { result } = renderHook(() => usePlayerCount("42"))
+    await act(async () => {})
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.count).toBe(3)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("sets isTrending when count >= TRENDING_PLAYER_THRESHOLD", async () => {
+    seedRegistrations("10", TRENDING_PLAYER_THRESHOLD)
+    const { result } = renderHook(() => usePlayerCount("10"))
+    await act(async () => {})
+    expect(result.current.isTrending).toBe(true)
+  })
+
+  it("does not set isTrending when count < TRENDING_PLAYER_THRESHOLD", async () => {
+    seedRegistrations("11", TRENDING_PLAYER_THRESHOLD - 1)
+    const { result } = renderHook(() => usePlayerCount("11"))
+    await act(async () => {})
+    expect(result.current.isTrending).toBe(false)
+  })
+
+  it("uses cache when entry is fresh — no second localStorage scan", async () => {
+    seedRegistrations("5", 2)
+    // Prime cache
+    const { result: r1 } = renderHook(() => usePlayerCount("5"))
+    await act(async () => {})
+    expect(r1.current.count).toBe(2)
+
+    // Add more registrations — should NOT be picked up (cache is fresh)
+    seedRegistrations("5", 1)
+    const { result: r2 } = renderHook(() => usePlayerCount("5"))
+    await act(async () => {})
+    expect(r2.current.count).toBe(2) // still cached value
+  })
+
+  it("re-fetches when cache is manually cleared", async () => {
+    seedRegistrations("7", 1)
+    const { result: r1 } = renderHook(() => usePlayerCount("7"))
+    await act(async () => {})
+    expect(r1.current.count).toBe(1)
+
+    // Clear cache and add another registration
+    playerCountCache.clear()
+    seedRegistrations("7", 1)
+
+    const { result: r2 } = renderHook(() => usePlayerCount("7"))
+    await act(async () => {})
+    expect(r2.current.count).toBe(2)
+  })
+
+  it("re-fetches when cache TTL has expired", async () => {
+    vi.useFakeTimers()
+    seedRegistrations("9", 1)
+    const { result: r1 } = renderHook(() => usePlayerCount("9"))
+    await act(async () => { vi.runAllTimers() })
+    expect(r1.current.count).toBe(1)
+
+    // Expire the cache entry manually
+    const entry = playerCountCache.get("9")!
+    playerCountCache.set("9", { ...entry, fetchedAt: Date.now() - PLAYER_COUNT_CACHE_TTL_MS - 1 })
+
+    seedRegistrations("9", 1)
+    const { result: r2 } = renderHook(() => usePlayerCount("9"))
+    await act(async () => { vi.runAllTimers() })
+    expect(r2.current.count).toBe(2)
+    vi.useRealTimers()
+  })
+
+  it("returns error result when huntId is empty", async () => {
+    const { result } = renderHook(() => usePlayerCount(""))
+    await act(async () => {})
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeTruthy()
+  })
+})

--- a/hooks/usePlayerCount.ts
+++ b/hooks/usePlayerCount.ts
@@ -1,0 +1,128 @@
+/**
+ * Findings (Issue #358):
+ *
+ * - No on-chain get_player_count method exists on the PlayerRegistration contract.
+ *   The app tracks registrations in localStorage as:
+ *   `hunt_registered_{huntId}_{playerAddress} = "true"`
+ *   This hook counts those keys for a given huntId — consistent with how
+ *   getPlayerProgress and registerPlayer work in lib/contracts/player-registration.ts.
+ *
+ * - Data-fetching pattern: useEffect + useState (matches useXlmUsdPrice.ts).
+ *   No new library introduced.
+ *
+ * - Cache: module-level Map keyed by huntId with TTL (PLAYER_COUNT_CACHE_TTL_MS).
+ *   Persists across re-renders; resets on full page reload — satisfying the
+ *   "updates on each arcade page load" requirement without stale counts surviving
+ *   navigation.
+ *
+ * - On error: returns { count: 0, isTrending: false, error: "..." } — never throws.
+ *
+ * - isTrending = count >= TRENDING_PLAYER_THRESHOLD (50).
+ */
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { TRENDING_PLAYER_THRESHOLD, PLAYER_COUNT_CACHE_TTL_MS, type PlayerCountResult } from "@/lib/types"
+
+// Module-level cache — survives re-renders, resets on page reload.
+const cache = new Map<string, { count: number; fetchedAt: number }>()
+
+/**
+ * Counts registered players for a hunt by scanning localStorage keys of the
+ * form `hunt_registered_{huntId}_{playerAddress}`.
+ */
+export function getPlayerCountFromStorage(huntId: string): number {
+  if (typeof window === "undefined") return 0
+  const prefix = `hunt_registered_${huntId}_`
+  let count = 0
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.startsWith(prefix) && localStorage.getItem(key) === "true") {
+      count++
+    }
+  }
+  return count
+}
+
+/**
+ * Fetch and cache the registered player count for a given hunt.
+ *
+ * **Data source:** scans `localStorage` for keys of the form
+ * `hunt_registered_{huntId}_{address}` with value `"true"` — the same keys
+ * written by `registerPlayer` in `lib/contracts/player-registration.ts`.
+ *
+ * **Caching:** a module-level `Map` keyed by `huntId` stores
+ * `{ count, fetchedAt }`. On each call the hook checks whether
+ * `Date.now() - fetchedAt < PLAYER_COUNT_CACHE_TTL_MS`. If the entry is
+ * fresh the cached value is returned immediately with no localStorage scan.
+ * If stale or absent the hook re-scans and updates the cache. Because the
+ * cache is module-level it persists across re-renders but resets on a full
+ * page reload, satisfying the "updates on each arcade page load" requirement.
+ *
+ * **No-throw guarantee:** all errors are caught and surfaced in the returned
+ * `error` field. A failed count fetch never throws and never breaks the
+ * calling component's render.
+ *
+ * @param huntId - The on-chain hunt identifier (string form of the numeric ID).
+ * @returns {@link PlayerCountResult} with count, isTrending, loading, and error state.
+ */
+export function usePlayerCount(huntId: string): PlayerCountResult {
+  const [result, setResult] = useState<PlayerCountResult>({
+    huntId,
+    count: 0,
+    isTrending: false,
+    fetchedAt: 0,
+    isLoading: true,
+    error: null,
+  })
+
+  useEffect(() => {
+    if (!huntId) {
+      setResult({ huntId, count: 0, isTrending: false, fetchedAt: 0, isLoading: false, error: "No huntId" })
+      return
+    }
+
+    const cached = cache.get(huntId)
+    if (cached && Date.now() - cached.fetchedAt < PLAYER_COUNT_CACHE_TTL_MS) {
+      setResult({
+        huntId,
+        count: cached.count,
+        isTrending: cached.count >= TRENDING_PLAYER_THRESHOLD,
+        fetchedAt: cached.fetchedAt,
+        isLoading: false,
+        error: null,
+      })
+      return
+    }
+
+    // Fetch (synchronous localStorage scan wrapped in try/catch)
+    try {
+      const count = getPlayerCountFromStorage(huntId)
+      const fetchedAt = Date.now()
+      cache.set(huntId, { count, fetchedAt })
+      setResult({
+        huntId,
+        count,
+        isTrending: count >= TRENDING_PLAYER_THRESHOLD,
+        fetchedAt,
+        isLoading: false,
+        error: null,
+      })
+    } catch (err) {
+      setResult({
+        huntId,
+        count: 0,
+        isTrending: false,
+        fetchedAt: 0,
+        isLoading: false,
+        error: err instanceof Error ? err.message : "Failed to fetch player count",
+      })
+    }
+  }, [huntId])
+
+  return result
+}
+
+/** Exposed for testing and bulk hook use. */
+export { cache as playerCountCache }

--- a/hooks/usePlayerCounts.test.ts
+++ b/hooks/usePlayerCounts.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { usePlayerCounts } from "./usePlayerCounts"
+import { playerCountCache } from "./usePlayerCount"
+import { TRENDING_PLAYER_THRESHOLD } from "@/lib/types"
+
+// ── localStorage mock ─────────────────────────────────────────────────────────
+
+function makeLocalStorageMock() {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    get length() { return Object.keys(store).length },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  }
+}
+
+const localStorageMock = makeLocalStorageMock()
+
+let seedCounter = 0
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", localStorageMock)
+  localStorageMock.clear()
+  playerCountCache.clear()
+  seedCounter = 0
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function seedRegistrations(huntId: string, count: number) {
+  for (let i = 0; i < count; i++) {
+    const unique = String(seedCounter++)
+    localStorage.setItem(`hunt_registered_${huntId}_G${"X".repeat(54 - unique.length)}${unique}`, "true")
+  }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("usePlayerCounts", () => {
+  it("returns counts for all provided hunt IDs", async () => {
+    seedRegistrations("1", 3)
+    seedRegistrations("2", 7)
+
+    const { result } = renderHook(() => usePlayerCounts(["1", "2"]))
+    await act(async () => {})
+
+    expect(result.current.counts.get("1")?.count).toBe(3)
+    expect(result.current.counts.get("2")?.count).toBe(7)
+  })
+
+  it("sets isTrending for hunts at or above threshold", async () => {
+    seedRegistrations("10", TRENDING_PLAYER_THRESHOLD)
+    seedRegistrations("11", TRENDING_PLAYER_THRESHOLD - 1)
+
+    const { result } = renderHook(() => usePlayerCounts(["10", "11"]))
+    await act(async () => {})
+
+    expect(result.current.counts.get("10")?.isTrending).toBe(true)
+    expect(result.current.counts.get("11")?.isTrending).toBe(false)
+  })
+
+  it("returns isLoading:false after settling", async () => {
+    const { result } = renderHook(() => usePlayerCounts(["1"]))
+    await act(async () => {})
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("uses cache — does not re-scan for fresh entries", async () => {
+    seedRegistrations("5", 2)
+    // Prime cache via first render
+    const { result: r1 } = renderHook(() => usePlayerCounts(["5"]))
+    await act(async () => {})
+    expect(r1.current.counts.get("5")?.count).toBe(2)
+
+    // Add more registrations — should NOT be picked up (cache is fresh)
+    seedRegistrations("5", 3)
+    const { result: r2 } = renderHook(() => usePlayerCounts(["5"]))
+    await act(async () => {})
+    expect(r2.current.counts.get("5")?.count).toBe(2)
+  })
+
+  it("refetch clears cache and re-fetches all IDs", async () => {
+    seedRegistrations("3", 1)
+    const { result } = renderHook(() => usePlayerCounts(["3"]))
+    await act(async () => {})
+    expect(result.current.counts.get("3")?.count).toBe(1)
+
+    // Add more registrations then refetch
+    seedRegistrations("3", 2)
+    await act(async () => { result.current.refetch() })
+    await act(async () => {})
+
+    expect(result.current.counts.get("3")?.count).toBe(3)
+  })
+
+  it("handles empty huntIds array without error", async () => {
+    const { result } = renderHook(() => usePlayerCounts([]))
+    await act(async () => {})
+    expect(result.current.counts.size).toBe(0)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("one failed fetch does not prevent others from resolving", async () => {
+    seedRegistrations("20", 4)
+
+    // Make localStorage.key throw for hunt "99" only
+    const originalKey = localStorageMock.key.bind(localStorageMock)
+    let callCount = 0
+    vi.spyOn(localStorageMock, "key").mockImplementation((index) => {
+      // Throw on the first scan attempt (hunt "99" is fetched first alphabetically
+      // in Promise.allSettled — we simulate by throwing once then recovering)
+      callCount++
+      if (callCount === 1) throw new Error("simulated storage error")
+      return originalKey(index)
+    })
+
+    const { result } = renderHook(() => usePlayerCounts(["99", "20"]))
+    await act(async () => {})
+
+    // "20" should still resolve
+    expect(result.current.counts.get("20")?.count).toBe(4)
+    // "99" should have an error, not crash the hook
+    expect(result.current.counts.get("99")?.error).toBeTruthy()
+  })
+})

--- a/hooks/usePlayerCounts.ts
+++ b/hooks/usePlayerCounts.ts
@@ -1,0 +1,125 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { TRENDING_PLAYER_THRESHOLD, PLAYER_COUNT_CACHE_TTL_MS, type PlayerCountResult } from "@/lib/types"
+import { getPlayerCountFromStorage, playerCountCache } from "./usePlayerCount"
+
+function buildResult(huntId: string, count: number, fetchedAt: number): PlayerCountResult {
+  return {
+    huntId,
+    count,
+    isTrending: count >= TRENDING_PLAYER_THRESHOLD,
+    fetchedAt,
+    isLoading: false,
+    error: null,
+  }
+}
+
+function buildErrorResult(huntId: string, err: unknown): PlayerCountResult {
+  return {
+    huntId,
+    count: 0,
+    isTrending: false,
+    fetchedAt: 0,
+    isLoading: false,
+    error: err instanceof Error ? err.message : "Failed to fetch player count",
+  }
+}
+
+/**
+ * Fetch player counts for multiple hunts in parallel, sharing the same
+ * module-level TTL cache as {@link usePlayerCount}.
+ *
+ * **Parallel fetching:** only hunt IDs that are absent from the cache or
+ * whose cached entry has expired are fetched. Those IDs are dispatched
+ * concurrently via `Promise.allSettled`, so a slow or failing fetch for one
+ * hunt does not delay or block the others.
+ *
+ * **Partial failure handling:** if an individual fetch throws, its
+ * `PlayerCountResult` is populated with `{ count: 0, error: "..." }` while
+ * all other results resolve normally. The hook itself never rejects.
+ *
+ * **Usage:** call at the page level (e.g. the arcade page) and pass the
+ * per-hunt results down as props to avoid N individual hook calls inside
+ * each card.
+ *
+ * @param huntIds - Array of hunt IDs visible on the current page.
+ * @returns `counts` map, `isLoading` flag, and a `refetch` function that
+ *   clears the cache for these IDs and re-fetches — call on page mount/focus.
+ */
+export function usePlayerCounts(huntIds: string[]): {
+  counts: Map<string, PlayerCountResult>
+  isLoading: boolean
+  refetch: () => void
+} {
+  const [counts, setCounts] = useState<Map<string, PlayerCountResult>>(new Map())
+  const [isLoading, setIsLoading] = useState(false)
+  // Stable ref to avoid stale closure in refetch
+  const huntIdsRef = useRef(huntIds)
+  huntIdsRef.current = huntIds
+
+  const fetchCounts = useCallback(async (ids: string[], forceRefresh = false) => {
+    if (ids.length === 0) return
+
+    if (forceRefresh) {
+      ids.forEach((id) => playerCountCache.delete(id))
+    }
+
+    const now = Date.now()
+    const staleIds = ids.filter((id) => {
+      const cached = playerCountCache.get(id)
+      return !cached || now - cached.fetchedAt >= PLAYER_COUNT_CACHE_TTL_MS
+    })
+
+    // Seed with cached values immediately
+    const next = new Map<string, PlayerCountResult>()
+    ids.forEach((id) => {
+      const cached = playerCountCache.get(id)
+      if (cached && now - cached.fetchedAt < PLAYER_COUNT_CACHE_TTL_MS) {
+        next.set(id, buildResult(id, cached.count, cached.fetchedAt))
+      } else {
+        next.set(id, { huntId: id, count: 0, isTrending: false, fetchedAt: 0, isLoading: true, error: null })
+      }
+    })
+    setCounts(new Map(next))
+
+    if (staleIds.length === 0) return
+
+    setIsLoading(true)
+
+    const settled = await Promise.allSettled(
+      staleIds.map(async (id) => {
+        const count = getPlayerCountFromStorage(id)
+        const fetchedAt = Date.now()
+        playerCountCache.set(id, { count, fetchedAt })
+        return { id, count, fetchedAt }
+      })
+    )
+
+    setCounts((prev) => {
+      const updated = new Map(prev)
+      settled.forEach((outcome, i) => {
+        const id = staleIds[i]
+        if (outcome.status === "fulfilled") {
+          updated.set(id, buildResult(id, outcome.value.count, outcome.value.fetchedAt))
+        } else {
+          updated.set(id, buildErrorResult(id, outcome.reason))
+        }
+      })
+      return updated
+    })
+
+    setIsLoading(false)
+  }, [])
+
+  useEffect(() => {
+    void fetchCounts(huntIds)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [huntIds.join(",")])
+
+  const refetch = useCallback(() => {
+    void fetchCounts(huntIdsRef.current, true)
+  }, [fetchCounts])
+
+  return { counts, isLoading, refetch }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -212,6 +212,51 @@ export interface HuntDraft {
   image?: string
 }
 
+// ─── Player Count ────────────────────────────────────────────────────────────
+
+/**
+ * Player count above which a hunt is considered "Trending".
+ *
+ * A hunt whose registered player count is >= this value receives the
+ * 🔥 Trending badge on its card. Set to 50 as a reasonable signal of
+ * meaningful engagement without being too easy to trigger on small hunts.
+ *
+ * To tune: lower the value to badge more hunts (e.g. 20 for a new platform
+ * with low traffic); raise it to reserve the badge for genuinely popular hunts.
+ */
+export const TRENDING_PLAYER_THRESHOLD = 50
+
+/**
+ * How long a fetched player count is considered fresh (ms).
+ *
+ * After this TTL the next call to `usePlayerCount` / `usePlayerCounts` will
+ * re-scan localStorage and update the cache. The cache is module-level, so it
+ * resets on a full page reload — satisfying the "updates on each arcade page
+ * load" requirement without stale counts surviving navigation.
+ *
+ * Tradeoff: shorter TTL → fresher counts but more localStorage scans per
+ * session; longer TTL → fewer scans but counts may lag behind reality.
+ * 60 s is a reasonable default for a game arcade where registration activity
+ * is bursty rather than continuous.
+ */
+export const PLAYER_COUNT_CACHE_TTL_MS = 60_000
+
+export interface PlayerCountResult {
+  huntId: string
+  count: number
+  /**
+   * `true` when `count >= TRENDING_PLAYER_THRESHOLD`.
+   *
+   * Computed at fetch time and cached alongside the count, so the badge
+   * reflects the same snapshot as the displayed number. Re-evaluated on
+   * every cache miss (stale or absent entry).
+   */
+  isTrending: boolean
+  fetchedAt: number   // Date.now() at time of fetch
+  isLoading: boolean
+  error: string | null
+}
+
 // ─── Profile Dashboard Types ───────────────────────────────────────────────────
 
 export type HuntProgressStatus = "Completed" | "In-Progress"


### PR DESCRIPTION
- Implement unit tests for the HuntCards component covering player count display, trending badge, accessibility, card rendering, and local answer submission.
- Create tests for the usePlayerCount hook to validate localStorage interactions and caching behavior.
- Introduce usePlayerCounts hook to fetch player counts for multiple hunts in parallel with error handling and caching.
- Add comprehensive tests for usePlayerCounts to ensure correct functionality with various scenarios.

closes #358