### PR TITLE
Add test data factories and fixtures

### DIFF
--- a/lib/__tests__/testDataFactory.test.ts
+++ b/lib/__tests__/testDataFactory.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  createClue,
+  createHunt,
+  createPlayer,
+  createSharedFixtures,
+  seedTestData,
+} from "@/lib/test-utils/factories"
+
+describe("test data factories", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it("creates a hunt with realistic defaults and override support", () => {
+    const hunt = createHunt({ title: "Custom Hunt", status: "Active" })
+
+    expect(hunt.id).toBeGreaterThan(0)
+    expect(hunt.title).toBe("Custom Hunt")
+    expect(hunt.status).toBe("Active")
+    expect(hunt.description).toMatch(/\w+/)
+    expect(hunt.cluesCount).toBeGreaterThan(0)
+  })
+
+  it("creates a clue that is linked to a hunt and supports overrides", () => {
+    const clue = createClue({ huntId: 42, points: 25, difficulty: "Hard" })
+
+    expect(clue.huntId).toBe(42)
+    expect(clue.points).toBe(25)
+    expect(clue.difficulty).toBe("Hard")
+    expect(clue.question).toMatch(/\w+/)
+    expect(clue.answer).toMatch(/\w+/)
+  })
+
+  it("creates a player profile with realistic defaults and override support", () => {
+    const player = createPlayer({ name: "Ada", address: "GABC123" })
+
+    expect(player.name).toBe("Ada")
+    expect(player.address).toBe("GABC123")
+    expect(player.points).toBeGreaterThanOrEqual(0)
+    expect(player.completedHunts).toBeGreaterThanOrEqual(0)
+    expect(player.joinedAt).toBeGreaterThan(0)
+  })
+
+  it("offers shared fixtures for common test scenarios", () => {
+    const fixtures = createSharedFixtures()
+
+    expect(fixtures.activeScenario.hunt.status).toBe("Active")
+    expect(fixtures.activeScenario.clues).toHaveLength(3)
+    expect(fixtures.activeScenario.player.name).toMatch(/\w+/)
+
+    expect(fixtures.completedScenario.hunt.status).toBe("Completed")
+    expect(fixtures.draftScenario.hunt.status).toBe("Draft")
+  })
+
+  it("seeds localStorage for integration-style tests", () => {
+    const result = seedTestData({
+      huntOverrides: { title: "Seeded Hunt" },
+      clueOverrides: { question: "What is the answer?" },
+    })
+
+    expect(result.hunts[0].title).toBe("Seeded Hunt")
+    expect(result.clues[0].question).toBe("What is the answer?")
+    expect(localStorage.getItem("hunty_hunts")).toContain("Seeded Hunt")
+    expect(localStorage.getItem("hunty_clues")).toContain("What is the answer?")
+  })
+})

--- a/lib/test-utils/factories.ts
+++ b/lib/test-utils/factories.ts
@@ -1,0 +1,154 @@
+import { faker } from "@faker-js/faker"
+
+import type { Clue, HuntStatus, StoredHunt } from "@/lib/types"
+
+export interface TestPlayer {
+  name: string
+  address: string
+  points: number
+  completedHunts: number
+  joinedAt: number
+}
+
+type HuntFactoryOverrides = Partial<StoredHunt>
+type ClueFactoryOverrides = Partial<Clue> & { huntId?: number }
+type PlayerFactoryOverrides = Partial<TestPlayer> & {
+  name?: string
+  address?: string
+  points?: number
+  completedHunts?: number
+  joinedAt?: number
+}
+
+type SeedTestDataOptions = {
+  huntOverrides?: HuntFactoryOverrides
+  clueOverrides?: ClueFactoryOverrides
+  playerOverrides?: PlayerFactoryOverrides
+  clueCount?: number
+}
+
+export function createHunt(overrides: HuntFactoryOverrides = {}): StoredHunt {
+  const now = Math.floor(Date.now() / 1000)
+  const startTime = overrides.startTime ?? now - faker.number.int({ min: 1800, max: 7 * 86400 })
+  const endTime = overrides.endTime ?? startTime + faker.number.int({ min: 2 * 86400, max: 10 * 86400 })
+
+  return {
+    id: overrides.id ?? faker.number.int({ min: 100, max: 99999 }),
+    title: overrides.title ?? `${faker.lorem.word()} ${faker.lorem.word()} Hunt`,
+    description: overrides.description ?? faker.lorem.sentence(8),
+    cluesCount: overrides.cluesCount ?? faker.number.int({ min: 3, max: 8 }),
+    status: overrides.status ?? faker.helpers.arrayElement(["Active", "Draft", "Completed", "Cancelled"] as const),
+    rewardType: overrides.rewardType ?? faker.helpers.arrayElement(["XLM", "NFT", "Both"] as const),
+    rewardPool: overrides.rewardPool ?? faker.number.int({ min: 50, max: 500 }),
+    playerCount: overrides.playerCount ?? faker.number.int({ min: 0, max: 100 }),
+    createdAt: overrides.createdAt ?? now - faker.number.int({ min: 600, max: 7 * 86400 }),
+    startTime,
+    endTime,
+    creatorEmail: overrides.creatorEmail ?? faker.internet.email(),
+    emailNotifications: overrides.emailNotifications ?? faker.datatype.boolean(),
+    is_private: overrides.is_private ?? false,
+    coverImageCid: overrides.coverImageCid ?? faker.image.url(),
+    isFeaturedOfWeek: overrides.isFeaturedOfWeek ?? false,
+    ...overrides,
+  }
+}
+
+export function createClue(overrides: ClueFactoryOverrides = {}): Clue {
+  return {
+    id: overrides.id ?? faker.number.int({ min: 1, max: 9999 }),
+    huntId: overrides.huntId ?? faker.number.int({ min: 1, max: 9999 }),
+    question: overrides.question ?? faker.lorem.sentence(6),
+    answer: overrides.answer ?? faker.lorem.word(),
+    points: overrides.points ?? faker.number.int({ min: 10, max: 50 }),
+    hint: overrides.hint ?? faker.lorem.sentence(8),
+    hintCost: overrides.hintCost ?? faker.number.int({ min: 5, max: 20 }),
+    difficulty: overrides.difficulty ?? faker.helpers.arrayElement(["Easy", "Medium", "Hard"] as const),
+    latitude: overrides.latitude ?? faker.location.latitude(),
+    longitude: overrides.longitude ?? faker.location.longitude(),
+    geofenceRadiusMeters: overrides.geofenceRadiusMeters ?? faker.number.int({ min: 50, max: 250 }),
+    ...overrides,
+  }
+}
+
+export function createPlayer(overrides: PlayerFactoryOverrides = {}): TestPlayer {
+  return {
+    name: overrides.name ?? faker.person.fullName(),
+    address: overrides.address ?? `G${faker.string.alphanumeric({ length: 55, casing: "upper" })}`,
+    points: overrides.points ?? faker.number.int({ min: 0, max: 1000 }),
+    completedHunts: overrides.completedHunts ?? faker.number.int({ min: 0, max: 20 }),
+    joinedAt: overrides.joinedAt ?? Math.floor(Date.now() / 1000) - faker.number.int({ min: 86400, max: 30 * 86400 }),
+    ...overrides,
+  }
+}
+
+export function createSharedFixtures() {
+  const activeHunt = createHunt({
+    status: "Active",
+    title: "Active Fixture Hunt",
+    cluesCount: 3,
+    rewardType: "XLM",
+  })
+
+  const completedHunt = createHunt({
+    status: "Completed",
+    title: "Completed Fixture Hunt",
+    cluesCount: 2,
+    rewardType: "NFT",
+  })
+
+  const draftHunt = createHunt({
+    status: "Draft",
+    title: "Draft Fixture Hunt",
+    cluesCount: 0,
+    rewardType: "Both",
+  })
+
+  const activeClues = [
+    createClue({ huntId: activeHunt.id, question: "Where does the trail begin?", answer: "river" }),
+    createClue({ huntId: activeHunt.id, question: "What color is the beacon?", answer: "blue" }),
+    createClue({ huntId: activeHunt.id, question: "Which landmark is hidden nearby?", answer: "statue" }),
+  ]
+
+  return {
+    activeScenario: {
+      hunt: activeHunt,
+      clues: activeClues,
+      player: createPlayer({ name: "Nova Player" }),
+    },
+    completedScenario: {
+      hunt: completedHunt,
+      clues: [createClue({ huntId: completedHunt.id, question: "Where was the reward hidden?", answer: "garden" })],
+      player: createPlayer({ name: "Completed Player" }),
+    },
+    draftScenario: {
+      hunt: draftHunt,
+      clues: [],
+      player: createPlayer({ name: "Draft Player" }),
+    },
+  }
+}
+
+export function seedTestData(options: SeedTestDataOptions = {}) {
+  const hunt = createHunt(options.huntOverrides)
+  const clueCount = options.clueCount ?? 3
+  const clues = Array.from({ length: clueCount }, (_, index) =>
+    createClue({
+      id: index + 1,
+      huntId: hunt.id,
+      ...options.clueOverrides,
+    })
+  )
+  const player = createPlayer(options.playerOverrides)
+
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem("hunty_hunts", JSON.stringify([hunt]))
+    window.localStorage.setItem("hunty_clues", JSON.stringify(clues))
+  }
+
+  return {
+    hunt,
+    hunts: [hunt],
+    clues,
+    player,
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "galagiorchi",
+  "name": "hunty",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "galagiorchi",
+      "name": "hunty",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
@@ -8202,6 +8202,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.19.1",
     "html2canvas": "^1.4.1",
+    "isomorphic-dompurify": "^2.2.0",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.522.0",
     "next": "15.3.4",
@@ -39,18 +40,18 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.72.0",
     "react-joyride": "^3.0.0",
+    "rehype-sanitize": "^5.0.0",
     "resend": "^6.9.4",
     "sonner": "^2.0.7",
     "soroban-client": "^0.11.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
-    ,"isomorphic-dompurify": "^2.2.0",
-    "rehype-sanitize": "^5.0.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@eslint/eslintrc": "^3",
+    "@faker-js/faker": "^10.5.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.3
+      '@faker-js/faker':
+        specifier: ^10.5.0
+        version: 10.5.0
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -474,6 +477,10 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@faker-js/faker@10.5.0':
+    resolution: {integrity: sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@fastify/deepmerge@3.2.1':
     resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
@@ -3831,6 +3838,8 @@ snapshots:
   '@exodus/bytes@1.14.1(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
+
+  '@faker-js/faker@10.5.0': {}
 
   '@fastify/deepmerge@3.2.1': {}
 


### PR DESCRIPTION
## closes #671

### Summary
- Added reusable test data factories for hunts, clues, and players
- Integrated Faker.js for realistic default values
- Added configurable overrides for flexible test setup
- Added shared fixtures for common test scenarios
- Added a seed helper for integration-style tests using the app’s localStorage keys

### Testing
- Verified with:
  - `pnpm vitest --run lib/__tests__/testDataFactory.test.ts`

### Notes
- This provides a consistent foundation for building future unit and integration tests.