### PR TITLE
[#651] Implement React Query caching strategy

### DIFF
--- a/app/hunt/[id]/share.tsx
+++ b/app/hunt/[id]/share.tsx
@@ -22,6 +22,7 @@ import { GameCompleteModal } from "@/components/GameCompleteModal";
 import { useQueryClient } from "@tanstack/react-query";
 import { debounce } from "@/lib/debounce";
 import { REGISTRATION_STATUS_DEBOUNCE_MS } from "@/lib/soroban/queryConfig";
+import { queryKeys } from "@/lib/queryKeys";
 
 interface HuntDetailProps {
   hunt: StoredHunt;
@@ -269,7 +270,9 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
               onGameComplete={(score) => {
                 // Refresh registration status to show completion/rewards
                 clearRegistrationCache(hunt.id, connectedPublicKey);
-                queryClient.invalidateQueries({ queryKey: ["registrationStatus", hunt.id, connectedPublicKey] });
+                queryClient.invalidateQueries({
+                  queryKey: queryKeys.registration.status(hunt.id, connectedPublicKey),
+                });
                 setCompletionScore(score);
                 setIsCompleteModalOpen(true);
               }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useWindowVirtualizer } from "@tanstack/react-virtual"
 import Image from "next/image"
 import Link from "next/link"
@@ -12,7 +12,7 @@ import { X, ArrowRight, Trophy } from "lucide-react"
 import { Card, CardDescription, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Header } from "@/components/Header"
-import { getAllHunts, type StoredHunt } from "@/lib/huntStore"
+import { getAllHunts, getHunt, type StoredHunt } from "@/lib/huntStore"
 import { LeaderboardTable } from "@/components/LeaderBoardTable"
 import { HuntOfTheWeekBanner } from "@/components/HuntOfTheWeekBanner"
 import { hankenGrotesk } from "@/lib/font"
@@ -25,6 +25,7 @@ import { usePlayerCounts } from "@/hooks/usePlayerCounts"
 import { useRecentlyCompleted } from "@/hooks/useRecentlyCompleted"
 import { RecentlyCompletedSection } from "@/components/RecentlyCompletedSection"
 import type { PlayerCountResult } from "@/lib/types"
+import { queryCachePolicy, queryKeys } from "@/lib/queryKeys"
 
 interface WalletOption {
   id: string
@@ -222,6 +223,7 @@ function VirtualizedActiveHuntsGrid({
 }
 
 export default function GameArcade() {
+  const queryClient = useQueryClient()
   const [isWalletModalOpen, setIsWalletModalOpen] = useState(false)
   const [isConnectingWallet, setIsConnectingWallet] = useState(false)
   const [displayName, setDisplayName] = useState("")
@@ -280,11 +282,23 @@ export default function GameArcade() {
   }, [statusFilter])
 
   const { data: hunts = [], isLoading: isLoadingHunts } = useQuery({
-    queryKey: ["activeHunts"],
+    queryKey: queryKeys.hunts.active(),
     queryFn: async () => fetchAllHunts(),
-    staleTime: 60_000,
-    gcTime: 300_000,
+    staleTime: queryCachePolicy.hunts.staleTime,
+    gcTime: queryCachePolicy.hunts.gcTime,
+    refetchInterval: queryCachePolicy.hunts.refetchInterval,
+    refetchIntervalInBackground: true,
   })
+
+  useEffect(() => {
+    hunts.slice(0, 6).forEach((hunt) => {
+      queryClient.prefetchQuery({
+        queryKey: queryKeys.hunts.detail(hunt.id),
+        queryFn: () => getHunt(String(hunt.id)),
+        staleTime: queryCachePolicy.hunts.staleTime,
+      })
+    })
+  }, [hunts, queryClient])
 
   // Fetch player counts for all visible hunts. refetch is called on mount via
   // useEffect below to ensure counts are fresh on each arcade page load.

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ThemeProvider } from "next-themes"
 import { useState } from "react"
 import { WalletProvider } from "@/lib/context/WalletContext"
+import { queryCachePolicy } from "@/lib/queryKeys"
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -12,8 +13,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         defaultOptions: {
           queries: {
             staleTime: 5 * 60 * 1000,
-            gcTime: 10 * 60 * 1000,
-            refetchOnWindowFocus: false,
+            gcTime: queryCachePolicy.hunts.gcTime,
+            refetchOnWindowFocus: true,
+            refetchOnReconnect: "always",
+            refetchIntervalInBackground: true,
           },
         },
       })

--- a/components/FeaturedHunts.tsx
+++ b/components/FeaturedHunts.tsx
@@ -6,6 +6,7 @@ import { Trophy, Clock, Sparkles, ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { HuntCoverImage } from "@/components/HuntCoverImage"
+import { queryCachePolicy, queryKeys } from "@/lib/queryKeys"
 import { cn } from "@/lib/utils"
 
 function timeRemaining(endTime?: number): string {
@@ -21,8 +22,12 @@ function timeRemaining(endTime?: number): string {
 
 export function FeaturedHunts() {
   const { data: featured = [], isLoading } = useQuery({
-    queryKey: ["featuredHunts"],
+    queryKey: queryKeys.hunts.featured(),
     queryFn: () => getFeaturedHunts(3),
+    staleTime: queryCachePolicy.featuredHunts.staleTime,
+    gcTime: queryCachePolicy.featuredHunts.gcTime,
+    refetchInterval: queryCachePolicy.featuredHunts.refetchInterval,
+    refetchIntervalInBackground: true,
   })
 
   if (!isLoading && featured.length === 0) return null

--- a/components/GameCompleteModal.tsx
+++ b/components/GameCompleteModal.tsx
@@ -28,6 +28,7 @@ import { toast } from "sonner"
 import { ACHIEVEMENTS } from "@/lib/achievements/config"
 import { checkAndAwardAchievements } from "@/lib/achievements/service"
 import { logger } from "@/lib/logger"
+import { queryCachePolicy, queryKeys } from "@/lib/queryKeys"
 
 interface GameCompleteModalProps {
   isOpen: boolean
@@ -67,10 +68,13 @@ export function GameCompleteModal({
   const [newAchievements, setNewAchievements] = useState<string[]>([])
 
   const { data: registrationStatus } = useQuery({
-    queryKey: ["registrationStatus", huntId, playerAddress],
+    queryKey: queryKeys.registration.status(huntId, playerAddress),
     queryFn: () => (huntId && playerAddress ? checkRegistrationStatus(huntId, playerAddress) : null),
     enabled: isOpen && !!huntId && !!playerAddress,
-    staleTime: SOROBAN_READ_STALE_TIME_MS,
+    staleTime: Math.max(SOROBAN_READ_STALE_TIME_MS, queryCachePolicy.registrationStatus.staleTime),
+    gcTime: queryCachePolicy.registrationStatus.gcTime,
+    refetchInterval: queryCachePolicy.registrationStatus.refetchInterval,
+    refetchIntervalInBackground: true,
   });
 
   const playerProgress = registrationStatus?.progressData ? {

--- a/components/PlayGame.tsx
+++ b/components/PlayGame.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/Header";
 import { PlayerProgressPanel } from "@/components/PlayerProgressPanel";
 import { get_clue_info, get_hunt } from "@/lib/contracts/hunt";
+import { queryCachePolicy, queryKeys } from "@/lib/queryKeys";
 import { SOROBAN_READ_STALE_TIME_MS } from "@/lib/soroban/queryConfig";
 
 import { HuntCards } from "./HuntCards";
@@ -50,7 +51,7 @@ export function PlayGame({
     error: queryError,
     refetch,
   } = useQuery({
-    queryKey: ["huntClues", huntId],
+    queryKey: queryKeys.hunts.clues(huntId),
     queryFn: async () => {
       if (huntId == null) return null;
       const huntInfo = await get_hunt(huntId);
@@ -73,7 +74,10 @@ export function PlayGame({
       return { clues, huntInfo };
     },
     enabled: huntId != null,
-    staleTime: SOROBAN_READ_STALE_TIME_MS,
+    staleTime: Math.max(SOROBAN_READ_STALE_TIME_MS, queryCachePolicy.hunts.staleTime),
+    gcTime: queryCachePolicy.hunts.gcTime,
+    refetchInterval: queryCachePolicy.hunts.refetchInterval,
+    refetchIntervalInBackground: true,
   });
 
   const error: string | null = queryError instanceof Error ? queryError.message : queryError ? "Failed to fetch clues" : null;

--- a/lib/hooks/useHuntMutations.ts
+++ b/lib/hooks/useHuntMutations.ts
@@ -1,0 +1,58 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { addHunt, takeHuntStoreSnapshot, restoreHuntStoreSnapshot, updateHuntStatus } from "@/lib/huntStore"
+import type { StoredHunt } from "@/lib/types"
+import { queryKeys } from "@/lib/queryKeys"
+
+export function useCreateHuntMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (hunt: StoredHunt) => {
+      addHunt(hunt)
+      return hunt
+    },
+    onMutate: async (hunt) => {
+      const snapshot = takeHuntStoreSnapshot()
+      await queryClient.cancelQueries({ queryKey: queryKeys.hunts.active() })
+      queryClient.setQueryData<StoredHunt[]>(queryKeys.hunts.active(), (existing = []) => [...existing, hunt])
+      return { snapshot }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.snapshot) {
+        restoreHuntStoreSnapshot(context.snapshot)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.hunts.active() })
+    },
+  })
+}
+
+export function useActivateHuntMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (huntId: number) => {
+      updateHuntStatus(huntId, "Active")
+      return huntId
+    },
+    onMutate: async (huntId) => {
+      const snapshot = takeHuntStoreSnapshot()
+      await queryClient.cancelQueries({ queryKey: queryKeys.hunts.active() })
+      queryClient.setQueryData<StoredHunt[]>(queryKeys.hunts.active(), (existing = []) =>
+        existing.map((hunt) => (hunt.id === huntId ? { ...hunt, status: "Active" } : hunt))
+      )
+      return { snapshot }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.snapshot) {
+        restoreHuntStoreSnapshot(context.snapshot)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.hunts.active() })
+    },
+  })
+}

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,0 +1,30 @@
+export const queryKeys = {
+  hunts: {
+    active: () => ["hunts", "active"] as const,
+    featured: () => ["hunts", "featured"] as const,
+    detail: (huntId: number | string) => ["hunts", "detail", String(huntId)] as const,
+    clues: (huntId: number | null | undefined) => ["hunts", "clues", huntId ?? "unknown"] as const,
+  },
+  registration: {
+    status: (huntId: number | undefined, playerAddress: string | undefined) =>
+      ["registration", "status", huntId ?? "unknown", playerAddress ?? "anonymous"] as const,
+  },
+} as const
+
+export const queryCachePolicy = {
+  hunts: {
+    staleTime: 2 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchInterval: 90 * 1000,
+  },
+  featuredHunts: {
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchInterval: 2 * 60 * 1000,
+  },
+  registrationStatus: {
+    staleTime: 30 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchInterval: 45 * 1000,
+  },
+} as const


### PR DESCRIPTION
Implements a centralized React Query caching strategy with query key factory, per-query stale/cache policies, background refetching, optimistic mutation hooks, and prefetching for anticipated navigation.

Closes #651