### PR TITLE
feat:Add a "Recently Completed" hunts section to the Arcade (#359)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,8 @@ import { FeaturedHunts } from "@/components/FeaturedHunts"
 import { HuntCoverImage } from "@/components/HuntCoverImage"
 import { Footer } from "@/components/Footer"
 import { usePlayerCounts } from "@/hooks/usePlayerCounts"
+import { useRecentlyCompleted } from "@/hooks/useRecentlyCompleted"
+import { RecentlyCompletedSection } from "@/components/RecentlyCompletedSection"
 
 interface WalletOption {
   id: string
@@ -78,6 +80,9 @@ export default function GameArcade() {
   // useEffect below to ensure counts are fresh on each arcade page load.
   const allHuntIds = hunts.map((h) => String(h.id))
   const { counts: playerCounts, refetch: refetchPlayerCounts } = usePlayerCounts(allHuntIds)
+
+  // Derive recently completed hunts from the same list — no extra fetch.
+  const recentlyCompleted = useRecentlyCompleted(hunts)
 
   // Refresh player counts whenever the hunt list loads/changes.
   useEffect(() => {
@@ -315,6 +320,9 @@ export default function GameArcade() {
 
         {/* Featured Hunts Hero Section */}
         <FeaturedHunts />
+
+        {/* Recently Completed — derived from the same hunt list, no extra fetch */}
+        <RecentlyCompletedSection hunts={recentlyCompleted} />
 
         {/* Active Hunts Grid */}
         <div className="mt-10">

--- a/components/CompletedHuntCard.tsx
+++ b/components/CompletedHuntCard.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import React from "react"
+import Link from "next/link"
+import { HuntCoverImage } from "@/components/HuntCoverImage"
+import type { StoredHunt } from "@/lib/types"
+
+interface CompletedHuntCardProps {
+  hunt: StoredHunt
+  /**
+   * Full Stellar G-address of the top-ranked player.
+   * Raw address is never shown as visible text — always truncated.
+   * The full address is accessible via `title` and `aria-label`.
+   * Omit while the leaderboard is still loading.
+   */
+  winnerAddress?: string
+}
+
+/** Truncates a Stellar address to `G…XXXX` form (5 + 4 chars). */
+function truncateAddress(address: string): string {
+  if (address.length <= 10) return address
+  return `${address.slice(0, 5)}…${address.slice(-4)}`
+}
+
+function rewardBadgeClass(rewardType: StoredHunt["rewardType"]): string {
+  if (rewardType === "XLM") return "bg-green-50 text-green-700"
+  if (rewardType === "NFT") return "bg-purple-50 text-purple-700"
+  return "bg-amber-50 text-amber-700"
+}
+
+export function CompletedHuntCard({ hunt, winnerAddress }: CompletedHuntCardProps) {
+  return (
+    <article
+      className="min-w-[220px] max-w-[260px] flex-shrink-0 rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm overflow-hidden"
+      aria-label={`Completed hunt: ${hunt.title}`}
+    >
+      <HuntCoverImage
+        src={hunt.coverImageCid}
+        alt={`${hunt.title} cover`}
+        className="relative w-full h-32 bg-slate-100"
+      />
+
+      <div className="p-4 flex flex-col gap-2">
+        {/* Title */}
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100 line-clamp-2 leading-snug">
+          {hunt.title}
+        </h3>
+
+        {/* Metadata row */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="inline-flex items-center rounded-full bg-slate-100 dark:bg-slate-700 px-2 py-0.5 text-[10px] font-medium text-slate-600 dark:text-slate-300">
+            {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
+          </span>
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${rewardBadgeClass(hunt.rewardType)}`}>
+            {hunt.rewardType}
+          </span>
+          {/* Completed badge */}
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
+            ✓ Completed
+          </span>
+        </div>
+
+        {/* Winner row — only rendered when address is available */}
+        {winnerAddress && (
+          <p className="text-[11px] text-slate-500 dark:text-slate-400 flex items-center gap-1">
+            <span aria-hidden="true">🏆</span>
+            <span
+              title={winnerAddress}
+              aria-label={`Winner: ${winnerAddress}`}
+              className="font-mono"
+            >
+              {truncateAddress(winnerAddress)}
+            </span>
+          </p>
+        )}
+
+        {/* CTA */}
+        <Link
+          href={`/hunt/${hunt.id}`}
+          className="mt-1 text-[11px] font-semibold text-[#3737A4] dark:text-blue-400 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3737A4] rounded"
+        >
+          View results →
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/components/RecentlyCompletedSection.tsx
+++ b/components/RecentlyCompletedSection.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import React, { useEffect, useState } from "react"
+import { CompletedHuntCard } from "@/components/CompletedHuntCard"
+import { get_hunt_leaderboard } from "@/lib/contracts/hunt"
+import type { StoredHunt } from "@/lib/types"
+
+interface RecentlyCompletedSectionProps {
+  hunts: StoredHunt[]
+}
+
+/**
+ * Renders a horizontally scrollable strip of recently completed hunts.
+ *
+ * Returns `null` (not an empty container) when `hunts` is empty — an empty
+ * section with a heading but no cards looks broken.
+ *
+ * Winner addresses are fetched in parallel via `Promise.allSettled` after
+ * mount. A failed leaderboard fetch for one hunt does not affect the others;
+ * the card simply renders without a winner line.
+ *
+ * The scroll container uses `overflow-x: auto` with focusable card children,
+ * giving native keyboard arrow-key scrolling when the container is focused.
+ */
+export function RecentlyCompletedSection({ hunts }: RecentlyCompletedSectionProps) {
+  // Map of huntId → top winner address (populated async after mount)
+  const [winners, setWinners] = useState<Map<number, string>>(new Map())
+
+  useEffect(() => {
+    if (hunts.length === 0) return
+
+    void Promise.allSettled(
+      hunts.map(async (hunt) => {
+        const entries = await get_hunt_leaderboard(hunt.id)
+        // Sort descending by points; take the top address
+        const sorted = [...entries].sort((a, b) => b.points - a.points)
+        const top = sorted[0]
+        return top ? { id: hunt.id, address: top.address } : null
+      })
+    ).then((results) => {
+      const next = new Map<number, string>()
+      results.forEach((outcome) => {
+        if (outcome.status === "fulfilled" && outcome.value) {
+          next.set(outcome.value.id, outcome.value.address)
+        }
+      })
+      setWinners(next)
+    })
+  }, [hunts])
+
+  // Constraint: return null, not an empty container
+  if (hunts.length === 0) return null
+
+  return (
+    <section aria-label="Recently completed hunts" className="mt-10">
+      <div className="mb-4">
+        <p className="text-xs uppercase tracking-[0.28em] text-slate-400 dark:text-slate-500 mb-1">
+          Recently completed
+        </p>
+        <h2 className="text-2xl font-bold bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-transparent">
+          Finished Hunts
+        </h2>
+      </div>
+
+      {/*
+        overflow-x: auto + focusable children = native keyboard arrow-key
+        scrolling when the container or a child has focus.
+        tabIndex={0} makes the container itself focusable as a fallback.
+      */}
+      <div
+        className="overflow-x-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3737A4] rounded-2xl"
+        tabIndex={0}
+        role="region"
+        aria-label="Scroll to see more completed hunts"
+      >
+        <div className="inline-flex gap-4 pb-2">
+          {hunts.map((hunt) => (
+            <CompletedHuntCard
+              key={hunt.id}
+              hunt={hunt}
+              winnerAddress={winners.get(hunt.id)}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/hooks/useRecentlyCompleted.ts
+++ b/hooks/useRecentlyCompleted.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useMemo } from "react"
+import type { StoredHunt } from "@/lib/types"
+
+/** Maximum number of completed hunts shown in the Recently Completed strip. */
+export const MAX_RECENTLY_COMPLETED = 5
+
+/**
+ * Derives the most recently completed hunts from the hunt list already
+ * fetched by the arcade page — no additional RPC call.
+ *
+ * Filters to `status === "Completed"` and non-private hunts, sorts by
+ * `endTime` descending (most recently ended first), then slices to
+ * `MAX_RECENTLY_COMPLETED`. Slicing is the hook's responsibility so the
+ * cap is easy to change in one place and the component stays dumb.
+ *
+ * @param hunts - Full hunt list from the arcade page's existing query.
+ * @returns Up to MAX_RECENTLY_COMPLETED completed hunts, newest first.
+ */
+export function useRecentlyCompleted(hunts: StoredHunt[]): StoredHunt[] {
+  return useMemo(
+    () =>
+      hunts
+        .filter((h) => h.status === "Completed" && !h.is_private)
+        .sort((a, b) => (b.endTime ?? 0) - (a.endTime ?? 0))
+        .slice(0, MAX_RECENTLY_COMPLETED),
+    [hunts]
+  )
+}


### PR DESCRIPTION
  What changed
  
  - HuntCards now shows a live registered player count and a 🔥 Trending badge
  when a hunt exceeds 50 players.
  - The arcade page shows a horizontally scrollable "Recently Completed" strip
  (up to 5 hunts) with winner addresses and a "View results" link per card.
  - Player counts are cached in-memory (60 s TTL) and batch-fetched on each
  arcade page load to avoid N sequential calls.
  
  New files
  
  ┌────────────────────────┬────────────────────────────────────────────────┐
  │ File                   │ Purpose                                        │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ hooks/usePlayerCo      │ Single-hunt count with TTL cache and no-throw  │
  │ unt.ts                 │ guarantee                                      │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ hooks/usePlayerCo      │ Bulk fetch via Promise.allSettled; exposes     │
  │ unts.ts                │ refetch()                                      │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ hooks/useRecently      │ Derives completed hunts from existing query;   │
  │ Completed.ts           │ slices to MAX_RECENTLY_COMPLETED = 5           │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ components/Comple      │ Separate card for completed hunts (distinct    │
  │ tedHuntCard.tsx        │ data shape from HuntCards)                     │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ components/Recent      │ Returns null when empty; horizontal scroll,    │
  │ lyCompletedSection.tsx │ keyboard-navigable                             │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ hooks/usePlayerCo      │ 10 tests: storage scan, TTL cache, trending    │
  │ unt.test.ts            │ threshold, stale re-fetch                      │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ hooks/usePlayerCo      │ 7 tests: bulk fetch, cache hit, refetch,       │
  │ unts.test.ts           │ partial failure isolation                      │
  ├────────────────────────┼────────────────────────────────────────────────┤
  │ components/__test      │ 20 tests: count display, badge, a11y, card     │
  │ s__/HuntCards.test.tsx │ rendering, answer submission                   │
  └────────────────────────┴────────────────────────────────────────────────┘
  
  Modified files
  
  - lib/types.ts — added TRENDING_PLAYER_THRESHOLD, PLAYER_COUNT_CACHE_TTL_MS,
  PlayerCountResult
  - components/HuntCards.tsx — optional playerCount/isTrending props; falls back
  to usePlayerCount in the play flow
  - app/page.tsx — calls usePlayerCounts + useRecentlyCompleted; renders
  RecentlyCompletedSection
  
  Design decisions
  
  - Player counts are read from localStorage keys
  (hunt_registered_{id}_{address}), consistent with how registerPlayer and
  getPlayerProgress already work — no new RPC call.
  - RecentlyCompletedSection returns null (not an empty container) when there
  are no completed hunts.
  - Raw winner addresses never appear as visible text — always truncateAddress;
  full address on title + aria-label.
  - CompletedHuntCard is a separate component; sharing HuntCards would require
  nullable props that make the type system unhelpful.
  
  Testing
  
  All 37 new tests pass. Pre-existing failures in huntStore.test.ts and
  GlobalActivityFeed.test.tsx are unrelated to this PR (pre-existing
  localStorage.clear and logger issues in the test environment).

closes #359