### PR TITLE
A11Y: announce HuntForm validation errors with role=alert and aria-de…

### DIFF
--- a/components/HuntForm.tsx
+++ b/components/HuntForm.tsx
@@ -165,6 +165,12 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
             Remove
           </Button>
         </div>
+
+        {errors.clues?.message && (
+          <div role="alert" aria-live="assertive" id="clues-error" className="text-red-500 text-sm mt-2">
+            {errors.clues.message}
+          </div>
+        )}
       </div>
 
       {showPreview && (
@@ -284,13 +290,21 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
                       <Input
                         placeholder="Riddle / Question"
                         aria-label={`Clue ${index + 1} Question`}
+                        aria-describedby={errors.clues?.[index]?.question ? `clue-${index}-question-error` : undefined}
                         {...f}
                         className="pl-3 py-2 text-sm"
                       />
                     )}
                   />
                   {errors.clues?.[index]?.question && (
-                    <span className="text-red-500 text-xs mt-0.5">{errors.clues[index].question.message}</span>
+                    <span
+                      role="alert"
+                      aria-live="assertive"
+                      id={`clue-${index}-question-error`}
+                      className="text-red-500 text-xs mt-0.5"
+                    >
+                      {errors.clues[index].question.message}
+                    </span>
                   )}
                 </div>
                 <div className="w-32 flex flex-col">
@@ -300,15 +314,23 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
                     render={({ field: f }) => (
                       <Input
                         placeholder="Answer (use | for multiple)"
-                        aria-label={`Clue ${index + 1} Answer`}
-                        {...f}
+                          aria-label={`Clue ${index + 1} Answer`}
+                          aria-describedby={errors.clues?.[index]?.answer ? `clue-${index}-answer-error` : undefined}
+                          {...f}
                         className="pl-3 py-2 text-sm"
                       />
                     )}
                   />
-                  {errors.clues?.[index]?.answer && (
-                    <span className="text-red-500 text-xs mt-0.5">{errors.clues[index].answer.message}</span>
-                  )}
+                    {errors.clues?.[index]?.answer && (
+                      <span
+                        role="alert"
+                        aria-live="assertive"
+                        id={`clue-${index}-answer-error`}
+                        className="text-red-500 text-xs mt-0.5"
+                      >
+                        {errors.clues[index].answer.message}
+                      </span>
+                    )}
                 </div>
                 <div className="w-16 flex flex-col">
                   <Controller


### PR DESCRIPTION
Title: A11Y: Announce HuntForm validation errors to screen readers

Description:
- Summary: Make validation errors in HuntForm.tsx accessible to screen reader users.

- What I changed:
  - Added `role="alert"` and `aria-live="assertive"` to clue-level and array-level error message elements so they are announced.
  - Added `aria-describedby` attributes on question and answer inputs to link them to their error message IDs.
  - Preserved existing visual styles; no behavior changes to validation logic.
- Why: Errors were visible but not announced by screen readers (NVDA/VoiceOver). These changes ensure error messages are programmatically exposed and announced.

- Testing notes:
  - Trigger validation by attempting to save clues with empty required fields — error elements now render with `role="alert"` and `aria-live="assertive"`.
  - Recommend verifying announcements with NVDA and VoiceOver.

Issue: 
closes #333
  
- Follow-ups:
  - Run a quick audit across other forms to apply the same pattern.
  - Consider extracting a small accessible `ErrorMessage` component to standardize error rendering.

- Branch: `fix/a11y-huntform-errors` (pushed)
- PR: https://github.com/eischideraa-unn/hunty/pull/new/fix/a11y-huntform-errors