### PR TITLE
fix(a11y): trap focus in WalletModal and add e2e test (#330)

### DIFF
--- a/components/WalletModal.tsx
+++ b/components/WalletModal.tsx
@@ -4,7 +4,9 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -55,16 +57,17 @@ export function WalletModal({ isOpen, onClose, onConnect }: WalletModalProps) {
           <DialogTitle className="text-slate-800 dark:text-slate-100 font-semibold">
             Connect a wallet
           </DialogTitle>
-          <Button
-            variant="ghost"
-            size="icon"
+          <DialogClose
             onClick={handleClose}
+            className="h-6 w-6 rounded-full bg-pink-500 hover:bg-pink-600 text-white inline-flex items-center justify-center"
             aria-label="Close wallet modal"
-            className="h-6 w-6 rounded-full bg-pink-500 hover:bg-pink-600 text-white"
           >
             <X className="h-4 w-4" />
-          </Button>
+          </DialogClose>
         </DialogHeader>
+        <DialogDescription className="sr-only">
+          Choose a Stellar wallet provider to connect to Hunty.
+        </DialogDescription>
 
         <div className="space-y-4 py-2">
           <Button

--- a/e2e/wallet-modal-focus-trap.spec.ts
+++ b/e2e/wallet-modal-focus-trap.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { seedHuntData } from "./helpers/mock-wallet";
+
+test.describe("WalletModal focus trap", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedHuntData(page);
+    await page.goto("/");
+    await page.getByRole("button", { name: /connect wallet/i }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  test("Tab key keeps focus inside the modal", async ({ page }) => {
+    const dialog = page.getByRole("dialog");
+
+    // Tab through all focusable elements several times and verify focus stays inside
+    for (let i = 0; i < 6; i++) {
+      await page.keyboard.press("Tab");
+      const focusedInsideDialog = await dialog.evaluate((el) =>
+        el.contains(document.activeElement)
+      );
+      expect(focusedInsideDialog).toBe(true);
+    }
+  });
+
+  test("Escape closes the modal", async ({ page }) => {
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
PR Description:
  
  ## Summary
  
  Fixes #330 — keyboard focus was escaping WalletModal because of two missing pieces in the Radix Dialog setup (the focus trap itself was
  already wired via FocusScope; the violations were in the surrounding structure).
  
  ## Changes
  
  **`components/WalletModal.tsx`**
  - Added `<DialogDescription className="sr-only">` — without it, Radix's auto-generated `aria-describedby` pointed to a non-existent
  element, which is an axe-core critical violation
  - Replaced the manual close `<Button>` with Radix's `<DialogClose>` so focus is correctly returned to the trigger element when the modal
  closes
  
  **`e2e/wallet-modal-focus-trap.spec.ts`** (new)
  - Verifies Tab key keeps focus inside the dialog (6 iterations)
  - Verifies Escape closes the modal
  
  ## No new dependencies added

#330 