### PR TITLE
Add Docker development environment with PostgreSQL and README docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+.pnp
+.pnp.js
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store
+/dist
+/.next
+/out
+.env*
+.idea
+.vscode
+*.log
+**/__tests__
+**/coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+
+WORKDIR /usr/src/app
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["pnpm", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ pnpm test
 pnpm run e2e
 ```
 
+## Docker development
+
+This repository includes a local Docker development environment for the web app and a PostgreSQL database container.
+
+1. Build and start the development stack:
+
+```bash
+docker compose up --build
+```
+
+2. Open the web app at:
+
+```bash
+http://localhost:3000
+```
+
+3. PostgreSQL is available at `localhost:5432` with:
+
+- `POSTGRES_USER=hunty`
+- `POSTGRES_PASSWORD=hunty`
+- `POSTGRES_DB=hunty_dev`
+
+4. Code changes are mounted from the host into the container, so hot reload works automatically.
+
+5. Stop the stack:
+
+```bash
+docker compose down
+```
+
 ## Notes
 
 - This project prefers `pnpm`; a `pnpm-lock.yaml` is included.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.9'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/usr/src/app:cached
+      - /usr/src/app/node_modules
+    environment:
+      NODE_ENV: development
+      NEXT_TELEMETRY_DISABLED: 1
+    command: pnpm dev -- --hostname 0.0.0.0 --port 3000
+    depends_on:
+      - db
+    stdin_open: true
+    tty: true
+
+  db:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: hunty
+      POSTGRES_PASSWORD: hunty
+      POSTGRES_DB: hunty_dev
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "galagiorchi",
+  "name": "hunty",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "galagiorchi",
+      "name": "hunty",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
closes #689 

PR Description
Title: Add Docker development environment with PostgreSQL support

Summary:
This PR adds a Docker-based local development environment for the web app, including:

Dockerfile for building the Next.js app image
docker-compose.yml with web and PostgreSQL db services
.dockerignore to exclude local artifacts and build files
README documentation for Docker startup, access, and teardown
Details:

web service uses the local repository mount and exposes port 3000
Hot reload is enabled via host volume mounts
PostgreSQL service uses postgres:15-alpine with persistent volume storage
Database credentials are documented in the README