### PR TITLE
feat(mobile): add location-based clue geofencing and privacy controls

### DIFF
--- a/lib/__tests__/locationServices.test.ts
+++ b/lib/__tests__/locationServices.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_GEOFENCE_RADIUS_METERS,
+  getClueGeofenceRadiusMeters,
+  getDistanceMeters,
+  isLocationWithinGeofence,
+} from '@/lib/locationServices';
+
+describe('locationServices', () => {
+  it('returns a zero distance for identical coordinates', () => {
+    expect(getDistanceMeters({ latitude: 0, longitude: 0 }, { latitude: 0, longitude: 0 })).toBe(0);
+  });
+
+  it('flags a position inside the geofence radius', () => {
+    const distanceMeters = getDistanceMeters(
+      { latitude: 40.7484, longitude: -73.9857 },
+      { latitude: 40.74845, longitude: -73.98575 },
+    );
+
+    expect(distanceMeters).toBeGreaterThan(0);
+    expect(isLocationWithinGeofence(distanceMeters, 100)).toBe(true);
+  });
+
+  it('uses the clue radius when provided and falls back to the default otherwise', () => {
+    expect(getClueGeofenceRadiusMeters({ geofenceRadiusMeters: 250 } as any)).toBe(250);
+    expect(getClueGeofenceRadiusMeters({} as any)).toBe(DEFAULT_GEOFENCE_RADIUS_METERS);
+  });
+});

--- a/lib/locationServices.ts
+++ b/lib/locationServices.ts
@@ -1,0 +1,43 @@
+import type { Clue } from './types';
+
+export const DEFAULT_GEOFENCE_RADIUS_METERS = 100;
+
+export type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+export type GeofenceCandidate = Pick<Clue, 'geofenceRadiusMeters'> & Coordinates;
+
+function toRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+export function getDistanceMeters(from: Coordinates, to: Coordinates): number {
+  const earthRadiusMeters = 6_371_000;
+  const latDelta = toRadians(to.latitude - from.latitude);
+  const lonDelta = toRadians(to.longitude - from.longitude);
+  const fromLat = toRadians(from.latitude);
+  const toLat = toRadians(to.latitude);
+
+  const a =
+    Math.sin(latDelta / 2) * Math.sin(latDelta / 2) +
+    Math.cos(fromLat) *
+      Math.cos(toLat) *
+      Math.sin(lonDelta / 2) *
+      Math.sin(lonDelta / 2);
+
+  return 2 * earthRadiusMeters * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function getClueGeofenceRadiusMeters(clue: GeofenceCandidate | null | undefined): number {
+  if (typeof clue?.geofenceRadiusMeters === 'number' && clue.geofenceRadiusMeters > 0) {
+    return clue.geofenceRadiusMeters;
+  }
+
+  return DEFAULT_GEOFENCE_RADIUS_METERS;
+}
+
+export function isLocationWithinGeofence(distanceMeters: number, radiusMeters: number): boolean {
+  return distanceMeters <= radiusMeters;
+}

--- a/mobile/app/(tabs)/play.tsx
+++ b/mobile/app/(tabs)/play.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { ScrollView, StyleSheet, Switch, TextInput, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedButton, ThemedCustomText, ThemedView } from '@components/themed';
 import { EmptyState } from '@components/EmptyState';
@@ -10,12 +10,21 @@ import type { Clue } from '@lib/types';
 import { useToast } from '@providers/ToastProvider';
 import { ClueMarkdownRenderer } from '@components/ClueMarkdownRenderer';
 import { verifyClueGeofence } from '@/lib/locationGate';
+import { usePlayerLocation } from '@app/hooks/usePlayerLocation';
 
 export default function PlayScreen() {
   const router = useRouter();
   const { colors } = useTheme();
   const { showToast } = useToast();
   const { network } = useWalletStore();
+  const {
+    location,
+    error: locationError,
+    loading: locationLoading,
+    permissionGranted,
+    shareLocation,
+    setShareLocation,
+  } = usePlayerLocation();
   const {
     currentProgress,
     updateClueIndex,
@@ -130,6 +139,42 @@ export default function PlayScreen() {
           <ThemedCustomText variant="body">{progressLabel}</ThemedCustomText>
         </View>
 
+        <View style={[styles.locationCard, { backgroundColor: colors.background, borderColor: colors.border }]}> 
+          <View style={styles.locationHeader}> 
+            <ThemedCustomText variant="label" weight="700">
+              Location services
+            </ThemedCustomText>
+            <Switch
+              value={shareLocation}
+              onValueChange={setShareLocation}
+              disabled={!permissionGranted}
+              trackColor={{ false: '#cbd5e1', true: colors.primary }}
+            />
+          </View>
+          <ThemedCustomText variant="caption" style={styles.locationCopy}>
+            {permissionGranted
+              ? shareLocation
+                ? 'GPS tracking is enabled for live geofence checks and low-power updates.'
+                : 'Location sharing is paused. Clues can still be checked using a one-time GPS read.'
+              : 'Allow location access to use location-based clues and geofencing.'}
+          </ThemedCustomText>
+          {locationLoading ? (
+            <ThemedCustomText variant="caption" color="warning">
+              Requesting location access…
+            </ThemedCustomText>
+          ) : null}
+          {locationError ? (
+            <ThemedCustomText variant="caption" color="error">
+              {locationError}
+            </ThemedCustomText>
+          ) : null}
+          {location ? (
+            <ThemedCustomText variant="caption" style={styles.locationMeta}>
+              Live coordinates: {location.latitude.toFixed(4)}, {location.longitude.toFixed(4)}
+            </ThemedCustomText>
+          ) : null}
+        </View>
+
         {clues.map((clue, index) => {
           const isActive = index === activeClueIndex && !allSolved;
           const isUnlocked = index <= activeClueIndex;
@@ -226,6 +271,23 @@ const styles = StyleSheet.create({
   },
   clueMeta: {
     opacity: 0.75,
+  },
+  locationCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 16,
+    gap: 8,
+  },
+  locationHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  locationCopy: {
+    opacity: 0.8,
+  },
+  locationMeta: {
+    opacity: 0.65,
   },
   answerPanel: {
     borderRadius: 16,

--- a/mobile/app/hooks/usePlayerLocation.ts
+++ b/mobile/app/hooks/usePlayerLocation.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import * as Location from 'expo-location';
 
 export type PlayerLocation = {
@@ -10,14 +10,17 @@ export type LocationState = {
   location: PlayerLocation | null;
   error: string | null;
   loading: boolean;
+  permissionGranted: boolean;
+  shareLocation: boolean;
+  setShareLocation: (value: boolean) => void;
 };
 
 export function usePlayerLocation(): LocationState {
-  const [state, setState] = useState<LocationState>({
-    location: null,
-    error: null,
-    loading: true,
-  });
+  const [location, setLocation] = useState<PlayerLocation | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [permissionGranted, setPermissionGranted] = useState(false);
+  const [shareLocation, setShareLocation] = useState(true);
 
   useEffect(() => {
     let subscription: Location.LocationSubscription | null = null;
@@ -25,34 +28,51 @@ export function usePlayerLocation(): LocationState {
     (async () => {
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') {
-        setState({ location: null, error: 'Location permission denied.', loading: false });
+        setPermissionGranted(false);
+        setError('Location permission denied.');
+        setLoading(false);
         return;
       }
 
-      // Get a quick initial fix
-      const initial = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
-      setState({
-        location: { latitude: initial.coords.latitude, longitude: initial.coords.longitude },
-        error: null,
-        loading: false,
-      });
+      setPermissionGranted(true);
 
-      // Then watch for updates
+      try {
+        const initial = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+        setLocation({ latitude: initial.coords.latitude, longitude: initial.coords.longitude });
+        setError(null);
+      } catch {
+        setError('Unable to resolve your current location.');
+      } finally {
+        setLoading(false);
+      }
+
+      if (!shareLocation) {
+        return;
+      }
+
       subscription = await Location.watchPositionAsync(
         { accuracy: Location.Accuracy.Balanced, distanceInterval: 10 },
         (pos) => {
-          setState((prev) => ({
-            ...prev,
-            location: { latitude: pos.coords.latitude, longitude: pos.coords.longitude },
-          }));
-        }
+          setLocation({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+          setError(null);
+        },
       );
     })();
 
     return () => {
       subscription?.remove();
     };
-  }, []);
+  }, [shareLocation]);
 
-  return state;
+  return useMemo(
+    () => ({
+      location,
+      error,
+      loading,
+      permissionGranted,
+      shareLocation,
+      setShareLocation,
+    }),
+    [error, loading, location, permissionGranted, shareLocation],
+  );
 }

--- a/mobile/lib/locationGate.ts
+++ b/mobile/lib/locationGate.ts
@@ -1,7 +1,11 @@
 import * as Location from 'expo-location';
 import type { Clue } from '@lib/types';
-
-const DEFAULT_GEOFENCE_RADIUS_METERS = 100;
+import {
+  DEFAULT_GEOFENCE_RADIUS_METERS,
+  getClueGeofenceRadiusMeters,
+  getDistanceMeters,
+  isLocationWithinGeofence,
+} from '@lib/locationServices';
 
 export type GeofenceCheckResult =
   | { allowed: true; distanceMeters: number; radiusMeters: number }
@@ -12,30 +16,6 @@ type GeofencedClue = Clue & {
   longitude: number;
   geofenceRadiusMeters?: number;
 };
-
-function toRadians(value: number): number {
-  return (value * Math.PI) / 180;
-}
-
-export function getDistanceMeters(
-  from: { latitude: number; longitude: number },
-  to: { latitude: number; longitude: number },
-): number {
-  const earthRadiusMeters = 6_371_000;
-  const latDelta = toRadians(to.latitude - from.latitude);
-  const lonDelta = toRadians(to.longitude - from.longitude);
-  const fromLat = toRadians(from.latitude);
-  const toLat = toRadians(to.latitude);
-
-  const a =
-    Math.sin(latDelta / 2) * Math.sin(latDelta / 2) +
-    Math.cos(fromLat) *
-      Math.cos(toLat) *
-      Math.sin(lonDelta / 2) *
-      Math.sin(lonDelta / 2);
-
-  return 2 * earthRadiusMeters * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
 
 export function hasClueGeofence(clue: Clue): clue is GeofencedClue {
   const candidate = clue as GeofencedClue;
@@ -68,10 +48,7 @@ export async function verifyClueGeofence(clue: Clue): Promise<GeofenceCheckResul
       accuracy: Location.Accuracy.Highest,
     });
 
-    const radiusMeters =
-      typeof clue.geofenceRadiusMeters === 'number' && clue.geofenceRadiusMeters > 0
-        ? clue.geofenceRadiusMeters
-        : DEFAULT_GEOFENCE_RADIUS_METERS;
+    const radiusMeters = getClueGeofenceRadiusMeters(clue);
 
     const distanceMeters = getDistanceMeters(
       {
@@ -84,7 +61,7 @@ export async function verifyClueGeofence(clue: Clue): Promise<GeofenceCheckResul
       },
     );
 
-    if (distanceMeters > radiusMeters) {
+    if (!isLocationWithinGeofence(distanceMeters, radiusMeters)) {
       return {
         allowed: false,
         distanceMeters,
@@ -105,3 +82,5 @@ export async function verifyClueGeofence(clue: Clue): Promise<GeofenceCheckResul
     };
   }
 }
+
+export { DEFAULT_GEOFENCE_RADIUS_METERS };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "galagiorchi",
+  "name": "hunty",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "galagiorchi",
+      "name": "hunty",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
@@ -8202,6 +8202,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
closes #682 

PR description
Summary
add shared geofence distance and radius helpers for location-based clues
enforce clue submission checks using live GPS coordinates and clue geofence boundaries
prompt for foreground location permission and surface location status in the mobile play flow
add privacy controls so players can pause location sharing while keeping the experience usable
include regression tests for the location service logic
