### PR TITLE
feat(soroban): optimize RPC reads with batching, caching, and fallback

### DIFF
--- a/lib/soroban/SorobanContext.tsx
+++ b/lib/soroban/SorobanContext.tsx
@@ -15,6 +15,7 @@ import {
   createSorobanServer,
   getSorobanNetworkPassphrase,
   getSorobanRpcUrl,
+  getSorobanRpcOptimizer,
 } from "./client"
 
 export type SorobanConnectionStatus =
@@ -54,6 +55,7 @@ export function SorobanProvider({ children }: { children: ReactNode }) {
     setConnectionStatus("connecting")
     setConnectionError(null)
     const s = createSorobanServer()
+    getSorobanRpcOptimizer()
     setServer(s)
     try {
       const health = await s.getHealth()

--- a/lib/soroban/__tests__/rpcOptimization.test.ts
+++ b/lib/soroban/__tests__/rpcOptimization.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest"
+
+import { createSorobanRpcOptimizer } from "../rpcOptimization"
+
+describe("createSorobanRpcOptimizer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal("fetch", vi.fn())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("batches debounced reads, caches TTL values, and falls back to a secondary endpoint", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch as unknown as ReturnType<typeof vi.fn>)
+    fetchMock
+      .mockRejectedValueOnce(new Error("primary failed"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: "1", result: { value: "alpha" } },
+          { id: "2", result: { value: "beta" } },
+        ],
+      })
+
+    const optimizer = createSorobanRpcOptimizer({
+      primaryRpcUrl: "https://primary.example",
+      fallbackRpcUrl: "https://fallback.example",
+      debounceMs: 25,
+      ttlMs: 5_000,
+    })
+
+    const first = optimizer.readContractState({
+      key: "alpha",
+      method: "getContractData",
+      params: ["alpha"],
+    })
+    const second = optimizer.readContractState({
+      key: "beta",
+      method: "getContractData",
+      params: ["beta"],
+    })
+
+    vi.advanceTimersByTime(25)
+
+    const [alpha, beta] = await Promise.all([first, second])
+
+    expect(alpha).toEqual({ value: "alpha" })
+    expect(beta).toEqual({ value: "beta" })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0][0]).toBe("https://primary.example")
+    expect(fetchMock.mock.calls[1][0]).toBe("https://fallback.example")
+
+    const cached = await optimizer.readContractState({
+      key: "alpha",
+      method: "getContractData",
+      params: ["alpha"],
+    })
+    expect(cached).toEqual({ value: "alpha" })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/lib/soroban/client.ts
+++ b/lib/soroban/client.ts
@@ -1,4 +1,5 @@
 import Server from "@stellar/stellar-sdk";
+import { createSorobanRpcOptimizer } from "./rpcOptimization";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const SorobanServer = Server as any;
@@ -33,9 +34,19 @@ function getNetworkPassphrase(): string {
  * Creates a Soroban Server instance for the configured RPC URL.
  * Uses the same Server API as soroban-client (stellar-sdk is the maintained package).
  */
+let sharedServer: any | null = null;
+let sharedServerRpcUrl: string | null = null;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createSorobanServer(): any {
-  return new SorobanServer(getRpcUrl());
+  const rpcUrl = getRpcUrl();
+  if (sharedServer && sharedServerRpcUrl === rpcUrl) {
+    return sharedServer;
+  }
+
+  sharedServer = new SorobanServer(rpcUrl);
+  sharedServerRpcUrl = rpcUrl;
+  return sharedServer;
 }
 
 /**
@@ -50,4 +61,28 @@ export function getSorobanNetworkPassphrase(): string {
  */
 export function getSorobanRpcUrl(): string {
   return getRpcUrl();
+}
+
+let sharedOptimizer: ReturnType<typeof createSorobanRpcOptimizer> | null = null
+
+export function getSorobanRpcOptimizer(): ReturnType<typeof createSorobanRpcOptimizer> {
+  if (!sharedOptimizer) {
+    sharedOptimizer = createSorobanRpcOptimizer({
+      primaryRpcUrl: getRpcUrl(),
+      fallbackRpcUrl: process.env.NEXT_PUBLIC_SOROBAN_FALLBACK_RPC_URL,
+      debounceMs: Number(process.env.NEXT_PUBLIC_SOROBAN_DEBOUNCE_MS ?? 50),
+      ttlMs: Number(process.env.NEXT_PUBLIC_SOROBAN_READ_TTL_MS ?? 30_000),
+    })
+  }
+
+  return sharedOptimizer
+}
+
+export async function readSorobanContractState<T>(request: {
+  key: string
+  method: string
+  params?: unknown[]
+  parser?: (response: unknown) => unknown
+}): Promise<T> {
+  return getSorobanRpcOptimizer().readContractState<T>(request)
 }

--- a/lib/soroban/rpcOptimization.ts
+++ b/lib/soroban/rpcOptimization.ts
@@ -1,0 +1,175 @@
+export type SorobanReadRequest = {
+  key: string
+  method: string
+  params?: unknown[]
+  parser?: (response: unknown) => unknown
+}
+
+export type SorobanRpcOptimizerOptions = {
+  primaryRpcUrl?: string
+  fallbackRpcUrl?: string
+  debounceMs?: number
+  ttlMs?: number
+  fetchImpl?: typeof fetch
+}
+
+type PendingBatchEntry = {
+  request: SorobanReadRequest
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+}
+
+type CacheEntry<T = unknown> = {
+  value: T
+  expiresAt: number
+}
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+export class SorobanRpcOptimizer {
+  private readonly primaryRpcUrl: string
+  private readonly fallbackRpcUrl?: string
+  private readonly debounceMs: number
+  private readonly ttlMs: number
+  private readonly fetchImpl: typeof fetch
+
+  private readonly pendingCache = new Map<string, CacheEntry>()
+  private readonly inflightRequests = new Map<string, Promise<unknown>>()
+  private readonly pendingBatch: PendingBatchEntry[] = []
+  private batchTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(options: SorobanRpcOptimizerOptions = {}) {
+    this.primaryRpcUrl = options.primaryRpcUrl ?? "https://rpc.futurenet.stellar.org"
+    this.fallbackRpcUrl = options.fallbackRpcUrl
+    this.debounceMs = options.debounceMs ?? 50
+    this.ttlMs = options.ttlMs ?? 30_000
+    this.fetchImpl = options.fetchImpl ?? fetch
+  }
+
+  async readContractState<T>(request: SorobanReadRequest): Promise<T> {
+    const cacheKey = request.key
+    const cached = this.pendingCache.get(cacheKey)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value as T
+    }
+
+    const inFlight = this.inflightRequests.get(cacheKey)
+    if (inFlight) {
+      return inFlight as Promise<T>
+    }
+
+    const deferred = createDeferred<T>()
+    this.inflightRequests.set(cacheKey, deferred.promise)
+
+    this.pendingBatch.push({
+      request,
+      resolve: (value) => deferred.resolve(value as T),
+      reject: (reason) => deferred.reject(reason),
+    })
+
+    if (!this.batchTimer) {
+      this.batchTimer = setTimeout(() => {
+        void this.flushBatch()
+      }, this.debounceMs)
+    }
+
+    return deferred.promise
+  }
+
+  clearCache(key?: string): void {
+    if (key) {
+      this.pendingCache.delete(key)
+      this.inflightRequests.delete(key)
+      return
+    }
+
+    this.pendingCache.clear()
+    this.inflightRequests.clear()
+  }
+
+  private async flushBatch(): Promise<void> {
+    const batch = this.pendingBatch.splice(0, this.pendingBatch.length)
+    this.batchTimer = null
+
+    if (batch.length === 0) {
+      return
+    }
+
+    try {
+      const results = await this.executeBatch(batch.map((entry) => entry.request))
+      batch.forEach((entry, index) => {
+        const value = results[index]
+        this.pendingCache.set(entry.request.key, {
+          value,
+          expiresAt: Date.now() + this.ttlMs,
+        })
+        entry.resolve(value)
+        this.inflightRequests.delete(entry.request.key)
+      })
+    } catch (error) {
+      batch.forEach((entry) => {
+        entry.reject(error)
+        this.inflightRequests.delete(entry.request.key)
+      })
+    }
+  }
+
+  private async executeBatch(requests: SorobanReadRequest[]): Promise<unknown[]> {
+    const endpoints = [this.primaryRpcUrl, this.fallbackRpcUrl].filter(Boolean) as string[]
+    let lastError: unknown
+
+    for (const endpoint of endpoints) {
+      try {
+        const response = await this.fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(
+            requests.map((request, index) => ({
+              jsonrpc: "2.0",
+              id: index + 1,
+              method: request.method,
+              params: request.params ?? [],
+            }))
+          ),
+        })
+
+        if (!response.ok) {
+          throw new Error(`RPC request failed with status ${response.status}`)
+        }
+
+        const body = (await response.json()) as unknown
+        const payloads = Array.isArray(body) ? body : [body]
+        return payloads.map((payload, index) => {
+          const parsed = (payload as { result?: unknown }).result
+          const value = parsed !== undefined ? parsed : payload
+          const request = requests[index]
+          return request.parser ? request.parser(value) : value
+        })
+      } catch (error) {
+        lastError = error
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error("Soroban RPC batch request failed")
+  }
+}
+
+export function createSorobanRpcOptimizer(options: SorobanRpcOptimizerOptions = {}): SorobanRpcOptimizer {
+  return new SorobanRpcOptimizer(options)
+}


### PR DESCRIPTION
closes #656 

PR Description
Summary
This change reduces Soroban RPC call volume by introducing a shared RPC optimization layer for contract-state reads.

What changed
Added a Soroban RPC optimizer that:
batches multiple read requests into a single RPC call
debounces rapid successive calls
caches query results with a TTL
falls back to a secondary RPC endpoint when the primary fails
Reused the Soroban server instance to improve connection reuse and reduce overhead
Added a regression test covering batching, caching, and fallback behavior
Files updated
[rpcOptimization.ts](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)
[client.ts](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)
[SorobanContext.tsx](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)
[rpcOptimization.test.ts](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)PR Description
Summary
This change reduces Soroban RPC call volume by introducing a shared RPC optimization layer for contract-state reads.

What changed
Added a Soroban RPC optimizer that:
batches multiple read requests into a single RPC call
debounces rapid successive calls
caches query results with a TTL
falls back to a secondary RPC endpoint when the primary fails
Reused the Soroban server instance to improve connection reuse and reduce overhead
Added a regression test covering batching, caching, and fallback behavior
Files updated
[rpcOptimization.ts](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)
[client.ts](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)
[SorobanContext.tsx](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)
[rpcOptimization.test.ts](https://turbo-space-guide-wvrv57w77j7wf55v7.github.dev/)

