### PR TITLE
feat: Add Native Mobile Push Notification System via Expo (#360)

### DIFF
--- a/mobile/__mocks__/config/env.js
+++ b/mobile/__mocks__/config/env.js
@@ -1,0 +1,11 @@
+module.exports = {
+  default: {
+    apiUrl: 'http://localhost:3000/api',
+    graphqlUrl: 'http://localhost:4000/graphql',
+    stellarRpcUrl: 'https://soroban-testnet.stellar.org',
+    stellarNetwork: 'testnet',
+    environment: 'development',
+  },
+};
+// Support both default and named import styles
+module.exports.default = module.exports.default || module.exports;

--- a/mobile/__mocks__/expo-constants.js
+++ b/mobile/__mocks__/expo-constants.js
@@ -1,0 +1,10 @@
+module.exports = {
+  default: {
+    expoConfig: {
+      extra: {
+        eas: { projectId: 'test-project-id' },
+        walletConnectProjectId: 'test-wc-id',
+      },
+    },
+  },
+};

--- a/mobile/__mocks__/expo-device.js
+++ b/mobile/__mocks__/expo-device.js
@@ -1,0 +1,4 @@
+module.exports = {
+  isDevice: true,
+  DeviceType: { PHONE: 1, TABLET: 2 },
+};

--- a/mobile/__mocks__/expo-modules-core.js
+++ b/mobile/__mocks__/expo-modules-core.js
@@ -1,0 +1,11 @@
+module.exports = {
+  NativeModulesProxy: {},
+  EventEmitter: class EventEmitter {
+    addListener() { return { remove: jest.fn() }; }
+    removeAllListeners() {}
+    emit() {}
+  },
+  requireNativeModule: jest.fn(() => ({})),
+  requireOptionalNativeModule: jest.fn(() => null),
+  Platform: { OS: 'ios' },
+};

--- a/mobile/__mocks__/expo-notifications.js
+++ b/mobile/__mocks__/expo-notifications.js
@@ -1,0 +1,14 @@
+/**
+ * Manual mock for expo-notifications in the Jest environment.
+ */
+module.exports = {
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn(),
+  addNotificationReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  getLastNotificationResponseAsync: jest.fn(() => Promise.resolve(null)),
+  setNotificationChannelAsync: jest.fn(),
+  AndroidImportance: { HIGH: 'HIGH', DEFAULT: 'DEFAULT', LOW: 'LOW' },
+};

--- a/mobile/__mocks__/expo-secure-store.js
+++ b/mobile/__mocks__/expo-secure-store.js
@@ -1,0 +1,5 @@
+module.exports = {
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+};

--- a/mobile/__mocks__/expo-virtual-env.js
+++ b/mobile/__mocks__/expo-virtual-env.js
@@ -1,0 +1,1 @@
+module.exports = { env: process.env };

--- a/mobile/__mocks__/expo.js
+++ b/mobile/__mocks__/expo.js
@@ -1,0 +1,3 @@
+module.exports = {
+  isRunningInExpoGo: jest.fn(() => false),
+};

--- a/mobile/__mocks__/fileMock.js
+++ b/mobile/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/mobile/__mocks__/jestSetup.js
+++ b/mobile/__mocks__/jestSetup.js
@@ -1,0 +1,2 @@
+// Define React Native globals for the Jest environment
+global.__DEV__ = true;

--- a/mobile/__tests__/notifications/notificationService.test.ts
+++ b/mobile/__tests__/notifications/notificationService.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for notificationService — permission helpers and payload extraction.
+ */
+
+import * as Notifications from 'expo-notifications';
+import {
+  getPermissionStatus,
+  requestPermission,
+  configureNotificationHandler,
+  extractPayload,
+  extractResponsePayload,
+} from '../../services/notifications/notificationService';
+
+jest.mock('expo-notifications');
+jest.mock('expo-device', () => ({ isDevice: true }));
+
+const mockNotifications = Notifications as jest.Mocked<typeof Notifications>;
+
+describe('getPermissionStatus', () => {
+  it('returns granted when permission is granted', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'granted',
+      granted: true,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    const status = await getPermissionStatus();
+    expect(status).toBe('granted');
+  });
+
+  it('returns denied when permission is denied', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'denied',
+      granted: false,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: false,
+    });
+    const status = await getPermissionStatus();
+    expect(status).toBe('denied');
+  });
+
+  it('returns undetermined when not yet asked', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'undetermined',
+      granted: false,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    const status = await getPermissionStatus();
+    expect(status).toBe('undetermined');
+  });
+});
+
+describe('requestPermission', () => {
+  it('returns granted without prompting if already granted', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'granted',
+      granted: true,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    const result = await requestPermission();
+    expect(result).toBe('granted');
+    expect(mockNotifications.requestPermissionsAsync).not.toHaveBeenCalled();
+  });
+
+  it('calls requestPermissionsAsync when not yet granted', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'undetermined',
+      granted: false,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    mockNotifications.requestPermissionsAsync.mockResolvedValueOnce({
+      status: 'granted',
+      granted: true,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    const result = await requestPermission();
+    expect(result).toBe('granted');
+    expect(mockNotifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns denied when user denies the prompt', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'undetermined',
+      granted: false,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    mockNotifications.requestPermissionsAsync.mockResolvedValueOnce({
+      status: 'denied',
+      granted: false,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: false,
+    });
+    const result = await requestPermission();
+    expect(result).toBe('denied');
+  });
+});
+
+describe('configureNotificationHandler', () => {
+  it('calls setNotificationHandler', () => {
+    configureNotificationHandler();
+    expect(mockNotifications.setNotificationHandler).toHaveBeenCalledTimes(1);
+    const [handler] = mockNotifications.setNotificationHandler.mock.calls[0];
+    expect(handler).toHaveProperty('handleNotification');
+  });
+
+  it('handler resolves with shouldShowAlert=true', async () => {
+    configureNotificationHandler();
+    const [handler] = mockNotifications.setNotificationHandler.mock.calls[0];
+    const options = await handler.handleNotification({} as Notifications.Notification);
+    expect(options.shouldShowAlert).toBe(true);
+    expect(options.shouldPlaySound).toBe(true);
+    expect(options.shouldSetBadge).toBe(true);
+  });
+});
+
+describe('extractPayload', () => {
+  const makeNotification = (data: Record<string, unknown>): Notifications.Notification =>
+    ({
+      request: { content: { data } },
+    } as unknown as Notifications.Notification);
+
+  it('returns null for missing data', () => {
+    expect(extractPayload(makeNotification({}))).toBeNull();
+  });
+
+  it('returns null when type field is missing', () => {
+    expect(extractPayload(makeNotification({ huntId: 1 }))).toBeNull();
+  });
+
+  it('returns the typed payload for hunt_start', () => {
+    const data = { type: 'hunt_start', huntId: 42, huntTitle: 'City Secrets' };
+    const result = extractPayload(makeNotification(data));
+    expect(result).toEqual(data);
+  });
+
+  it('returns the typed payload for correct_answer', () => {
+    const data = { type: 'correct_answer', huntId: 5, huntTitle: 'Campus Quest', score: 80 };
+    const result = extractPayload(makeNotification(data));
+    expect(result).toEqual(data);
+  });
+});
+
+describe('extractResponsePayload', () => {
+  it('extracts payload from a notification response', () => {
+    const data = { type: 'leaderboard_outranked', huntId: 3, huntTitle: 'Sprint', currentRank: 2 };
+    const response = {
+      notification: { request: { content: { data } } },
+    } as unknown as Notifications.NotificationResponse;
+    const result = extractResponsePayload(response);
+    expect(result).toEqual(data);
+  });
+});

--- a/mobile/__tests__/notifications/tokenRegistry.test.ts
+++ b/mobile/__tests__/notifications/tokenRegistry.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for tokenRegistry — push token retrieval, registration, and cleanup.
+ */
+
+import * as Notifications from 'expo-notifications';
+import * as SecureStore from 'expo-secure-store';
+import { registerPushToken, unregisterPushToken, getExpoPushToken } from '../../services/notifications/tokenRegistry';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('expo-notifications');
+jest.mock('expo-device');
+jest.mock('expo-secure-store');
+jest.mock('expo-constants');
+
+const mockNotifications = Notifications as jest.Mocked<typeof Notifications>;
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+
+// Spy on global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetch.mockResolvedValue({ ok: true, status: 200 });
+  mockSecureStore.getItemAsync.mockResolvedValue(null);
+  mockSecureStore.setItemAsync.mockResolvedValue(undefined);
+  mockSecureStore.deleteItemAsync.mockResolvedValue(undefined);
+  // Default: permission granted
+  mockNotifications.getPermissionsAsync.mockResolvedValue({
+    status: 'granted',
+    granted: true,
+    expires: 'never',
+    ios: undefined,
+    canAskAgain: true,
+  } as any);
+  mockNotifications.getExpoPushTokenAsync.mockResolvedValue({
+    data: 'ExponentPushToken[default-token]',
+    type: 'expo',
+  } as any);
+});
+
+// ─── getExpoPushToken ──────────────────────────────────────────────────────────
+
+describe('getExpoPushToken', () => {
+  it('returns null when Device.isDevice is false (simulator)', async () => {
+    // No way to override the module-level isDevice in Jest without re-mocking,
+    // so test the observable outcome: when permission check returns no status we bail
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({ status: 'denied' } as any);
+    const token = await getExpoPushToken();
+    expect(token).toBeNull();
+    expect(mockNotifications.getExpoPushTokenAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns null when permission is not granted', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'denied',
+      granted: false,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: false,
+    });
+    const token = await getExpoPushToken();
+    expect(token).toBeNull();
+  });
+
+  it('returns the token string when permission is granted', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'granted',
+      granted: true,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    mockNotifications.getExpoPushTokenAsync.mockResolvedValueOnce({
+      data: 'ExponentPushToken[test-token-123]',
+      type: 'expo',
+    });
+    const token = await getExpoPushToken();
+    expect(token).toBe('ExponentPushToken[test-token-123]');
+  });
+
+  it('returns null when getExpoPushTokenAsync throws', async () => {
+    mockNotifications.getPermissionsAsync.mockResolvedValueOnce({
+      status: 'granted',
+      granted: true,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    mockNotifications.getExpoPushTokenAsync.mockRejectedValueOnce(new Error('SDK error'));
+    const token = await getExpoPushToken();
+    expect(token).toBeNull();
+  });
+});
+
+// ─── registerPushToken ────────────────────────────────────────────────────────
+
+describe('registerPushToken', () => {
+  const walletAddress = 'GTEST123';
+
+  beforeEach(() => {
+    // Default: permission granted, token available
+    mockNotifications.getPermissionsAsync.mockResolvedValue({
+      status: 'granted',
+      granted: true,
+      expires: 'never',
+      ios: undefined,
+      canAskAgain: true,
+    });
+    mockNotifications.getExpoPushTokenAsync.mockResolvedValue({
+      data: 'ExponentPushToken[abc]',
+      type: 'expo',
+    });
+  });
+
+  it('does nothing when walletAddress is empty', async () => {
+    await registerPushToken('');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('registers token with backend and persists it', async () => {
+    await registerPushToken(walletAddress);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/push-tokens'),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining(walletAddress),
+      }),
+    );
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      'hunty_push_token',
+      'ExponentPushToken[abc]',
+    );
+  });
+
+  it('skips backend call when token + wallet are already stored', async () => {
+    // Simulate stored token matching current token + wallet
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'hunty_push_token') return 'ExponentPushToken[abc]';
+      if (key === 'hunty_push_token_wallet') return walletAddress;
+      return null;
+    });
+    await registerPushToken(walletAddress);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('re-registers when wallet changes', async () => {
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'hunty_push_token') return 'ExponentPushToken[abc]';
+      if (key === 'hunty_push_token_wallet') return 'OLD_WALLET';
+      return null;
+    });
+    await registerPushToken(walletAddress);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when backend registration fails after retries', async () => {
+    mockFetch.mockRejectedValue(new Error('Network offline'));
+    await expect(registerPushToken(walletAddress)).resolves.not.toThrow();
+  });
+
+  it('treats HTTP 409 as success (already registered)', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 409 });
+    await expect(registerPushToken(walletAddress)).resolves.not.toThrow();
+  });
+});
+
+// ─── unregisterPushToken ─────────────────────────────────────────────────────
+
+describe('unregisterPushToken', () => {
+  it('clears local storage even when backend call fails', async () => {
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'hunty_push_token') return 'ExponentPushToken[abc]';
+      if (key === 'hunty_push_token_wallet') return 'GTEST123';
+      return null;
+    });
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    await unregisterPushToken();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('hunty_push_token');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('hunty_push_token_wallet');
+  });
+
+  it('calls DELETE on the backend with stored token and wallet', async () => {
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'hunty_push_token') return 'ExponentPushToken[xyz]';
+      if (key === 'hunty_push_token_wallet') return 'GWALLET456';
+      return null;
+    });
+    await unregisterPushToken();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/push-tokens'),
+      expect.objectContaining({
+        method: 'DELETE',
+        body: expect.stringContaining('GWALLET456'),
+      }),
+    );
+  });
+
+  it('does not call backend when no stored token exists', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    await unregisterPushToken();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/__tests__/notifications/types.test.ts
+++ b/mobile/__tests__/notifications/types.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for notification payload types and navigation target resolution.
+ */
+
+import { resolveNavTarget } from '../../services/notifications/types';
+import type {
+  HuntStartPayload,
+  CorrectAnswerPayload,
+  LeaderboardOutrankedPayload,
+  HuntEndingSoonPayload,
+} from '../../services/notifications/types';
+
+describe('resolveNavTarget', () => {
+  it('routes hunt_start to /hunt/:id', () => {
+    const payload: HuntStartPayload = {
+      type: 'hunt_start',
+      huntId: 10,
+      huntTitle: 'City Secrets',
+    };
+    expect(resolveNavTarget(payload)).toEqual({ path: '/hunt/10' });
+  });
+
+  it('routes correct_answer to /hunt/:id', () => {
+    const payload: CorrectAnswerPayload = {
+      type: 'correct_answer',
+      huntId: 5,
+      huntTitle: 'Campus Quest',
+      score: 100,
+    };
+    expect(resolveNavTarget(payload)).toEqual({ path: '/hunt/5' });
+  });
+
+  it('routes leaderboard_outranked to /hunt/:id', () => {
+    const payload: LeaderboardOutrankedPayload = {
+      type: 'leaderboard_outranked',
+      huntId: 3,
+      huntTitle: 'Sprint',
+      currentRank: 2,
+      overtakenBy: 'GUSER789',
+    };
+    expect(resolveNavTarget(payload)).toEqual({ path: '/hunt/3' });
+  });
+
+  it('routes hunt_ending_soon to /hunt/:id', () => {
+    const payload: HuntEndingSoonPayload = {
+      type: 'hunt_ending_soon',
+      huntId: 42,
+      huntTitle: 'Museum Mystery',
+      minutesRemaining: 30,
+    };
+    expect(resolveNavTarget(payload)).toEqual({ path: '/hunt/42' });
+  });
+});

--- a/mobile/__tests__/notifications/useNotifications.test.ts
+++ b/mobile/__tests__/notifications/useNotifications.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the useNotifications hook — permission flow and token registration.
+ */
+
+import { renderHook, act } from '@testing-library/react-native';
+import { useNotifications } from '../../hooks/useNotifications';
+import * as notificationService from '../../services/notifications/notificationService';
+import * as tokenRegistry from '../../services/notifications/tokenRegistry';
+
+jest.mock('../../services/notifications/notificationService');
+jest.mock('../../services/notifications/tokenRegistry');
+
+const mockGetPermissionStatus = notificationService.getPermissionStatus as jest.MockedFunction<
+  typeof notificationService.getPermissionStatus
+>;
+const mockRequestPermission = notificationService.requestPermission as jest.MockedFunction<
+  typeof notificationService.requestPermission
+>;
+const mockRegisterPushToken = tokenRegistry.registerPushToken as jest.MockedFunction<
+  typeof tokenRegistry.registerPushToken
+>;
+const mockUnregisterPushToken = tokenRegistry.unregisterPushToken as jest.MockedFunction<
+  typeof tokenRegistry.unregisterPushToken
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPermissionStatus.mockResolvedValue('undetermined');
+  mockRequestPermission.mockResolvedValue('granted');
+  mockRegisterPushToken.mockResolvedValue(undefined);
+  mockUnregisterPushToken.mockResolvedValue(undefined);
+});
+
+describe('initial state', () => {
+  it('starts with loading=true while hydrating', () => {
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('sets enabled=false when permission is undetermined', async () => {
+    mockGetPermissionStatus.mockResolvedValue('undetermined');
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.permissionStatus).toBe('undetermined');
+  });
+
+  it('sets enabled=true when permission is granted', async () => {
+    mockGetPermissionStatus.mockResolvedValue('granted');
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('sets enabled=false when permission is denied', async () => {
+    mockGetPermissionStatus.mockResolvedValue('denied');
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.permissionStatus).toBe('denied');
+  });
+});
+
+describe('toggle', () => {
+  it('requests permission when toggling on from undetermined', async () => {
+    mockGetPermissionStatus.mockResolvedValue('undetermined');
+    mockRequestPermission.mockResolvedValue('granted');
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.toggle(true);
+    });
+
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1);
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.permissionStatus).toBe('granted');
+  });
+
+  it('reflects denied status after user refuses the prompt', async () => {
+    mockGetPermissionStatus.mockResolvedValue('undetermined');
+    mockRequestPermission.mockResolvedValue('denied');
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.toggle(true);
+    });
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.permissionStatus).toBe('denied');
+  });
+
+  it('does not call requestPermission when toggling off', async () => {
+    mockGetPermissionStatus.mockResolvedValue('granted');
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.toggle(false);
+    });
+
+    expect(mockRequestPermission).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerForWallet', () => {
+  it('delegates to registerPushToken with the wallet address', async () => {
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.registerForWallet('GWALLET123');
+    });
+
+    expect(mockRegisterPushToken).toHaveBeenCalledWith('GWALLET123');
+  });
+});
+
+describe('unregister', () => {
+  it('delegates to unregisterPushToken', async () => {
+    const { result } = renderHook(() => useNotifications());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.unregister();
+    });
+
+    expect(mockUnregisterPushToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -65,6 +65,7 @@
     },
     "plugins": [
       "expo-router",
+      "expo-notifications",
       [
         "expo-location",
         {

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -11,6 +11,7 @@ import ReactQueryProvider from '@providers/ReactQueryProvider';
 import { ToastProvider, useToast } from '@providers/ToastProvider';
 import { Web3Provider } from '@providers/Web3Provider';
 import { ModalProvider } from '@providers/ModalProvider';
+import { NotificationsProvider } from '@providers/NotificationsProvider';
 import { ThemedButton, ThemedCustomText } from '@components/themed';
 import { useFonts } from '@app/hooks/useFonts';
 import { useBackHandler } from '@hooks/useBackHandler';
@@ -63,7 +64,9 @@ export default function RootLayout() {
           <Web3Provider>
             <ToastProvider>
               <ModalProvider>
-                <RootLayoutNav />
+                <NotificationsProvider>
+                  <RootLayoutNav />
+                </NotificationsProvider>
               </ModalProvider>
             </ToastProvider>
           </Web3Provider>

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,26 +1,31 @@
 module.exports = function (api) {
-  api.cache(true);
+  const isTest = api.env('test');
+  api.cache.using(() => isTest);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      [
-        'module-resolver',
-        {
-          root: ['.'],
-          alias: {
-            '@': './',
-            '@lib': '../lib',
-            '@store': './store',
-            '@providers': './providers',
-            '@components': './components',
-            '@utils': './utils',
-            '@config': './config',
-            '@services': './services',
-          },
-        },
-      ],
-      'nativewind/babel',
-      'react-native-reanimated/plugin',
-    ],
+    plugins: isTest
+      ? []
+      : [
+          [
+            'module-resolver',
+            {
+              root: ['.'],
+              alias: {
+                '@': './',
+                '@lib': '../lib',
+                '@store': './store',
+                '@providers': './providers',
+                '@components': './components',
+                '@utils': './utils',
+                '@config': './config',
+                '@services': './services',
+                '@hooks': './hooks',
+                '@app': './app',
+              },
+            },
+          ],
+          'nativewind/babel',
+          'react-native-reanimated/plugin',
+        ],
   };
 };

--- a/mobile/babel.config.test.js
+++ b/mobile/babel.config.test.js
@@ -1,0 +1,24 @@
+/** Minimal Babel config used only during Jest runs. */
+module.exports = {
+  presets: ['babel-preset-expo'],
+  plugins: [
+    [
+      'module-resolver',
+      {
+        root: ['.'],
+        alias: {
+          '@': './',
+          '@lib': '../lib',
+          '@store': './store',
+          '@providers': './providers',
+          '@components': './components',
+          '@utils': './utils',
+          '@config': './config',
+          '@services': './services',
+          '@hooks': './hooks',
+          '@app': './app',
+        },
+      },
+    ],
+  ],
+};

--- a/mobile/hooks/useNotifications.ts
+++ b/mobile/hooks/useNotifications.ts
@@ -1,23 +1,98 @@
-import { useState, useEffect } from "react";
-import * as Notifications from "expo-notifications";
+/**
+ * useNotifications hook
+ *
+ * Exposes permission state and a toggle for the Settings screen.
+ * Also drives token registration whenever wallet connection is detected.
+ *
+ * Usage:
+ *   const { enabled, permissionStatus, toggle, registerForWallet } = useNotifications();
+ */
 
-export function useNotifications() {
-  const [enabled, setEnabled] = useState(false);
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getPermissionStatus,
+  requestPermission,
+  type PermissionStatus,
+} from '@services/notifications/notificationService';
+import { registerPushToken, unregisterPushToken } from '@services/notifications/tokenRegistry';
 
+export interface UseNotificationsResult {
+  /** Whether push notifications are currently enabled (permission granted). */
+  enabled: boolean;
+  /** The raw permission status: 'granted' | 'denied' | 'undetermined'. */
+  permissionStatus: PermissionStatus;
+  /** Loading state while permission check or request is in progress. */
+  loading: boolean;
+  /**
+   * Toggle handler for the settings switch.
+   * Requesting permission (value=true) prompts the OS dialog.
+   * Disabling (value=false) only updates local state — OS permissions cannot be
+   * revoked programmatically; users must visit device settings.
+   */
+  toggle: (value: boolean) => Promise<void>;
+  /**
+   * Register the device push token for a given wallet address.
+   * Safe to call on every wallet connect — skips the backend call if the token
+   * is already registered for the same wallet.
+   */
+  registerForWallet: (walletAddress: string) => Promise<void>;
+  /** Unregister the token (call on wallet disconnect). */
+  unregister: () => Promise<void>;
+}
+
+export function useNotifications(): UseNotificationsResult {
+  const [permissionStatus, setPermissionStatus] = useState<PermissionStatus>('undetermined');
+  const [loading, setLoading] = useState(true);
+
+  // Hydrate permission state on mount
   useEffect(() => {
-    Notifications.getPermissionsAsync().then(({ status }) => {
-      setEnabled(status === "granted");
-    });
+    let cancelled = false;
+    getPermissionStatus()
+      .then((status) => {
+        if (!cancelled) setPermissionStatus(status);
+      })
+      .catch(() => {
+        if (!cancelled) setPermissionStatus('undetermined');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const toggle = async (value: boolean) => {
-    if (value) {
-      const { status } = await Notifications.requestPermissionsAsync();
-      setEnabled(status === "granted");
-    } else {
-      setEnabled(false);
+  const toggle = useCallback(async (value: boolean) => {
+    if (!value) {
+      // We can't revoke OS permission — just reflect the current OS state
+      const status = await getPermissionStatus();
+      setPermissionStatus(status);
+      return;
     }
-  };
 
-  return { enabled, toggle };
+    setLoading(true);
+    try {
+      const status = await requestPermission();
+      setPermissionStatus(status);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const registerForWallet = useCallback(async (walletAddress: string) => {
+    await registerPushToken(walletAddress);
+  }, []);
+
+  const unregister = useCallback(async () => {
+    await unregisterPushToken();
+  }, []);
+
+  return {
+    enabled: permissionStatus === 'granted',
+    permissionStatus,
+    loading,
+    toggle,
+    registerForWallet,
+    unregister,
+  };
 }

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -1,0 +1,34 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  // Don't use jest-expo preset — expo-modules-core is not fully installed.
+  // We configure transforms manually below.
+  testEnvironment: 'node',
+
+  setupFiles: ['<rootDir>/__mocks__/jestSetup.js'],
+
+  transform: {
+    '^.+\\.[jt]sx?$': ['babel-jest', { configFile: require('path').resolve(__dirname, 'babel.config.js') }],
+  },
+
+  // Transform expo/* packages since they ship ESM
+  transformIgnorePatterns: [
+    'node_modules/(?!(expo|@expo|expo-notifications|expo-device|expo-constants|expo-secure-store|expo-modules-core|react-native|@react-native))',
+  ],
+
+  // Manual mocks for native/expo modules
+  moduleNameMapper: {
+    '^@config/(.*)$': '<rootDir>/config/$1',
+    '^@services/(.*)$': '<rootDir>/services/$1',
+    '^@hooks/(.*)$': '<rootDir>/hooks/$1',
+    '^@store/(.*)$': '<rootDir>/store/$1',
+    '^@providers/(.*)$': '<rootDir>/providers/$1',
+    '^@lib/(.*)$': '<rootDir>/../lib/$1',
+    '^@utils/(.*)$': '<rootDir>/utils/$1',
+    '^@components/(.*)$': '<rootDir>/components/$1',
+    '^@/(.*)$': '<rootDir>/$1',
+    // Mock assets
+    '\\.(png|jpg|jpeg|gif|svg|ico|webp|ttf|otf)$': '<rootDir>/__mocks__/fileMock.js',
+  },
+
+  testMatch: ['**/__tests__/**/*.test.{ts,tsx}'],
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -7,6 +7,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
+    "lint": "expo lint",
+    "test": "jest --passWithNoTests",
     "store:validate": "node scripts/validate-store-metadata.js"
   },
   "dependencies": {
@@ -54,8 +56,13 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@testing-library/react-native": "^12.9.0",
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.1.17",
+    "babel-jest": "^29.7.0",
     "babel-plugin-module-resolver": "^5.0.0",
+    "jest": "^29.7.0",
+    "jest-expo": "~55.0.5",
     "nativewind": "^4.1.23",
     "tailwindcss": "3.4.17",
     "typescript": "~5.9.3"

--- a/mobile/providers/NotificationsProvider.tsx
+++ b/mobile/providers/NotificationsProvider.tsx
@@ -1,0 +1,98 @@
+/**
+ * NotificationsProvider
+ *
+ * Centralises all expo-notifications subscription management:
+ *  - Configures the notification handler on mount.
+ *  - Listens for incoming notifications (foreground + background).
+ *  - Listens for notification taps and drives deep-link navigation.
+ *  - Handles the last-response that arrived before the app opened (cold-start).
+ *  - Cleans up all subscriptions on unmount.
+ *
+ * Wrap this provider inside Web3Provider so wallet state is available when
+ * handling navigation targets.
+ */
+
+import React, { createContext, useContext, useEffect, useRef } from 'react';
+import * as Notifications from 'expo-notifications';
+import { useRouter } from 'expo-router';
+import {
+  configureNotificationHandler,
+  ensureAndroidChannel,
+  extractPayload,
+  extractResponsePayload,
+} from '@services/notifications/notificationService';
+import { resolveNavTarget } from '@services/notifications/types';
+
+// ─── Context (exposed for convenience hooks) ──────────────────────────────────
+
+interface NotificationsContextValue {
+  /** Shortcut to check if a subscription is active — always true while mounted */
+  isListening: boolean;
+}
+
+const NotificationsContext = createContext<NotificationsContextValue>({ isListening: false });
+
+export function useNotificationsContext(): NotificationsContextValue {
+  return useContext(NotificationsContext);
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const router = useRouter();
+  const isListeningRef = useRef(false);
+
+  useEffect(() => {
+    // Configure handler as early as possible so foreground notifications show
+    configureNotificationHandler();
+
+    // Ensure Android channel exists
+    void ensureAndroidChannel();
+
+    isListeningRef.current = true;
+
+    // ── Foreground notification listener ──────────────────────────────────
+    const receiveSubscription = Notifications.addNotificationReceivedListener((notification) => {
+      const payload = extractPayload(notification);
+      if (__DEV__) console.log('[Notifications] Received:', payload);
+    });
+
+    // ── Tap / interaction listener ────────────────────────────────────────
+    const responseSubscription = Notifications.addNotificationResponseReceivedListener(
+      (response) => {
+        const payload = extractResponsePayload(response);
+        if (!payload) return;
+        const { path } = resolveNavTarget(payload);
+        if (__DEV__) console.log('[Notifications] Tapped → navigating to:', path);
+        router.push(path as Parameters<typeof router.push>[0]);
+      },
+    );
+
+    // ── Cold-start: handle the last notification the user tapped before ───
+    // ── the app was fully open ────────────────────────────────────────────
+    Notifications.getLastNotificationResponseAsync()
+      .then((response) => {
+        if (!response) return;
+        const payload = extractResponsePayload(response);
+        if (!payload) return;
+        const { path } = resolveNavTarget(payload);
+        if (__DEV__) console.log('[Notifications] Cold-start → navigating to:', path);
+        router.push(path as Parameters<typeof router.push>[0]);
+      })
+      .catch(() => {
+        // Non-critical — ignore failures
+      });
+
+    return () => {
+      receiveSubscription.remove();
+      responseSubscription.remove();
+      isListeningRef.current = false;
+    };
+  }, [router]);
+
+  return (
+    <NotificationsContext.Provider value={{ isListening: isListeningRef.current }}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};

--- a/mobile/providers/Web3Provider.tsx
+++ b/mobile/providers/Web3Provider.tsx
@@ -3,6 +3,7 @@ import SignClient from '@walletconnect/sign-client';
 import Constants from 'expo-constants';
 import { useWalletStore } from '@store/useStore';
 import { saveSession, loadSession, clearSession } from '@services/walletSession';
+import { registerPushToken, unregisterPushToken } from '@services/notifications/tokenRegistry';
 
 type SessionInfo = {
   topic: string;
@@ -59,6 +60,8 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
         setSession({ topic: persisted.topic, publicKey: persisted.publicKey, network: persisted.network });
         setWallet(persisted.publicKey);
         setNetwork(persisted.network.includes('main') ? 'mainnet' : 'testnet');
+        // #360 — Refresh token registration after session restore
+        void registerPushToken(persisted.publicKey);
       }
     };
     void restorePersistedSession();
@@ -182,6 +185,8 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
         setNetwork(net.includes('main') ? 'mainnet' : 'testnet');
         // #189 — Persist new session so it survives app restarts
         void saveSession(sessionInfo);
+        // #360 — Register push token after wallet connect
+        void registerPushToken(pubKey);
       }
     } finally {
       if (mountedRef.current) {
@@ -210,6 +215,8 @@ export const Web3Provider: React.FC<{ children: React.ReactNode }> = ({ children
       clearWallet();
       // #189 — Remove persisted session on explicit user disconnect
       void clearSession();
+      // #360 — Unregister push token on wallet disconnect
+      void unregisterPushToken();
     }
   }, [session, clearWallet]);
 

--- a/mobile/services/notifications/index.ts
+++ b/mobile/services/notifications/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './notificationService';
+export * from './tokenRegistry';

--- a/mobile/services/notifications/notificationService.ts
+++ b/mobile/services/notifications/notificationService.ts
@@ -1,0 +1,96 @@
+/**
+ * Central notification service for Hunty Mobile.
+ *
+ * Configures the expo-notifications handler (foreground behaviour), provides
+ * permission request helpers, and exposes notification listener utilities that
+ * the NotificationsProvider consumes.
+ */
+
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import type { NotificationPayload } from './types';
+
+// ─── Handler configuration ────────────────────────────────────────────────────
+
+/**
+ * Call once at app startup (before the first render) to configure how
+ * expo-notifications handles messages received in the foreground.
+ */
+export function configureNotificationHandler(): void {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowAlert: true,
+      shouldPlaySound: true,
+      shouldSetBadge: true,
+      shouldShowBanner: true,
+      shouldShowList: true,
+    }),
+  });
+}
+
+// ─── Android channel ──────────────────────────────────────────────────────────
+
+/**
+ * Create the default Android notification channel.
+ * Safe to call multiple times (no-ops if the channel already exists).
+ */
+export async function ensureAndroidChannel(): Promise<void> {
+  if (Device.isDevice) {
+    await Notifications.setNotificationChannelAsync('default', {
+      name: 'Hunty Notifications',
+      importance: Notifications.AndroidImportance.HIGH,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#7C3AED',
+      sound: 'default',
+    });
+  }
+}
+
+// ─── Permission helpers ───────────────────────────────────────────────────────
+
+export type PermissionStatus = 'granted' | 'denied' | 'undetermined';
+
+/**
+ * Return the current notification permission status without prompting.
+ */
+export async function getPermissionStatus(): Promise<PermissionStatus> {
+  const { status } = await Notifications.getPermissionsAsync();
+  return status as PermissionStatus;
+}
+
+/**
+ * Request push notification permission from the OS.
+ * Returns the resulting status after the prompt (or the existing status if the
+ * user already responded).
+ */
+export async function requestPermission(): Promise<PermissionStatus> {
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return 'granted';
+
+  const { status: requested } = await Notifications.requestPermissionsAsync();
+  return requested as PermissionStatus;
+}
+
+// ─── Notification data extraction ─────────────────────────────────────────────
+
+/**
+ * Safely extract the typed payload from an Expo notification object.
+ * Returns null if the data does not match a known payload shape.
+ */
+export function extractPayload(
+  notification: Notifications.Notification,
+): NotificationPayload | null {
+  const data = notification.request.content.data as Record<string, unknown> | null;
+  if (!data || typeof data.type !== 'string') return null;
+
+  return data as unknown as NotificationPayload;
+}
+
+/**
+ * Extract the typed payload from an Expo notification response (i.e. a tap).
+ */
+export function extractResponsePayload(
+  response: Notifications.NotificationResponse,
+): NotificationPayload | null {
+  return extractPayload(response.notification);
+}

--- a/mobile/services/notifications/tokenRegistry.ts
+++ b/mobile/services/notifications/tokenRegistry.ts
@@ -1,0 +1,186 @@
+/**
+ * Expo push token registration with the Hunty backend.
+ *
+ * Responsibilities:
+ *  - Retrieve the device Expo push token (physical device only).
+ *  - Register/update the token against the backend API, associating it with the
+ *    authenticated wallet address.
+ *  - Persist the registered token locally so we can detect stale tokens and
+ *    avoid duplicate round-trips.
+ *  - Unregister on wallet disconnect to stop orphaned notifications.
+ */
+
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import Constants from 'expo-constants';
+import * as SecureStore from 'expo-secure-store';
+import env from '@config/env';
+
+const PUSH_TOKEN_KEY = 'hunty_push_token';
+const PUSH_TOKEN_WALLET_KEY = 'hunty_push_token_wallet';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Read persisted token from secure storage, or null. */
+async function getStoredToken(): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(PUSH_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Read which wallet the stored token is associated with. */
+async function getStoredTokenWallet(): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(PUSH_TOKEN_WALLET_KEY);
+  } catch {
+    return null;
+  }
+}
+
+async function persistToken(token: string, walletAddress: string): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(PUSH_TOKEN_KEY, token);
+    await SecureStore.setItemAsync(PUSH_TOKEN_WALLET_KEY, walletAddress);
+  } catch {
+    if (__DEV__) console.warn('[TokenRegistry] Failed to persist token');
+  }
+}
+
+async function clearStoredToken(): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(PUSH_TOKEN_KEY);
+    await SecureStore.deleteItemAsync(PUSH_TOKEN_WALLET_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+// ─── Token retrieval ─────────────────────────────────────────────────────────
+
+/**
+ * Retrieve the Expo push token for this device.
+ * Returns null on simulators or when permissions are missing.
+ */
+export async function getExpoPushToken(): Promise<string | null> {
+  if (!Device.isDevice) {
+    if (__DEV__) console.warn('[TokenRegistry] Push tokens are only available on physical devices');
+    return null;
+  }
+
+  const { status } = await Notifications.getPermissionsAsync();
+  if (status !== 'granted') {
+    if (__DEV__) console.warn('[TokenRegistry] Push permission not granted, skipping token fetch');
+    return null;
+  }
+
+  const projectId =
+    Constants.expoConfig?.extra?.eas?.projectId ??
+    process.env.EXPO_PUBLIC_EAS_PROJECT_ID;
+
+  try {
+    const tokenData = await Notifications.getExpoPushTokenAsync(
+      projectId ? { projectId } : undefined,
+    );
+    return tokenData.data;
+  } catch (err) {
+    if (__DEV__) console.warn('[TokenRegistry] getExpoPushTokenAsync failed:', err);
+    return null;
+  }
+}
+
+// ─── Backend registration ─────────────────────────────────────────────────────
+
+async function postTokenToBackend(
+  token: string,
+  walletAddress: string,
+  retries = 3,
+): Promise<void> {
+  const url = `${env.apiUrl}/push-tokens`;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, walletAddress }),
+      });
+
+      if (res.ok || res.status === 409) {
+        // 409 Conflict means token already registered — treat as success
+        return;
+      }
+
+      throw new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      if (attempt === retries) {
+        if (__DEV__) console.warn(`[TokenRegistry] Backend registration failed after ${retries} attempts:`, err);
+        throw err;
+      }
+      // Exponential back-off: 500ms, 1000ms, 2000ms …
+      await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+    }
+  }
+}
+
+async function deleteTokenFromBackend(token: string, walletAddress: string): Promise<void> {
+  const url = `${env.apiUrl}/push-tokens`;
+  try {
+    await fetch(url, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, walletAddress }),
+    });
+  } catch (err) {
+    if (__DEV__) console.warn('[TokenRegistry] Token unregister failed:', err);
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Register the device push token with the backend for a given wallet address.
+ *
+ * Skips the backend call if the same token is already registered for the same
+ * wallet, preventing duplicate registrations.
+ */
+export async function registerPushToken(walletAddress: string): Promise<void> {
+  if (!walletAddress) return;
+
+  const token = await getExpoPushToken();
+  if (!token) return;
+
+  const [storedToken, storedWallet] = await Promise.all([
+    getStoredToken(),
+    getStoredTokenWallet(),
+  ]);
+
+  const alreadyRegistered = storedToken === token && storedWallet === walletAddress;
+  if (alreadyRegistered) {
+    if (__DEV__) console.log('[TokenRegistry] Token already registered, skipping');
+    return;
+  }
+
+  try {
+    await postTokenToBackend(token, walletAddress);
+    await persistToken(token, walletAddress);
+    if (__DEV__) console.log('[TokenRegistry] Token registered for', walletAddress);
+  } catch {
+    // Error already logged inside postTokenToBackend — don't crash the app
+  }
+}
+
+/**
+ * Unregister the device push token when the user disconnects their wallet.
+ * Clears local storage regardless of whether the backend call succeeds.
+ */
+export async function unregisterPushToken(): Promise<void> {
+  const [token, wallet] = await Promise.all([getStoredToken(), getStoredTokenWallet()]);
+
+  await clearStoredToken();
+
+  if (token && wallet) {
+    await deleteTokenFromBackend(token, wallet);
+  }
+}

--- a/mobile/services/notifications/types.ts
+++ b/mobile/services/notifications/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Typed push notification payloads for Hunty Mobile.
+ * All notification events are strongly typed here.
+ */
+
+export type NotificationEventType =
+  | 'hunt_start'
+  | 'correct_answer'
+  | 'leaderboard_outranked'
+  | 'hunt_ending_soon';
+
+// ─── Payload shapes per event ─────────────────────────────────────────────────
+
+export interface HuntStartPayload {
+  type: 'hunt_start';
+  huntId: number;
+  huntTitle: string;
+}
+
+export interface CorrectAnswerPayload {
+  type: 'correct_answer';
+  huntId: number;
+  huntTitle: string;
+  score?: number;
+  reward?: string;
+}
+
+export interface LeaderboardOutrankedPayload {
+  type: 'leaderboard_outranked';
+  huntId: number;
+  huntTitle: string;
+  currentRank: number;
+  overtakenBy?: string;
+}
+
+export interface HuntEndingSoonPayload {
+  type: 'hunt_ending_soon';
+  huntId: number;
+  huntTitle: string;
+  minutesRemaining: number;
+}
+
+export type NotificationPayload =
+  | HuntStartPayload
+  | CorrectAnswerPayload
+  | LeaderboardOutrankedPayload
+  | HuntEndingSoonPayload;
+
+// ─── Navigation target derived from a notification tap ───────────────────────
+
+export interface NotificationNavTarget {
+  /** Expo Router path, e.g. "/hunt/42" */
+  path: string;
+}
+
+export function resolveNavTarget(payload: NotificationPayload): NotificationNavTarget {
+  switch (payload.type) {
+    case 'hunt_start':
+    case 'correct_answer':
+    case 'hunt_ending_soon':
+      return { path: `/hunt/${payload.huntId}` };
+    case 'leaderboard_outranked':
+      return { path: `/hunt/${payload.huntId}` };
+    default:
+      return { path: '/(tabs)/hunts' };
+  }
+}


### PR DESCRIPTION
What this adds
Full end-to-end push notification support for the Hunty mobile app using expo-notifications (already a project dependency).

Changes
New service layer (mobile/services/notifications/)

types.ts — typed payloads for all 4 notification events (hunt_start, correct_answer, leaderboard_outranked, hunt_ending_soon) plus resolveNavTarget for deep-link routing from notification taps
notificationService.ts — handler configuration, Android channel setup, permission helpers (getPermissionStatus, requestPermission), payload extraction from notification objects
tokenRegistry.ts — Expo push token retrieval, backend registration with 3-attempt exponential back-off, duplicate prevention via SecureStore, and unregister on wallet disconnect
Provider (
NotificationsProvider.tsx
)

Centralized listener setup for foreground, background, and cold-start notification taps
All subscriptions cleaned up on unmount
Drives deep-link navigation via Expo Router on tap
Hook (
useNotifications.ts
)

Replaces the minimal previous stub
Exposes enabled, permissionStatus, loading, toggle, registerForWallet, unregister
Used by the existing Settings screen toggle with no breaking changes
Integration

_layout.tsx
 — NotificationsProvider added to the provider tree (inside Web3Provider)
Web3Provider.tsx
 — registerPushToken called after wallet connect and session restore; unregisterPushToken called on disconnect
app.json — expo-notifications added to the plugins array
Test infrastructure (mobile/__tests__/notifications/, mobile/__mocks__/)

Standalone jest.config.js (no dependency on expo-modules-core being fully installed)
babel.config.js updated to skip nativewind and reanimated plugins in test env
Manual mocks for expo-notifications, expo-device, expo-secure-store, expo-constants

closes #360