### PR TITLE
Feat/404 error pages

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { Home, RefreshCw, AlertTriangle } from "lucide-react";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    // Log to console in development; swap for Sentry/LogRocket in production.
+    console.error("[Hunty error boundary]", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-tr from-blue-50 via-purple-50 to-[#f9f9ff] dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 flex flex-col">
+      {/* Ambient blobs */}
+      <div className="fixed inset-0 pointer-events-none overflow-hidden">
+        <div className="absolute top-0 left-1/3 w-[500px] h-[400px] bg-[#E87785]/10 dark:bg-rose-700/20 rounded-full blur-[120px]" />
+        <div className="absolute bottom-0 right-1/4 w-[400px] h-[300px] bg-[#3737A4]/10 dark:bg-indigo-600/15 rounded-full blur-[100px]" />
+      </div>
+
+      <Header />
+
+      <main className="relative flex-1 flex flex-col items-center justify-center px-6 py-24 text-center">
+        {/* Illustration */}
+        <div className="relative mb-10 select-none" aria-hidden="true">
+          <div className="text-[clamp(96px,20vw,180px)] font-black leading-none bg-gradient-to-b from-[#E87785] to-[#3737A4] bg-clip-text text-transparent dark:from-rose-400 dark:to-indigo-400 tracking-tighter">
+            500
+          </div>
+          {/* Floating warning icon */}
+          <div className="absolute -top-4 -right-6 md:-right-12 w-16 h-16 md:w-20 md:h-20 rounded-full bg-gradient-to-br from-[#E87785] to-[#3737A4] flex items-center justify-center shadow-xl animate-pulse">
+            <AlertTriangle className="w-7 h-7 md:w-9 md:h-9 text-white" strokeWidth={2.5} />
+          </div>
+          {/* Decorative dots */}
+          <div className="absolute -bottom-2 -left-4 flex gap-1.5">
+            {[...Array(5)].map((_, i) => (
+              <span
+                key={i}
+                className="block w-2 h-2 rounded-full bg-[#E87785]/30 dark:bg-rose-400/30"
+                style={{ opacity: 1 - i * 0.15 }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Copy */}
+        <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 dark:text-white mb-3 tracking-tight">
+          Something went wrong
+        </h1>
+        <p className="text-slate-500 dark:text-slate-400 text-base md:text-lg mb-2 max-w-md">
+          An unexpected error occurred on our end. It&apos;s not you — it&apos;s us.
+        </p>
+        {error.digest && (
+          <p className="text-xs text-slate-400 dark:text-slate-500 font-mono mb-6">
+            Error ID: {error.digest}
+          </p>
+        )}
+
+        {/* CTAs */}
+        <div className="flex flex-col sm:flex-row gap-3 mt-4 mb-12">
+          <button
+            onClick={reset}
+            className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-[#E87785] to-[#3737A4] hover:opacity-90 text-white font-bold px-7 py-3.5 rounded-2xl shadow-lg transition-all hover:scale-[1.02] active:scale-[0.98]"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center gap-2 border-2 border-[#3737A4]/30 dark:border-indigo-500/30 text-[#3737A4] dark:text-indigo-400 hover:bg-[#3737A4]/5 dark:hover:bg-indigo-500/10 font-bold px-7 py-3.5 rounded-2xl transition-all hover:scale-[1.02] active:scale-[0.98]"
+          >
+            <Home className="w-4 h-4" />
+            Go home
+          </Link>
+        </div>
+
+        {/* What you can try */}
+        <div className="w-full max-w-sm text-left bg-white/80 dark:bg-slate-800/60 border border-slate-200 dark:border-white/10 rounded-2xl p-5 mb-8">
+          <p className="text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-3">
+            What you can try
+          </p>
+          <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 w-4 h-4 rounded-full bg-[#3737A4]/10 dark:bg-indigo-900/40 flex items-center justify-center flex-shrink-0">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#3737A4] dark:bg-indigo-400" />
+              </span>
+              Refresh the page and try again
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 w-4 h-4 rounded-full bg-[#3737A4]/10 dark:bg-indigo-900/40 flex items-center justify-center flex-shrink-0">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#3737A4] dark:bg-indigo-400" />
+              </span>
+              Check your internet connection
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 w-4 h-4 rounded-full bg-[#3737A4]/10 dark:bg-indigo-900/40 flex items-center justify-center flex-shrink-0">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#3737A4] dark:bg-indigo-400" />
+              </span>
+              Clear your browser cache and reload
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 w-4 h-4 rounded-full bg-[#3737A4]/10 dark:bg-indigo-900/40 flex items-center justify-center flex-shrink-0">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#3737A4] dark:bg-indigo-400" />
+              </span>
+              If the problem persists, report it below
+            </li>
+          </ul>
+        </div>
+
+        {/* Report link */}
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          Still broken?{" "}
+          <a
+            href={`https://github.com/Samuel1-ona/hunty/issues/new?title=Error+${encodeURIComponent(error.digest ?? "unknown")}&body=${encodeURIComponent(`Error digest: ${error.digest ?? "N/A"}\n\nSteps to reproduce:\n1. \n\nExpected behavior:\n\nActual behavior:\n`)}`}
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-[#3737A4] dark:hover:text-indigo-400 transition-colors"
+          >
+            Report this issue on GitHub
+          </a>
+        </p>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,27 +1,102 @@
 import Link from "next/link";
 import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { Home, Search, Trophy, Compass } from "lucide-react";
+
+const SUGGESTIONS = [
+  { href: "/", label: "Game Arcade", icon: Compass, desc: "Browse all active hunts" },
+  { href: "/dashboard", label: "My Hunts", icon: Trophy, desc: "View hunts you've joined" },
+  { href: "/hunty", label: "Create a Hunt", icon: Search, desc: "Start your own challenge" },
+];
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-[#0b0c10] text-white pb-24">
-      <div className="fixed inset-0 pointer-events-none">
-        <div className="absolute top-0 left-1/3 w-150 h-100 bg-violet-700/20 rounded-full blur-[120px]" />
-        <div className="absolute bottom-0 right-1/4 w-100p h-75 bg-indigo-600/15 rounded-full blur-[100px]" />
+    <div className="min-h-screen bg-gradient-to-tr from-blue-50 via-purple-50 to-[#f9f9ff] dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 flex flex-col">
+      {/* Ambient blobs */}
+      <div className="fixed inset-0 pointer-events-none overflow-hidden">
+        <div className="absolute top-0 left-1/3 w-[500px] h-[400px] bg-[#3737A4]/10 dark:bg-violet-700/20 rounded-full blur-[120px]" />
+        <div className="absolute bottom-0 right-1/4 w-[400px] h-[300px] bg-[#E87785]/10 dark:bg-indigo-600/15 rounded-full blur-[100px]" />
       </div>
 
       <Header />
 
-      <main className="relative max-w-3xl mx-auto px-6 pt-24 text-center">
-        <h1 className="text-6xl font-extrabold mb-4">404</h1>
-        <p className="text-zinc-400 text-lg mb-8">We couldn't find that hunt.</p>
-
-        <div className="mx-auto max-w-xl">
-          <p className="text-zinc-300 mb-6">The hunt you tried to access doesn't exist or may have been removed.</p>
-          <Link href="/" className="inline-flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-black font-semibold px-5 py-3 rounded-md">
-            Return to Game Arcade
-          </Link>
+      <main className="relative flex-1 flex flex-col items-center justify-center px-6 py-24 text-center">
+        {/* Illustration */}
+        <div className="relative mb-10 select-none" aria-hidden="true">
+          {/* Big 404 */}
+          <div className="text-[clamp(96px,20vw,180px)] font-black leading-none bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-transparent dark:from-indigo-400 dark:to-blue-300 tracking-tighter">
+            404
+          </div>
+          {/* Floating magnifier */}
+          <div className="absolute -top-4 -right-6 md:-right-12 w-16 h-16 md:w-20 md:h-20 rounded-full bg-gradient-to-br from-[#3737A4] to-[#E87785] flex items-center justify-center shadow-xl animate-bounce">
+            <Search className="w-7 h-7 md:w-9 md:h-9 text-white" strokeWidth={2.5} />
+          </div>
+          {/* Decorative dots */}
+          <div className="absolute -bottom-2 -left-4 flex gap-1.5">
+            {[...Array(5)].map((_, i) => (
+              <span
+                key={i}
+                className="block w-2 h-2 rounded-full bg-[#3737A4]/30 dark:bg-indigo-400/30"
+                style={{ opacity: 1 - i * 0.15 }}
+              />
+            ))}
+          </div>
         </div>
+
+        {/* Copy */}
+        <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 dark:text-white mb-3 tracking-tight">
+          This hunt has gone missing!
+        </h1>
+        <p className="text-slate-500 dark:text-slate-400 text-base md:text-lg mb-3 max-w-md">
+          The page you&apos;re looking for doesn&apos;t exist, was removed, or the link might be wrong.
+        </p>
+
+        {/* Primary CTA */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 bg-gradient-to-r from-[#3737A4] to-[#0C0C4F] hover:opacity-90 text-white font-bold px-7 py-3.5 rounded-2xl shadow-lg transition-all hover:scale-[1.02] active:scale-[0.98] mb-12"
+        >
+          <Home className="w-4 h-4" />
+          Back to Game Arcade
+        </Link>
+
+        {/* Search suggestions */}
+        <div className="w-full max-w-lg text-left">
+          <p className="text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-4 text-center">
+            Or try one of these
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {SUGGESTIONS.map(({ href, label, icon: Icon, desc }) => (
+              <Link
+                key={href}
+                href={href}
+                className="group flex flex-col items-center gap-2 p-4 rounded-2xl border border-slate-200 dark:border-white/10 bg-white/80 dark:bg-slate-800/60 hover:border-[#3737A4]/40 hover:shadow-md dark:hover:border-indigo-500/40 transition-all text-center"
+              >
+                <span className="w-10 h-10 rounded-xl bg-gradient-to-br from-[#3737A4]/10 to-[#E87785]/10 dark:from-indigo-900/40 dark:to-pink-900/20 flex items-center justify-center group-hover:from-[#3737A4]/20 group-hover:to-[#E87785]/20 transition-all">
+                  <Icon className="w-5 h-5 text-[#3737A4] dark:text-indigo-400" />
+                </span>
+                <span className="font-semibold text-slate-800 dark:text-slate-100 text-sm">{label}</span>
+                <span className="text-xs text-slate-500 dark:text-slate-400">{desc}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* Report link */}
+        <p className="mt-10 text-xs text-slate-400 dark:text-slate-500">
+          Think this is a mistake?{" "}
+          <a
+            href="https://github.com/Samuel1-ona/hunty/issues/new"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-[#3737A4] dark:hover:text-indigo-400 transition-colors"
+          >
+            Report an issue
+          </a>
+        </p>
       </main>
+
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
Closes #647 

- Custom 404 with floating search illustration, animated bounce icon
- Search suggestions grid (Arcade, My Hunts, Create a Hunt)
- Link back to home and report issue on GitHub
- 500 error page with retry button, error digest display
- What-to-try checklist on error page
- Auto-prefilled GitHub issue link with error digest
- Consistent branding: gradient text, brand colors, Header + Footer
- Dark mode support throughout"