### PR TITLE
Add cross-browser Playwright projects and CI matrix

### DIFF
--- a/.github/workflows/playwright-cross-browser.yml
+++ b/.github/workflows/playwright-cross-browser.yml
@@ -1,0 +1,39 @@
+name: Playwright Cross-Browser Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  playwright-tests:
+    name: Playwright tests — ${{ matrix.project }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [chromium, firefox, webkit, msedge, iphone, pixel, chromium-dark]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests for project
+        env:
+          CI: true
+          WALLET_EXTENSION_PATH: ${{ secrets.WALLET_EXTENSION_PATH }}
+        run: npx playwright test --project=${{ matrix.project }} --reporter=github

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,9 +20,51 @@ export default defineConfig({
   // ────────────────────────────────────────────────────────────────────────────
   projects: [
     {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+    {
       name: "msedge",
       use: { ...devices["Desktop Edge"], channel: "msedge" },
     },
+    {
+      name: "iphone",
+      use: { ...devices["iPhone 13"] },
+    },
+    {
+      name: "pixel",
+      use: { ...devices["Pixel 5"] },
+    },
+    // Dark-mode / CSS-compat project (runs on Chromium emulation)
+    {
+      name: "chromium-dark",
+      use: { ...devices["Desktop Chrome"], colorScheme: "dark", reducedMotion: "reduce" },
+    },
+    // Optional wallet-extension project: only enabled when WALLET_EXTENSION_PATH is set
+    ...(process.env.WALLET_EXTENSION_PATH
+      ? [
+          {
+            name: "chromium-wallet",
+            use: {
+              ...devices["Desktop Chrome"],
+              launchOptions: {
+                args: [
+                  `--disable-extensions-except=${process.env.WALLET_EXTENSION_PATH}`,
+                  `--load-extension=${process.env.WALLET_EXTENSION_PATH}`,
+                ],
+              },
+            },
+          },
+        ]
+      : []),
   ],
   webServer: {
     command: "pnpm dev",


### PR DESCRIPTION
ummary

Adds Playwright projects for desktop browsers, mobile emulations, a CSS/dark-mode project, optional wallet-extension support, and a GitHub Actions CI matrix to run them.

closes #670