### PR TITLE
fix: block publish on failed ipfs cover uploads

### DIFF
--- a/app/hunty/page.tsx
+++ b/app/hunty/page.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
 import { logger } from "@/lib/logger"
 import { Suspense, useState, useEffect, useRef } from "react"
 import { motion, AnimatePresence } from "framer-motion"
@@ -28,7 +27,8 @@ import { RewardsPanel } from "@/components/RewardsPanel"
 import { GamePreview } from "@/components/GamePreview"
 import { PublishModal } from "@/components/PublishModal"
 import ToggleButton from "@/components/ToggleButton"
-import type { HuntDraft, Reward } from "@/lib/types"
+import { COVER_IMAGE_UPLOAD_ERROR_MESSAGE } from "@/lib/ipfs"
+import type { CoverImageUploadState, HuntDraft, Reward } from "@/lib/types"
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { toast } from "sonner"
 import { downloadElementAsImage } from "@/lib/downloadAsImage"
@@ -58,6 +58,7 @@ function CreateGameContent() {
   const [timerEnabled, setTimerEnabled] = useState(false)
   const [isPrivate, setIsPrivate] = useState(false)
   const [isPublishing, setIsPublishing] = useState(false);
+  const [coverImageUploadStates, setCoverImageUploadStates] = useState<Record<number, CoverImageUploadState>>({})
   const [selectedTemplateTitle, setSelectedTemplateTitle] = useState<string | null>(null)
   const previewContainerRef = useRef<HTMLDivElement | null>(null)
   const appliedTemplateRef = useRef<string | null>(null)
@@ -101,6 +102,32 @@ function CreateGameContent() {
   }, [router, searchParams, setGameName, setHunts])
 
   const rewardPool = rewards.reduce((sum, r) => sum + r.amount, 0)
+
+  const setCoverImageUploadState = (huntId: number, state: CoverImageUploadState) => {
+    setCoverImageUploadStates((current) => {
+      if (state === "idle" || state === "succeeded") {
+        const next = { ...current }
+        delete next[huntId]
+        return next
+      }
+
+      return { ...current, [huntId]: state }
+    })
+  }
+
+  const getCoverImageUploadBlockMessage = () => {
+    const states = Object.values(coverImageUploadStates)
+
+    if (states.includes("uploading")) {
+      return "Please wait for the cover image upload to finish before publishing."
+    }
+
+    if (states.includes("failed")) {
+      return COVER_IMAGE_UPLOAD_ERROR_MESSAGE
+    }
+
+    return null
+  }
 
   const huntItemSchema = z.object({
     id: z.number(),
@@ -245,6 +272,11 @@ function CreateGameContent() {
   const removeHunt = (id: number) => {
     if (hunts.length > 1) {
       setHunts(hunts.filter((hunt) => hunt.id !== id));
+      setCoverImageUploadStates((current) => {
+        const next = { ...current }
+        delete next[id]
+        return next
+      })
     }
   };
 
@@ -257,6 +289,12 @@ function CreateGameContent() {
   };
 
   const handlePublish = async (formValues: z.infer<typeof formSchema>) => {
+    const coverImageUploadBlockMessage = getCoverImageUploadBlockMessage()
+    if (coverImageUploadBlockMessage) {
+      toast.error(coverImageUploadBlockMessage)
+      return
+    }
+
     if (!isFormValidated) {
       toast.error("Please fix validation issues before publishing the hunt.")
       return
@@ -429,6 +467,7 @@ function CreateGameContent() {
                             updateHunt(hunt.id, field, value)
                           }
                           onRemove={() => removeHunt(hunt.id)}
+                          onImageUploadStateChange={(state) => setCoverImageUploadState(hunt.id, state)}
                         />
                       ))}
 
@@ -715,6 +754,12 @@ function CreateGameContent() {
                         </Button>
                         <Button
                           onClick={() => {
+                            const coverImageUploadBlockMessage = getCoverImageUploadBlockMessage()
+                            if (coverImageUploadBlockMessage) {
+                              toast.error(coverImageUploadBlockMessage)
+                              return
+                            }
+
                             if (!isFormValidated) {
                               toast.error("Please fill all required hunt details before publishing.")
                               return

--- a/components/HuntForm.tsx
+++ b/components/HuntForm.tsx
@@ -12,10 +12,11 @@ import { addClue } from "@/lib/contracts/hunt"
 import { saveClueLocally, updateClueAnswer } from "@/lib/huntStore"
 import { sha256Hex } from "@/lib/crypto"
 import { withTransactionToast } from "@/lib/txToast"
-import { uploadToIPFS } from "@/lib/ipfs"
+import { COVER_IMAGE_UPLOAD_ERROR_MESSAGE, uploadToIPFS } from "@/lib/ipfs"
+import { logger } from "@/lib/logger"
 import { toast } from "sonner"
 import { HuntCards } from "./HuntCards"
-import type { HuntDraft } from "@/lib/types"
+import type { CoverImageUploadState, HuntDraft } from "@/lib/types"
 
 interface HuntFormProps {
   hunt: HuntDraft
@@ -23,6 +24,7 @@ interface HuntFormProps {
   onRemove: () => void
   huntId?: number
   onCluesSaved?: (count: number) => void
+  onImageUploadStateChange?: (state: CoverImageUploadState) => void
 }
 
 const clueSchema = z.object({
@@ -40,12 +42,13 @@ const cluesFormSchema = z.object({
 
 type CluesFormData = z.infer<typeof cluesFormSchema>
 
-export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: HuntFormProps) {
+export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onImageUploadStateChange }: HuntFormProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [isUploading, setIsUploading] = useState(false)
   const [isSavingClues, setIsSavingClues] = useState(false)
   const [showPreview, setShowPreview] = useState(false)
   const [linkEnabled, setLinkEnabled] = useState(false)
+  const [imageUploadState, setImageUploadState] = useState<CoverImageUploadState>("idle")
 
   const {
     control,
@@ -64,20 +67,40 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
     name: "clues",
   })
 
+  const updateImageUploadState = (state: CoverImageUploadState) => {
+    setImageUploadState(state)
+    onImageUploadStateChange?.(state)
+  }
+
   const handleImageUpload = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
 
+    updateImageUploadState("uploading")
     setIsUploading(true)
 
     try {
       const ipfsUri = await uploadToIPFS(file)
-      onUpdate('image', ipfsUri)
+      onUpdate("image", ipfsUri)
+      updateImageUploadState("succeeded")
     } catch (error) {
-      logger.error('Error uploading image to IPFS:', error)
-      toast.error(error instanceof Error ? error.message : 'Image upload failed')
+      logger.error("Error uploading image to IPFS:", error)
+      updateImageUploadState("failed")
+      toast.error(COVER_IMAGE_UPLOAD_ERROR_MESSAGE)
     } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ""
+      }
       setIsUploading(false)
+    }
+  }
+
+  const handleClearImage = () => {
+    onUpdate("image", "")
+    updateImageUploadState("idle")
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""
     }
   }
 
@@ -234,6 +257,22 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved }: Hun
           )}
         </div>
       </div>
+      {(hunt.image || imageUploadState === "failed") && (
+        <div className="flex items-center justify-between gap-3 text-sm">
+          <span className={imageUploadState === "failed" ? "text-red-500" : "text-slate-500 dark:text-slate-400"}>
+            {imageUploadState === "failed" ? "Cover image upload failed." : "Cover image attached."}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleClearImage}
+            className="h-auto px-0 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            {hunt.image ? "Remove cover image" : "Skip cover image"}
+          </Button>
+        </div>
+      )}
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">

--- a/components/__tests__/HuntForm.imageUpload.test.tsx
+++ b/components/__tests__/HuntForm.imageUpload.test.tsx
@@ -1,0 +1,98 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { HuntForm } from "../HuntForm"
+import type { HuntDraft } from "@/lib/types"
+
+const { loggerError, toastError, uploadToIPFSMock } = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+  toastError: vi.fn(),
+  uploadToIPFSMock: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: vi.fn() },
+}))
+
+vi.mock("@/lib/ipfs", () => ({
+  COVER_IMAGE_UPLOAD_ERROR_MESSAGE: "Failed to upload cover image. Please try again.",
+  uploadToIPFS: uploadToIPFSMock,
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: loggerError, warn: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock("@/lib/contracts/hunt", () => ({
+  addClue: vi.fn().mockResolvedValue({ success: true }),
+}))
+
+vi.mock("@/lib/huntStore", () => ({
+  saveClueLocally: vi.fn().mockReturnValue(1),
+  updateClueAnswer: vi.fn(),
+}))
+
+vi.mock("@/lib/crypto", () => ({
+  sha256Hex: vi.fn().mockResolvedValue("mockhash"),
+}))
+
+vi.mock("@/lib/txToast", () => ({
+  withTransactionToast: vi.fn().mockImplementation(async (fn: Function) => fn(() => {})),
+}))
+
+vi.mock("@/components/HuntCards", () => ({
+  HuntCards: () => <div data-testid="hunt-cards-preview" />,
+}))
+
+const baseHunt: HuntDraft = {
+  id: 1,
+  title: "Test Hunt",
+  description: "A test description",
+  link: "",
+  code: "",
+}
+
+describe("HuntForm cover image uploads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the expected toast and blocks the upload state until the user skips after a failed upload", async () => {
+    uploadToIPFSMock.mockRejectedValueOnce(new Error("PINATA_JWT missing"))
+
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+    const onImageUploadStateChange = vi.fn()
+
+    const { container } = render(
+      <HuntForm
+        hunt={baseHunt}
+        onUpdate={onUpdate}
+        onRemove={vi.fn()}
+        onImageUploadStateChange={onImageUploadStateChange}
+      />
+    )
+
+    const fileInput = container.querySelector('input[type="file"]')
+    expect(fileInput).not.toBeNull()
+
+    await user.upload(fileInput as HTMLInputElement, new File(["cover"], "cover.png", { type: "image/png" }))
+
+    await waitFor(() => {
+      expect(uploadToIPFSMock).toHaveBeenCalledTimes(1)
+      expect(toastError).toHaveBeenCalledWith("Failed to upload cover image. Please try again.")
+    })
+
+    expect(loggerError).toHaveBeenCalled()
+    expect(onUpdate).not.toHaveBeenCalledWith("image", expect.any(String))
+    expect(onImageUploadStateChange).toHaveBeenNthCalledWith(1, "uploading")
+    expect(onImageUploadStateChange).toHaveBeenNthCalledWith(2, "failed")
+
+    await user.click(screen.getByRole("button", { name: /skip cover image/i }))
+
+    expect(onUpdate).toHaveBeenCalledWith("image", "")
+    expect(onImageUploadStateChange).toHaveBeenLastCalledWith("idle")
+  })
+})

--- a/lib/ipfs.ts
+++ b/lib/ipfs.ts
@@ -8,6 +8,7 @@
  */
 
 const PINATA_GATEWAY = process.env.NEXT_PUBLIC_PINATA_GATEWAY
+export const COVER_IMAGE_UPLOAD_ERROR_MESSAGE = "Failed to upload cover image. Please try again."
 
 // Ordered list of public fallback gateways.
 const GATEWAYS: string[] = [
@@ -77,6 +78,11 @@ export async function uploadToIPFS(file: File): Promise<string> {
     throw new Error(err.error ?? "IPFS upload failed")
   }
 
-  const { cid } = await res.json() as { cid: string }
+  const data = await res.json().catch(() => null) as { cid?: string } | null
+  const cid = data?.cid?.trim()
+  if (!cid) {
+    throw new Error("IPFS upload response did not include a CID")
+  }
+
   return `ipfs://${cid}`
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -219,6 +219,8 @@ export interface HuntDraft {
   image?: string
 }
 
+export type CoverImageUploadState = "idle" | "uploading" | "succeeded" | "failed"
+
 // ─── Player Count ────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Closes: #316 

## Summary
- show a Sonner error toast when cover image upload fails
- reject malformed `/api/ipfs` success responses that do not include a CID
- block publishing while a cover image upload is still in progress or after it fails
- let creators explicitly skip/remove the cover image before publishing
- add a regression test for the failed upload flow

