### PR TITLE
fix(a11y): add aria-labels to icon-only buttons

### DIFF
--- a/app/hunt/[id]/share.tsx
+++ b/app/hunt/[id]/share.tsx
@@ -213,7 +213,13 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
               </>
             )}
           </Button>
-          <Button variant="outline" size="icon" onClick={() => setQrOpen(true)} title="Show QR Code">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setQrOpen(true)}
+            title="Show QR Code"
+            aria-label="Show QR code for this hunt"
+          >
             <QrCode className="w-4 h-4" />
           </Button>
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -119,6 +119,7 @@ export function Header({ balance = "0" }: { balance?: string }) {
                   <div className="p-2 flex flex-col gap-1">
                     <button
                       onClick={handleCopy}
+                      aria-label="Copy wallet address"
                       className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-white/5 transition-colors text-left"
                     >
                       {copied ? (

--- a/components/HuntDashboard.tsx
+++ b/components/HuntDashboard.tsx
@@ -369,7 +369,11 @@ export function HuntDashboard({
                     <CardTitle className="line-clamp-2 text-lg dark:text-white">{hunt.title}</CardTitle>
                     <div className="flex items-center gap-1 bg-slate-100 dark:bg-white/5 px-2 py-0.5 rounded-md text-xs text-slate-500 dark:text-slate-400 font-mono">
                       #{hunt.id}
-                      <button onClick={(e) => handleCopyId(e, hunt.id)} className="hover:text-slate-800 dark:hover:text-white transition-colors">
+                      <button
+                        onClick={(e) => handleCopyId(e, hunt.id)}
+                        aria-label={`Copy hunt ID ${hunt.id}`}
+                        className="hover:text-slate-800 dark:hover:text-white transition-colors"
+                      >
                         <Copy className="w-3 h-3" />
                       </button>
                     </div>
@@ -422,6 +426,7 @@ export function HuntDashboard({
                           #{hunt.id}
                           <button
                             onClick={(event) => handleCopyId(event, hunt.id)}
+                            aria-label={`Copy hunt ID ${hunt.id}`}
                             className="transition-colors hover:text-slate-800 dark:hover:text-white"
                           >
                             <Copy className="h-3 w-3" />
@@ -630,6 +635,7 @@ export function HuntDashboard({
                   variant="ghost"
                   size="icon"
                   onClick={() => removeClueRow(row.id)}
+                  aria-label={`Remove clue row ${index + 1}`}
                   disabled={clueRows.length === 1}
                   className="text-red-400 hover:text-red-600 disabled:opacity-30"
                 >

--- a/components/RewardsPanel.tsx
+++ b/components/RewardsPanel.tsx
@@ -85,6 +85,7 @@ export function RewardsPanel({ rewards, onUpdateReward, onAddReward, onDeleteRew
                 size="icon"
                 variant="ghost"
                 onClick={() => onUpdateReward(reward.place, reward.amount - 0.1)}
+                aria-label={`Decrease reward for place ${reward.place}`}
                 className="w-6 h-6 border-2 border-transparent bg-origin-border hover:opacity-80 rounded-lg"
                 style={{
                   background: 'linear-gradient(var(--background), var(--background)) padding-box, linear-gradient(to right, #0C0C4F, #4A4AFF) border-box'
@@ -110,6 +111,7 @@ export function RewardsPanel({ rewards, onUpdateReward, onAddReward, onDeleteRew
                 size="icon"
                 variant="ghost"
                 onClick={() => onUpdateReward(reward.place, reward.amount + 0.1)}
+                aria-label={`Increase reward for place ${reward.place}`}
                 className="w-6 h-6 border-2 border-transparent bg-origin-border hover:opacity-80 rounded-lg"
                 style={{
                   background: 'linear-gradient(var(--background), var(--background)) padding-box, linear-gradient(to right, #0C0C4F, #4A4AFF) border-box'
@@ -121,6 +123,7 @@ export function RewardsPanel({ rewards, onUpdateReward, onAddReward, onDeleteRew
             {onDeleteReward && (
               <Button 
                 variant="ghost" 
+                aria-label={`Delete reward for place ${reward.place}`}
                 className="w-8 h-8 p-3 bg-gradient-to-b from-[#FD0A44] to-[#932331] text-white rounded-lg ml-2 cursor-pointer hover:opacity-80"
                 onClick={() => onDeleteReward(reward.place)}
               >

--- a/components/WalletBottomSheet.tsx
+++ b/components/WalletBottomSheet.tsx
@@ -87,6 +87,7 @@ export function WalletBottomSheet({ isOpen, onClose, onConnect }: WalletBottomSh
                 variant="ghost"
                 size="icon"
                 onClick={onClose}
+                aria-label="Close wallet options"
                 className="rounded-full bg-slate-100 dark:bg-slate-800 h-10 w-10"
               >
                 <X className="h-5 w-5" />
@@ -98,6 +99,7 @@ export function WalletBottomSheet({ isOpen, onClose, onConnect }: WalletBottomSh
               <button
                 onClick={() => handleConnect("xbull")}
                 disabled={!!connectingProvider}
+                aria-label="Connect xBull wallet"
                 className="group relative w-full overflow-hidden rounded-2xl bg-gradient-to-r from-orange-500 to-red-500 p-[1px] transition-all hover:scale-[1.02] active:scale-[0.98]"
               >
                 <div className="flex items-center gap-4 bg-white dark:bg-slate-900 p-4 rounded-[calc(1rem-1px)]">
@@ -116,6 +118,7 @@ export function WalletBottomSheet({ isOpen, onClose, onConnect }: WalletBottomSh
               <button
                 onClick={() => handleConnect("lobstr")}
                 disabled={!!connectingProvider}
+                aria-label="Connect Lobstr wallet"
                 className="group relative w-full overflow-hidden rounded-2xl bg-gradient-to-r from-blue-500 to-cyan-500 p-[1px] transition-all hover:scale-[1.02] active:scale-[0.98]"
               >
                 <div className="flex items-center gap-4 bg-white dark:bg-slate-900 p-4 rounded-[calc(1rem-1px)]">
@@ -150,6 +153,7 @@ export function WalletBottomSheet({ isOpen, onClose, onConnect }: WalletBottomSh
               <div className="mt-8 rounded-3xl bg-slate-50 dark:bg-slate-800/50 p-6 border border-slate-100 dark:border-slate-800">
                 <button 
                   onClick={() => setShowEducation(!showEducation)}
+                  aria-label={showEducation ? "Hide wallet education" : "Show wallet education"}
                   className="flex w-full items-center justify-between"
                 >
                   <div className="flex items-center gap-3">

--- a/components/WalletModal.tsx
+++ b/components/WalletModal.tsx
@@ -59,6 +59,7 @@ export function WalletModal({ isOpen, onClose, onConnect }: WalletModalProps) {
             variant="ghost"
             size="icon"
             onClick={handleClose}
+            aria-label="Close wallet modal"
             className="h-6 w-6 rounded-full bg-pink-500 hover:bg-pink-600 text-white"
           >
             <X className="h-4 w-4" />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,10 +17,15 @@ const eslintConfig = [
 const isProduction = process.env.NODE_ENV === "production";
 
 eslintConfig.push({
+  plugins: {
+    "jsx-a11y": jsxA11y,
+  },
   rules: {
     // In production builds treat any console usage as an error to avoid
     // leaking sensitive data (warnings during development remain helpful).
     "no-console": isProduction ? "error" : "warn",
+    "jsx-a11y/control-has-associated-label": "error",
+    "jsx-a11y/interactive-supports-focus": "error",
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@vitest/ui": "^4.0.18",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "jsdom": "^28.1.0",
     "pnpm": "^10.33.0",
     "tailwindcss": "^4.0.0",


### PR DESCRIPTION
## Summary
- add descriptive aria-labels to icon-only buttons used for copy, QR, close, reward adjustment, and related actions
- improve accessibility for wallet modal and bottom sheet controls
- add jsx-a11y lint rules to catch unlabeled controls and focus issues going forward

## Testing
- not run

closes #336 