### PR TITLE
Add production smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,84 @@
+name: Production Smoke Tests
+
+on:
+  deployment_status:
+  workflow_dispatch:
+    inputs:
+      deployment_url:
+        description: "Deployment URL to smoke test"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: production-smoke-${{ github.event.deployment_status.deployment.id || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Smoke test deployed app
+    if: github.event_name == 'workflow_dispatch' || github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SMOKE_BASE_URL: ${{ inputs.deployment_url || github.event.deployment_status.environment_url || github.event.deployment_status.target_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Validate deployment URL
+        run: |
+          if [ -z "$SMOKE_BASE_URL" ]; then
+            echo "::error::No deployment URL was provided by the deployment_status event or workflow_dispatch input."
+            exit 1
+          fi
+          echo "Running smoke tests against $SMOKE_BASE_URL"
+
+      - name: Run production smoke tests
+        run: npm run smoke
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-smoke-playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Alert on smoke failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const baseUrl = process.env.SMOKE_BASE_URL || "unknown deployment URL";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Production smoke tests failed for ${baseUrl}`,
+              body: [
+                "The post-deployment smoke test suite failed.",
+                "",
+                `Deployment URL: ${baseUrl}`,
+                `Workflow run: ${runUrl}`,
+                "",
+                "Please inspect the Playwright report artifact and deployment logs."
+              ].join("\n")
+            });

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      service: "hunty",
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    }
+  );
+}

--- a/components/HuntDashboard.tsx
+++ b/components/HuntDashboard.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link"
 import { useState, type MouseEvent as ReactMouseEvent } from "react"
 import { Plus, Trash2, Trophy, Copy, X } from "lucide-react"
-import { cn } from "@/lib/utils"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -336,61 +335,6 @@ export function HuntDashboard({
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {hunts.map((hunt) => {
-          const isDraft = hunt.status === "Draft"
-          const isActive = hunt.status === "Active"
-          const isCompleted = hunt.status === "Completed"
-          const hasClues = hunt.cluesCount > 0
-          const canActivate = isDraft && hasClues
-
-          return (
-            <Card
-              key={hunt.id}
-              className={cn(
-                "group relative overflow-hidden rounded-2xl border transition-all",
-                selectedIds.has(hunt.id)
-                  ? "border-blue-400 dark:border-blue-500 bg-blue-50/30 dark:bg-blue-900/10 ring-1 ring-blue-400 dark:ring-blue-500"
-                  : "border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 hover:border-slate-300 dark:hover:border-white/20 shadow-sm"
-              )}
-            >
-              <div className="absolute right-3 top-3 z-10">
-                <Checkbox
-                  checked={selectedIds.has(hunt.id)}
-                  onCheckedChange={() => toggleSelect(hunt.id)}
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                  className="h-5 w-5 rounded-md border-slate-300 dark:border-white/20"
-                  aria-label={`Select hunt ${hunt.title}`}
-                />
-              </div>
-              <Link href={`/hunt/${hunt.id}`}>
-              <div className="p-5">
-                <div className="mb-2 flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    <CardTitle className="line-clamp-2 text-lg dark:text-white">{hunt.title}</CardTitle>
-                    <div className="flex items-center gap-1 bg-slate-100 dark:bg-white/5 px-2 py-0.5 rounded-md text-xs text-slate-500 dark:text-slate-400 font-mono">
-                      #{hunt.id}
-                      <button
-                        onClick={(e) => handleCopyId(e, hunt.id)}
-                        aria-label={`Copy hunt ID ${hunt.id}`}
-                        className="hover:text-slate-800 dark:hover:text-white transition-colors"
-                      >
-                        <Copy className="w-3 h-3" />
-                      </button>
-                    </div>
-                  </div>
-                  <StatusBadge status={hunt.status} />
-      {hunts.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-slate-300 bg-white/70 px-6 py-14 text-center shadow-sm dark:border-white/10 dark:bg-slate-950/50">
-          <p className="text-lg font-semibold text-slate-900 dark:text-white">
-            No hunts found for this filter
-          </p>
-          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-            Try another status or sort option to explore your hunt history.
-          </p>
-        </div>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {hunts.map((hunt) => {
         {hunts.length === 0 ? (
           <div className="col-span-full rounded-3xl border border-dashed border-slate-300 bg-white/70 px-6 py-14 text-center shadow-sm dark:border-white/10 dark:bg-slate-950/50">
             <p className="text-lg font-semibold text-slate-900 dark:text-white">
@@ -509,6 +453,7 @@ export function HuntDashboard({
             )
           })
         )}
+      </div>
 
       <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
         <p className="text-sm text-slate-500 dark:text-slate-400">

--- a/e2e/smoke/production-smoke.spec.ts
+++ b/e2e/smoke/production-smoke.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const criticalPages = [
+  { path: "/", heading: /ultimate web3 game arcade/i },
+  { path: "/hunty", heading: /create scavenge hunt/i },
+  { path: "/dashboard", heading: /my hunts/i },
+  { path: "/help", heading: /troubleshooting guide/i },
+];
+
+const apiChecks = [
+  {
+    path: "/api/health",
+    assert: async (response: Awaited<ReturnType<typeof fetchJson>>) => {
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        status: "ok",
+        service: "hunty",
+      });
+    },
+  },
+  {
+    path: "/api/v1/hunts?page=1&limit=5",
+    assert: async (response: Awaited<ReturnType<typeof fetchJson>>) => {
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.pagination).toMatchObject({
+        page: 1,
+        limit: 5,
+      });
+    },
+  },
+  {
+    path: "/api/admin/featured",
+    assert: async (response: Awaited<ReturnType<typeof fetchJson>>) => {
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("featuredHuntId");
+    },
+  },
+];
+
+async function fetchJson(request: APIRequestContext, path: string) {
+  const response = await request.get(path);
+  const contentType = response.headers()["content-type"] ?? "";
+
+  expect(response.status(), `${path} should be available`).toBeLessThan(500);
+  expect(contentType, `${path} should return JSON`).toContain("application/json");
+
+  return {
+    status: response.status(),
+    body: await response.json(),
+  };
+}
+
+test.describe("production smoke checks", () => {
+  test("health endpoint reports the service as ready", async ({ request }) => {
+    const response = await fetchJson(request, "/api/health");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      status: "ok",
+      service: "hunty",
+    });
+    expect(Date.parse(response.body.timestamp)).not.toBeNaN();
+  });
+
+  for (const { path, heading } of criticalPages) {
+    test(`critical page loads: ${path}`, async ({ page }) => {
+      const response = await page.goto(path, { waitUntil: "domcontentloaded" });
+
+      expect(response?.status(), `${path} should not return an error`).toBeLessThan(400);
+      await expect(page.getByRole("heading", { name: heading })).toBeVisible({
+        timeout: 15_000,
+      });
+    });
+  }
+
+  test("public API endpoints are available", async ({ request }) => {
+    for (const check of apiChecks) {
+      await check.assert(await fetchJson(request, check.path));
+    }
+  });
+
+  test("wallet connection entry point opens the wallet provider flow", async ({ page }) => {
+    const response = await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    expect(response?.status()).toBeLessThan(400);
+
+    await page.getByRole("button", { name: /connect wallet/i }).click();
+
+    await expect(page.getByRole("heading", { name: /connect wallet/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /freighter/i })).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "e2e": "playwright test",
+    "smoke": "playwright test --config=playwright.smoke.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL =
+  process.env.SMOKE_BASE_URL ||
+  process.env.DEPLOYMENT_URL ||
+  "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./e2e/smoke",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Added a post-deployment smoke test setup for the production app.

Closes #672

## Changes

- Added a health check endpoint at /api/health
- Added Playwright smoke tests for critical pages
- Added API availability checks for public endpoints
- Added a wallet connection UI smoke check
- Added a GitHub Actions workflow to run smoke tests after successful deployments
- Added failure alerting by opening a GitHub issue when smoke tests fail
- Cleaned up broken duplicate JSX in the dashboard component

## Testing

- npx playwright test --config=playwright.smoke.config.ts --list
- Verified /api/health returns 200 OK
- Verified /api/v1/hunts?page=1&limit=5 returns 200 OK