### PR TITLE
fix(a11y): increase dark mode text contrast to meet WCAG AA

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -90,7 +90,7 @@
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
+  --muted-foreground: oklch(0.78 0 0);
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);

--- a/components/FeaturedHunts.tsx
+++ b/components/FeaturedHunts.tsx
@@ -76,7 +76,7 @@ export function FeaturedHunts() {
                   className="relative w-full h-36 rounded-xl overflow-hidden mb-3 bg-slate-100 dark:bg-slate-800"
                 />
 
-                <p className="text-sm text-slate-600 dark:text-slate-400 mb-4 line-clamp-2 flex-1">
+                <p className="text-sm text-slate-600 dark:text-slate-300 mb-4 line-clamp-2 flex-1">
                   {hunt.description}
                 </p>
 
@@ -97,7 +97,7 @@ export function FeaturedHunts() {
                     {hunt.rewardType} Reward
                   </span>
                   {hunt.endTime && (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400">
+                    <span className="inline-flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-300">
                       <Clock className="w-3 h-3" />
                       {timeRemaining(hunt.endTime)}
                     </span>

--- a/components/GlobalActivityFeed.tsx
+++ b/components/GlobalActivityFeed.tsx
@@ -68,7 +68,7 @@ function ActivityItem({ event }: { event: ActivityEvent }) {
       </div>
 
       {/* Time */}
-      <span className="shrink-0 text-[11px] text-slate-400 dark:text-slate-500 tabular-nums">
+      <span className="shrink-0 text-[11px] text-slate-400 dark:text-slate-300 tabular-nums">
         {relativeTime(event.timestamp)}
       </span>
     </motion.div>
@@ -194,7 +194,7 @@ export function GlobalActivityFeed({
             <SkeletonItem />
           </>
         ) : events.length === 0 ? (
-          <div className="text-center py-6 text-slate-500 dark:text-slate-400 text-sm">
+          <div className="text-center py-6 text-slate-500 dark:text-slate-300 text-sm">
             No activity yet — be the first to complete a hunt!
           </div>
         ) : (

--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -363,7 +363,7 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           </div>
         )}
         {!huntEnded && !success && isPending && (
-          <p className="text-center text-slate-400 dark:text-slate-500 text-xs sm:text-sm">Submitting...</p>
+          <p className="text-center text-slate-400 dark:text-slate-400 text-xs sm:text-sm">Submitting...</p>
         )}
         {!huntEnded && !success && !isPending && error && (
           <p className="text-center text-red-500 dark:text-red-400 font-semibold text-xs sm:text-sm">{error}</p>


### PR DESCRIPTION
  Closes #338

  Increases secondary text contrast in dark mode to meet WCAG AA minimum
  (4.5:1).

  Changes:
  - globals.css: raised --muted-foreground from oklch(0.708) to oklch(0.78)
  - GlobalActivityFeed: timestamps slate-500 → slate-300, empty state
  slate-400 → slate-300
  - FeaturedHunts: description and time remaining slate-400 → slate-300
  - HuntCards: "Submitting..." feedback slate-500 → slate-400

  All affected elemen