### PR TITLE
Add ARIA live region for transaction status updates

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import "./globals.css"
 import { hankenGrotesk } from "@/lib/font"
 import { TxToaster } from "@/components/TxToaster"
+import { SrAnnouncer } from "@/components/SrAnnouncer"
 import Providers from "./providers"
 
 export const metadata: Metadata = {
@@ -75,6 +76,7 @@ export default function RootLayout({
             Skip to content
           </a>
           <TxToaster />
+          <SrAnnouncer />
           <main id="main-content">
             {children}
           </main>

--- a/components/SrAnnouncer.tsx
+++ b/components/SrAnnouncer.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+let setMessage: (msg: string) => void = () => {}
+
+export function announceSr(message: string) {
+  setMessage(message)
+}
+
+export function SrAnnouncer() {
+  const [message, setMessageState] = useState("")
+
+  useEffect(() => {
+    setMessage = setMessageState
+    return () => {
+      setMessage = () => {}
+    }
+  }, [])
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {message}
+    </div>
+  )
+}

--- a/components/TxToaster.tsx
+++ b/components/TxToaster.tsx
@@ -9,6 +9,7 @@ export function TxToaster() {
       richColors
       expand
       closeButton
+      containerAriaLabel="Transaction status notifications"
     />
   )
 }

--- a/lib/txToast.ts
+++ b/lib/txToast.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner"
 import { mapContractError } from "@/lib/contracts/errors"
+import { announceSr } from "@/components/SrAnnouncer"
 
 // ─── Stage type ───────────────────────────────────────────────────────────────
 
@@ -68,10 +69,12 @@ export async function withTransactionToast<T>(
   const msgs: Required<TxToastMessages> = { ...DEFAULTS, ...messages }
 
   // Stage 1 — Pending
+  announceSr(msgs.pending)
   const toastId = toast.loading(msgs.pending)
 
   const setStage: SetStageFn = (stage) => {
     if (stage === "approving") {
+      announceSr(msgs.approving)
       // Update the same toast in-place so it doesn't flicker
       toast.loading(msgs.approving, { id: toastId })
     }
@@ -81,6 +84,7 @@ export async function withTransactionToast<T>(
     const result = await fn(setStage)
 
     // Stage 3 — Confirmed
+    announceSr(msgs.confirmed)
     toast.success(msgs.confirmed, { id: toastId })
 
     return result
@@ -89,8 +93,10 @@ export async function withTransactionToast<T>(
 
     if (mapped.isUserRejection) {
       // Yellow warning — user intentionally cancelled, not an error.
+      announceSr("Transaction cancelled")
       toast.warning(mapped.message, { id: toastId })
     } else {
+      announceSr("Failed: " + mapped.message)
       toast.error(mapped.message, { id: toastId })
     }
 


### PR DESCRIPTION
Added a visually-hidden <SrAnnouncer> component with aria-live='polite' that mirrors toast content for screen readers. The global announceSr() function is called before each transaction stage transition in withTransactionToast(), ensuring reliable announcements.

Also configures Sonner's container AriaLabel for better context.

Closes #334