### PR TITLE
feat(#634): add animated page transitions with Framer Motion

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -139,7 +139,19 @@
 .skip-to-content:focus {
   top: 1rem;
 }
+/* ─── Page transition ──────────────────────────────────────────────────────
+   The motion.div rendered by PageTransitionWrapper.
+   will-change promotes the layer early so the browser doesn't repaint the
+   full page on the first frame of each animation.
+   -------------------------------------------------------------------------- */
+[data-page-transition] {
+  will-change: opacity, transform;
+}
+
 @media (prefers-reduced-motion: reduce) {
+  /* CSS-level safety net on top of the JS useReducedMotion hook.
+     Framer Motion respects the hook, but this catches any edge cases
+     where the component hasn't hydrated yet. */
   *,
   *::before,
   *::after {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
 
 import "./globals.css"
 import { hankenGrotesk } from "@/lib/font"
 import { TxToaster } from "@/components/TxToaster"
 import Providers from "./providers"
+import { PageTransitionWrapper } from "@/components/PageTransitionWrapper"
+import { PageSkeleton } from "@/components/PageSkeleton"
 
 export const metadata: Metadata = {
   title: "Hunty - Decentralized Scavenger Hunt Game",
@@ -75,8 +78,20 @@ export default function RootLayout({
             Skip to content
           </a>
           <TxToaster />
+          {/*
+           * The <main> tag is the animation boundary.
+           * PageTransitionWrapper lives inside Providers (client tree) so
+           * it can read pathname and run AnimatePresence.
+           * Suspense catches any async page segments and shows the skeleton
+           * while they stream in — the same skeleton is also visible during
+           * the brief window between route change and first paint.
+           */}
           <main id="main-content">
-            {children}
+            <Suspense fallback={<PageSkeleton />}>
+              <PageTransitionWrapper>
+                {children}
+              </PageTransitionWrapper>
+            </Suspense>
           </main>
         </Providers>
       </body>

--- a/components/PageSkeleton.tsx
+++ b/components/PageSkeleton.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { motion, useReducedMotion } from "framer-motion"
+
+/**
+ * Generic full-page loading skeleton shown by the root Suspense boundary
+ * while a route segment is streaming in.
+ *
+ * Matches the site's colour palette and avoids layout shift by reserving
+ * a full viewport height.  Pulse animation is disabled when the user
+ * prefers reduced motion.
+ */
+export function PageSkeleton() {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <motion.div
+      role="status"
+      aria-label="Loading page…"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1, transition: { duration: 0.2 } }}
+      className="min-h-screen bg-gradient-to-tr from-blue-100 via-purple-50 to-[#f9f9ff] dark:from-slate-900 dark:via-slate-900 dark:to-slate-800"
+    >
+      {/* Simulated header bar */}
+      <div className="max-w-[1600px] mx-auto px-14 pt-8 pb-6 flex items-center justify-between">
+        <div
+          className={`h-8 w-24 rounded-xl bg-slate-200 dark:bg-slate-700 ${
+            shouldReduceMotion ? "" : "animate-pulse"
+          }`}
+        />
+        <div
+          className={`h-8 w-32 rounded-xl bg-slate-200 dark:bg-slate-700 ${
+            shouldReduceMotion ? "" : "animate-pulse"
+          }`}
+        />
+      </div>
+
+      {/* Content area */}
+      <div className="max-w-[1600px] mx-auto px-14 pt-8 space-y-6">
+        {/* Hero block */}
+        <div
+          className={`h-52 w-full rounded-3xl bg-slate-200 dark:bg-slate-700/60 ${
+            shouldReduceMotion ? "" : "animate-pulse"
+          }`}
+        />
+
+        {/* Card grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 pt-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className={`h-64 rounded-2xl bg-slate-200 dark:bg-slate-700/60 ${
+                shouldReduceMotion ? "" : "animate-pulse"
+              }`}
+              style={shouldReduceMotion ? {} : { animationDelay: `${i * 60}ms` }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Screen-reader only live region */}
+      <span className="sr-only" aria-live="polite">
+        Loading, please wait…
+      </span>
+    </motion.div>
+  )
+}

--- a/components/PageTransitionWrapper.tsx
+++ b/components/PageTransitionWrapper.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
+import { usePathname } from "next/navigation"
+import { type ReactNode, useEffect } from "react"
+
+/**
+ * Wraps every page in an AnimatePresence boundary so route changes
+ * produce a smooth fade + slight upward slide transition.
+ *
+ * Reduced-motion: when the OS "prefers-reduced-motion" flag is set
+ * the component still mounts/unmounts correctly but uses an instant
+ * opacity-only transition (no layout shift).
+ */
+export function PageTransitionWrapper({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  const shouldReduceMotion = useReducedMotion()
+
+  // Reset scroll to top on every route change so the incoming page
+  // always starts at the top — prevents a perceived layout shift where
+  // the new page appears mid-scroll from the previous route.
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "instant" })
+  }, [pathname])
+
+  const variants = {
+    initial: shouldReduceMotion
+      ? { opacity: 0 }
+      : { opacity: 0, y: 12 },
+    animate: shouldReduceMotion
+      ? { opacity: 1, transition: { duration: 0.15 } }
+      : { opacity: 1, y: 0, transition: { duration: 0.28, ease: [0.25, 0.1, 0.25, 1] } },
+    exit: shouldReduceMotion
+      ? { opacity: 0, transition: { duration: 0.1 } }
+      : { opacity: 0, y: -8, transition: { duration: 0.18, ease: [0.25, 0.1, 0.25, 1] } },
+  }
+
+  return (
+    // mode="wait" ensures the exit animation completes before the next
+    // page enters — avoids two pages overlapping in the DOM.
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.div
+        key={pathname}
+        data-page-transition          // ← activates will-change hint in globals.css
+        variants={variants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        style={{ minHeight: "inherit" }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  )
+}


### PR DESCRIPTION
- Add PageTransitionWrapper: AnimatePresence mode=wait with fade+slide variants keyed by pathname; useReducedMotion cuts motion to opacity-only
- Add PageSkeleton: full-page loading skeleton shown by Suspense fallback; pulse disabled under prefers-reduced-motion
- Wire both into app/layout.tsx inside <main> via Suspense boundary
- globals.css: will-change hint on [data-page-transition]; consolidate prefers-reduced-motion block as CSS-level safety net
- Scroll reset on pathname change prevents mid-scroll layout shift

Closes #634