### PR TITLE
fix: add e2e script to package.json to match README

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "test": "vitest --run",
     "test:watch": "vitest",
+    "e2e": "playwright test",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },


### PR DESCRIPTION
#315 [BUG] Creator stats page (/creator/stats/[id]) missing back navigation
Repo Avatar
[Samuel1-ona/hunty](https://github.com/Samuel1-ona/hunty)
Description
The creator stats page at /creator/stats/[id] has no back button or breadcrumb. Users must use the browser's back button to return to their dashboard.

Steps to Reproduce
Go to Creator Dashboard
Click into stats for a hunt
There is no visible way to navigate back to the dashboard
Proposed Fix
Add a back button at the top of the stats page
Add a breadcrumb: "Dashboard > Hunt Stats"

closes #315 