### PR TITLE
Add Reward History UI for Player and Creator Pages

### DIFF
--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -7,9 +7,11 @@ import { ArrowLeft, Pencil, BarChart3 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardDescription, CardTitle } from "@/components/ui/card"
 import { Header } from "@/components/Header"
+import { RewardHistorySection } from "@/components/RewardHistorySection"
 import { useWallet } from "@/lib/context/WalletContext"
 import type { StoredHunt } from "@/lib/types"
 import { getHuntsByCreator } from "@/lib/huntStore"
+import { fetchCreatorRewardHistory } from "@/lib/rewardHistory"
 
 function StatusBadge({ status }: { status: StoredHunt["status"] }) {
   const config = {
@@ -32,6 +34,7 @@ export default function CreatorPage() {
   const router = useRouter()
   const { connected, publicKey, connect } = useWallet()
   const [hunts, setHunts] = useState<StoredHunt[]>([])
+  const [rewardHistory, setRewardHistory] = useState<Awaited<ReturnType<typeof fetchCreatorRewardHistory>>>([])
 
   const loadHunts = useCallback(() => {
     if (!publicKey) {
@@ -44,6 +47,30 @@ export default function CreatorPage() {
   useEffect(() => {
     loadHunts()
   }, [loadHunts])
+
+  useEffect(() => {
+    if (!publicKey) {
+      setRewardHistory([])
+      return
+    }
+
+    let cancelled = false
+
+    const loadRewardHistory = async () => {
+      try {
+        const data = await fetchCreatorRewardHistory(publicKey)
+        if (!cancelled) setRewardHistory(data)
+      } catch (err) {
+        console.error("Failed to load creator reward history:", err)
+      }
+    }
+
+    loadRewardHistory()
+
+    return () => {
+      cancelled = true
+    }
+  }, [publicKey])
 
   const handleCardClick = (hunt: StoredHunt) => {
     if (hunt.status === "Draft") {
@@ -110,54 +137,66 @@ export default function CreatorPage() {
             </div>
           </Card>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {hunts.map((hunt) => {
-              const isDraft = hunt.status === "Draft"
-              const isActive = hunt.status === "Active"
-              const isClickable = isDraft || isActive
+          <>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {hunts.map((hunt) => {
+                const isDraft = hunt.status === "Draft"
+                const isActive = hunt.status === "Active"
+                const isClickable = isDraft || isActive
 
-              return (
-                <Card
-                  key={hunt.id}
-                  className={`overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-shadow ${
-                    isClickable
-                      ? "cursor-pointer hover:shadow-md"
-                      : "opacity-90"
-                  }`}
-                  onClick={() => isClickable && handleCardClick(hunt)}
-                >
-                  <div className="p-5">
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <CardTitle className="line-clamp-2 text-lg">
-                        {hunt.title}
-                      </CardTitle>
-                      <StatusBadge status={hunt.status} />
-                    </div>
-                    <CardDescription className="mb-4 line-clamp-3 text-sm text-slate-600">
-                      {hunt.description}
-                    </CardDescription>
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <span className="text-xs text-slate-500">
-                        {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
-                      </span>
-                      {isDraft && (
-                        <span className="flex items-center gap-1 text-xs text-amber-700">
-                          <Pencil className="h-3 w-3" />
-                          Edit
+                return (
+                  <Card
+                    key={hunt.id}
+                    className={`overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-shadow ${
+                      isClickable
+                        ? "cursor-pointer hover:shadow-md"
+                        : "opacity-90"
+                    }`}
+                    onClick={() => isClickable && handleCardClick(hunt)}
+                  >
+                    <div className="p-5">
+                      <div className="mb-2 flex items-center justify-between gap-2">
+                        <CardTitle className="line-clamp-2 text-lg">
+                          {hunt.title}
+                        </CardTitle>
+                        <StatusBadge status={hunt.status} />
+                      </div>
+                      <CardDescription className="mb-4 line-clamp-3 text-sm text-slate-600">
+                        {hunt.description}
+                      </CardDescription>
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="text-xs text-slate-500">
+                          {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
                         </span>
-                      )}
-                      {isActive && (
-                        <span className="flex items-center gap-1 text-xs text-emerald-700">
-                          <BarChart3 className="h-3 w-3" />
-                          Live Statistics
-                        </span>
-                      )}
+                        {isDraft && (
+                          <span className="flex items-center gap-1 text-xs text-amber-700">
+                            <Pencil className="h-3 w-3" />
+                            Edit
+                          </span>
+                        )}
+                        {isActive && (
+                          <span className="flex items-center gap-1 text-xs text-emerald-700">
+                            <BarChart3 className="h-3 w-3" />
+                            Live Statistics
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                </Card>
-              )
-            })}
-          </div>
+                  </Card>
+                )
+              })}
+            </div>
+
+            <div className="mt-10">
+              <RewardHistorySection
+                title="Reward Distribution"
+                description="All rewards you distributed across your created hunts, with explorer links and filters."
+                entries={rewardHistory}
+                showRecipient
+                recipientLabel="Recipient"
+              />
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -12,6 +12,8 @@ import { WalletContext, shortenAddress } from "@/lib/context/WalletContext"
 import { NftGallery } from "@/components/NftGallery"
 import { BadgeWall } from "@/components/BadgeWall"
 import type { NftRewardDetail } from "@/components/NftDetailModal"
+import { RewardHistorySection } from "@/components/RewardHistorySection"
+import { fetchPlayerRewardHistory } from "@/lib/rewardHistory"
 
 // ---------------------------------------------------------------------------
 // #355 — Registered Hunts types and fetcher
@@ -173,6 +175,7 @@ export default function UserProfilePage() {
   const publicKey = wallet?.publicKey ?? ""
   const [hunts, setHunts] = useState<PlayerHuntProgress[]>([])
   const [nftRewards, setNftRewards] = useState<NftReward[]>([])
+  const [rewardHistory, setRewardHistory] = useState<ReturnType<typeof fetchPlayerRewardHistory> extends Promise<infer U> ? U : never>([])
   const [registrations, setRegistrations] = useState<RegisteredHunt[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -226,9 +229,19 @@ export default function UserProfilePage() {
       }
     }
 
+    const loadRewardHistory = async () => {
+      try {
+        const data = await fetchPlayerRewardHistory(publicKey!)
+        if (!cancelled) setRewardHistory(data)
+      } catch (err) {
+        logger.error("Failed to load reward history:", err)
+      }
+    }
+
     load()
     loadRewards()
     loadRegistrations()
+    loadRewardHistory()
 
     return () => {
       cancelled = true
@@ -355,6 +368,12 @@ export default function UserProfilePage() {
               
               <NftGallery nfts={nftRewards} />
             </section>
+
+            <RewardHistorySection
+              title="Reward History"
+              description="All rewards you have received, with transaction links and date filters."
+              entries={rewardHistory}
+            />
 
             <section aria-label="Achievements" className="mt-8">
               <BadgeWall playerAddress={publicKey} />

--- a/components/RewardHistorySection.tsx
+++ b/components/RewardHistorySection.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { ArrowRight, CalendarDays, ExternalLink, Gift, Sparkles } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { RewardHistoryEntry, RewardHistoryType } from "@/lib/types"
+import { formatISOString } from "@/lib/dateUtils"
+
+const DATE_RANGES = [
+  { id: "all", label: "All time" },
+  { id: "7", label: "Last 7 days" },
+  { id: "30", label: "Last 30 days" },
+  { id: "90", label: "Last 90 days" },
+]
+
+const TYPE_FILTERS: Array<{ id: RewardHistoryType | "All"; label: string }> = [
+  { id: "All", label: "All" },
+  { id: "XLM", label: "XLM" },
+  { id: "NFT", label: "NFT" },
+]
+
+interface RewardHistorySectionProps {
+  title: string
+  description: string
+  entries: RewardHistoryEntry[]
+  showRecipient?: boolean
+  recipientLabel?: string
+}
+
+export function RewardHistorySection({
+  title,
+  description,
+  entries,
+  showRecipient = false,
+  recipientLabel = "Recipient",
+}: RewardHistorySectionProps) {
+  const [typeFilter, setTypeFilter] = useState<RewardHistoryType | "All">("All")
+  const [dateFilter, setDateFilter] = useState<string>("all")
+
+  const filteredEntries = useMemo(() => {
+    const now = Date.now()
+    return entries.filter((entry) => {
+      if (typeFilter !== "All" && entry.type !== typeFilter) return false
+
+      if (dateFilter !== "all") {
+        const days = Number(dateFilter)
+        const threshold = now - days * 24 * 60 * 60 * 1000
+        const timestamp = new Date(entry.earnedAt).getTime()
+        if (Number.isNaN(timestamp) || timestamp < threshold) {
+          return false
+        }
+      }
+
+      return true
+    })
+  }, [entries, typeFilter, dateFilter])
+
+  const summary = useMemo(() => {
+    const totalXlm = entries.filter((entry) => entry.type === "XLM").reduce((sum, entry) => sum + (entry.amount ?? 0), 0)
+    const totalNfts = entries.filter((entry) => entry.type === "NFT").length
+    const totalTx = entries.length
+    return { totalXlm, totalNfts, totalTx }
+  }, [entries])
+
+  return (
+    <section aria-label={title} className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h2 className="text-xl md:text-2xl font-bold text-slate-900">{title}</h2>
+          <p className="text-sm text-slate-500 mt-1">{description}</p>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3 sm:grid-cols-3">
+          <Card className="rounded-3xl border border-slate-200 bg-slate-50 p-4 shadow-sm">
+            <CardTitle className="text-sm text-slate-500">Total Distributed</CardTitle>
+            <CardContent className="p-0 mt-3 text-2xl font-semibold text-slate-900">{summary.totalTx}</CardContent>
+          </Card>
+          <Card className="rounded-3xl border border-slate-200 bg-slate-50 p-4 shadow-sm">
+            <CardTitle className="text-sm text-slate-500">XLM Total</CardTitle>
+            <CardContent className="p-0 mt-3 text-2xl font-semibold text-emerald-700">{summary.totalXlm.toFixed(2)}</CardContent>
+          </Card>
+          <Card className="rounded-3xl border border-slate-200 bg-slate-50 p-4 shadow-sm">
+            <CardTitle className="text-sm text-slate-500">NFT Events</CardTitle>
+            <CardContent className="p-0 mt-3 text-2xl font-semibold text-violet-700">{summary.totalNfts}</CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+        <div className="grid grid-cols-3 gap-2">
+          {TYPE_FILTERS.map((filter) => (
+            <Button
+              key={filter.id}
+              variant={typeFilter === filter.id ? "default" : "outline"}
+              className="text-sm"
+              onClick={() => setTypeFilter(filter.id)}
+            >
+              {filter.label}
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-4 w-4 text-slate-500" />
+          <div className="flex flex-wrap items-center gap-2">
+            {DATE_RANGES.map((range) => (
+              <Button
+                key={range.id}
+                variant={dateFilter === range.id ? "default" : "outline"}
+                className="text-sm"
+                onClick={() => setDateFilter(range.id)}
+              >
+                {range.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+        <div className="grid grid-cols-[1.7fr_0.7fr_0.7fr_1.1fr_1.4fr] gap-0 border-b border-slate-200 bg-slate-50 px-4 py-3 text-xs uppercase tracking-[0.16em] text-slate-500">
+          <span>Reward</span>
+          <span>Type</span>
+          <span>{showRecipient ? recipientLabel : "Amount"}</span>
+          <span>Date</span>
+          <span className="text-right">Transaction</span>
+        </div>
+
+        {filteredEntries.length === 0 ? (
+          <div className="px-4 py-10 text-center text-slate-500">
+            No reward history matches this filter.
+          </div>
+        ) : (
+          <div className="divide-y divide-slate-200">
+            {filteredEntries.map((entry) => (
+              <div key={entry.id} className="grid grid-cols-[1.7fr_0.7fr_0.7fr_1.1fr_1.4fr] gap-0 px-4 py-4 items-center text-sm text-slate-700">
+                <div className="space-y-1">
+                  <p className="font-semibold text-slate-900">{entry.huntName ?? "Unknown Hunt"}</p>
+                  <p className="text-xs text-slate-500">{entry.description}</p>
+                </div>
+                <span className="font-semibold text-slate-900">{entry.type}</span>
+                <span className="font-medium text-slate-900">
+                  {showRecipient ? entry.recipient ?? "—" : entry.type === "XLM" ? `${entry.amount?.toFixed(2)} XLM` : "NFT"}
+                </span>
+                <span className="text-slate-500">{formatISOString(entry.earnedAt)}</span>
+                <div className="flex justify-end">
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="h-9 rounded-full text-xs px-3"
+                  >
+                    <a href={entry.explorerUrl} target="_blank" rel="noreferrer noopener">
+                      <span className="inline-flex items-center gap-1">
+                        Explorer <ExternalLink className="h-3.5 w-3.5" />
+                      </span>
+                    </a>
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/lib/rewardHistory.ts
+++ b/lib/rewardHistory.ts
@@ -1,0 +1,116 @@
+import { getHuntsByCreator, getHuntById } from "@/lib/huntStore"
+import { NETWORK_PASSPHRASE } from "@/lib/contracts/config"
+import type { RewardHistoryEntry, RewardHistoryType } from "@/lib/types"
+
+const DEFAULT_PLAYER_HISTORY: RewardHistoryEntry[] = [
+  {
+    id: "player-xlm-1",
+    type: "XLM",
+    amount: 12.5,
+    description: "Claimed first place completion reward",
+    txHash: "mock_tx_xlm_1",
+    earnedAt: "2026-02-10T15:16:00Z",
+    huntId: 1,
+    huntName: "City Secrets",
+    explorerUrl: "https://stellar.expert/explorer/testnet/tx/mock_tx_xlm_1",
+  },
+  {
+    id: "player-nft-1",
+    type: "NFT",
+    description: "Unlocked collectible reward for completing City Secrets.",
+    txHash: "mock_tx_nft_1",
+    earnedAt: "2026-02-10T15:18:00Z",
+    huntId: 1,
+    huntName: "City Secrets",
+    explorerUrl: "https://stellar.expert/explorer/testnet/tx/mock_tx_nft_1",
+  },
+  {
+    id: "player-xlm-2",
+    type: "XLM",
+    amount: 3.75,
+    description: "Claimed bonus reward for fast completion.",
+    txHash: "mock_tx_xlm_2",
+    earnedAt: "2026-03-04T12:02:00Z",
+    huntId: 3,
+    huntName: "Office Onboarding Hunt",
+    explorerUrl: "https://stellar.expert/explorer/testnet/tx/mock_tx_xlm_2",
+  },
+  {
+    id: "player-nft-2",
+    type: "NFT",
+    description: "Unlocked Explorer Trophy reward.",
+    txHash: "mock_tx_nft_2",
+    earnedAt: "2026-02-20T11:26:00Z",
+    huntId: 3,
+    huntName: "Office Onboarding Hunt",
+    explorerUrl: "https://stellar.expert/explorer/testnet/tx/mock_tx_nft_2",
+  },
+]
+
+const DEFAULT_CREATOR_HISTORY: RewardHistoryEntry[] = [
+  {
+    id: "creator-xlm-1",
+    type: "XLM",
+    amount: 150,
+    description: "Distributed XLM reward pool to top finishers.",
+    txHash: "mock_tx_dist_xlm_1",
+    earnedAt: "2026-02-10T15:20:00Z",
+    huntId: 1,
+    huntName: "City Secrets",
+    recipient: "GAD7...FGHA",
+    explorerUrl: "https://stellar.expert/explorer/testnet/tx/mock_tx_dist_xlm_1",
+  },
+  {
+    id: "creator-nft-1",
+    type: "NFT",
+    description: "Minted and distributed the Golden Compass collectible.",
+    txHash: "mock_tx_dist_nft_1",
+    earnedAt: "2026-02-10T15:22:00Z",
+    huntId: 1,
+    huntName: "City Secrets",
+    recipient: "GAD7...FGHA",
+    explorerUrl: "https://stellar.expert/explorer/testnet/tx/mock_tx_dist_nft_1",
+  },
+  {
+    id: "creator-xlm-2",
+    type: "XLM",
+    amount: 40,
+    description: "Distributed XLM bonus rewards for Campus Quest.",
+    txHash: "mock_tx_dist_xlm_2",
+    earnedAt: "2026-02-18T19:05:00Z",
+    huntId: 2,
+    huntName: "Campus Quest",
+    recipient: "GBYL...KQTC",
+    explorerUrl: "https://stellar.expert/explorer/testnet/tx/mock_tx_dist_xlm_2",
+  },
+]
+
+function getExplorerUrl(hash: string): string {
+  if (!hash) return "#"
+  const network = NETWORK_PASSPHRASE.toLowerCase()
+  const isPublic = !/future|test/i.test(network)
+  return isPublic
+    ? `https://stellar.expert/explorer/public/tx/${hash}`
+    : `https://stellar.expert/explorer/testnet/tx/${hash}`
+}
+
+export async function fetchPlayerRewardHistory(address: string): Promise<RewardHistoryEntry[]> {
+  if (!address) return []
+  return DEFAULT_PLAYER_HISTORY.map((entry) => ({
+    ...entry,
+    explorerUrl: getExplorerUrl(entry.txHash),
+  }))
+}
+
+export async function fetchCreatorRewardHistory(address: string): Promise<RewardHistoryEntry[]> {
+  if (!address) return []
+
+  const hunts = getHuntsByCreator(address)
+  const huntMap = new Map<number, string>(hunts.map((hunt) => [hunt.id, hunt.title]))
+
+  return DEFAULT_CREATOR_HISTORY.map((entry) => ({
+    ...entry,
+    huntName: huntMap.get(entry.huntId ?? -1) ?? entry.huntName,
+    explorerUrl: getExplorerUrl(entry.txHash),
+  }))
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -181,6 +181,21 @@ export interface RewardPlayerProgress {
   hunt_id?: number | string
 }
 
+export type RewardHistoryType = "XLM" | "NFT"
+
+export interface RewardHistoryEntry {
+  id: string
+  type: RewardHistoryType
+  amount?: number
+  description: string
+  txHash: string
+  earnedAt: string
+  huntId?: number
+  huntName?: string
+  recipient?: string
+  explorerUrl: string
+}
+
 // ─── Activity Feed ───────────────────────────────────────────────────────────
 
 export type ActivityEventType = "HuntCompleted" | "ClueCompleted"


### PR DESCRIPTION
Description
Implements comprehensive reward history views for both players and creators, enabling users to track all rewards earned/distributed with transaction details and filtering capabilities.

Changes
lib/types.ts — Added RewardHistoryType and RewardHistoryEntry shared types
lib/rewardHistory.ts (new) — Mock reward history data and explorer URL generator for both player and creator workflows
components/RewardHistorySection.tsx (new) — Reusable UI component with:
Type filtering (XLM / NFT / All)
Date range filtering (All time / Last 7/30/90 days)
Summary totals (transaction count, XLM sum, NFT count)