### PR TITLE
feat: add leaderboard filtering by time period, category, difficulty and metric

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import { Suspense, useCallback, useEffect, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import Link from "next/link"
+import { ArrowLeft, Copy, Check, Trophy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Header } from "@/components/Header"
+import { LeaderboardTable } from "@/components/LeaderBoardTable"
+import { LeaderboardFilterBar } from "@/components/LeaderboardFilterBar"
+import type { LeaderboardFilters, LeaderboardTimePeriod, LeaderboardMetric } from "@/lib/types"
+import type { ClueDifficulty } from "@/lib/types"
+
+const DEFAULT_FILTERS: LeaderboardFilters = {
+  timePeriod: "all",
+  category: "all",
+  difficulty: "all",
+  metric: "points",
+}
+
+function parseFiltersFromParams(params: URLSearchParams): LeaderboardFilters {
+  const timePeriod = params.get("period") as LeaderboardTimePeriod | null
+  const category = params.get("category") ?? "all"
+  const difficulty = params.get("difficulty") as ClueDifficulty | "all" | null
+  const metric = params.get("metric") as LeaderboardMetric | null
+
+  const validPeriods: LeaderboardTimePeriod[] = ["today", "week", "month", "all"]
+  const validDifficulties: (ClueDifficulty | "all")[] = ["all", "Easy", "Medium", "Hard"]
+  const validMetrics: LeaderboardMetric[] = ["points", "completions"]
+
+  return {
+    timePeriod: timePeriod && validPeriods.includes(timePeriod) ? timePeriod : DEFAULT_FILTERS.timePeriod,
+    category: category || DEFAULT_FILTERS.category,
+    difficulty: difficulty && validDifficulties.includes(difficulty) ? difficulty : DEFAULT_FILTERS.difficulty,
+    metric: metric && validMetrics.includes(metric) ? metric : DEFAULT_FILTERS.metric,
+  }
+}
+
+function LeaderboardContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [filters, setFilters] = useState<LeaderboardFilters>(() => parseFiltersFromParams(searchParams))
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    setFilters(parseFiltersFromParams(searchParams))
+  }, [searchParams])
+
+  const handleFilterChange = useCallback((updated: Partial<LeaderboardFilters>) => {
+    setFilters((prev) => {
+      const next = { ...prev, ...updated }
+      const params = new URLSearchParams()
+      if (next.timePeriod !== "all") params.set("period", next.timePeriod)
+      if (next.category !== "all") params.set("category", next.category)
+      if (next.difficulty !== "all") params.set("difficulty", next.difficulty)
+      if (next.metric !== "points") params.set("metric", next.metric)
+      const query = params.toString()
+      router.replace(`/leaderboard${query ? `?${query}` : ""}`, { scroll: false })
+      return next
+    })
+  }, [router])
+
+  const handleCopyLink = useCallback(() => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }, [])
+
+  const isFiltered =
+    filters.timePeriod !== "all" ||
+    filters.category !== "all" ||
+    filters.difficulty !== "all" ||
+    filters.metric !== "points"
+
+  return (
+    <>
+      <div className="mb-6 flex items-center justify-between gap-4 flex-wrap">
+        <Button variant="ghost" asChild className="flex items-center gap-2 text-zinc-400 hover:text-white hover:bg-white/5">
+          <Link href="/">
+            <ArrowLeft className="h-4 w-4" />
+            Back to Arcade
+          </Link>
+        </Button>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleCopyLink}
+          className="flex items-center gap-2 border-white/20 text-white hover:bg-white/10"
+        >
+          {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
+          {copied ? "Copied!" : "Share filtered view"}
+        </Button>
+      </div>
+
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl sm:text-4xl font-bold tracking-tight text-white leading-tight">
+          Global Leaderboard
+        </h1>
+        <p className="text-zinc-400 text-base">
+          Rankings across all hunts - auto-refreshes every 30 seconds
+        </p>
+      </div>
+
+      <div className="bg-white/5 border border-white/10 rounded-2xl p-5 mb-6">
+        <LeaderboardFilterBar filters={filters} onChange={handleFilterChange} />
+      </div>
+
+      {isFiltered && (
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-xs text-zinc-500">Active filters applied.</span>
+          <button
+            onClick={() => {
+              router.replace("/leaderboard", { scroll: false })
+              setFilters(DEFAULT_FILTERS)
+            }}
+            className="text-xs text-[#6b8cff] hover:underline"
+          >
+            Clear all
+          </button>
+        </div>
+      )}
+
+      <div className="bg-white/5 border border-white/10 rounded-2xl p-6 shadow-inner">
+        <LeaderboardTable huntId={1} filters={filters} />
+      </div>
+    </>
+  )
+}
+
+export default function LeaderboardPage() {
+  return (
+    <div className="min-h-screen bg-[#0b0c10] text-white pb-12 relative">
+      <div className="fixed inset-0 pointer-events-none">
+        <div className="absolute top-0 left-1/3 w-150 h-100 bg-violet-700/20 rounded-full blur-[120px]" />
+        <div className="absolute bottom-0 right-1/4 w-100 h-75 bg-indigo-600/15 rounded-full blur-[100px]" />
+      </div>
+
+      <Header />
+
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8 relative z-10">
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center py-20">
+              <Trophy className="w-8 h-8 text-zinc-600 animate-pulse" />
+            </div>
+          }
+        >
+          <LeaderboardContent />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -656,18 +656,28 @@ export default function GameArcade() {
         {activeTab === "leaderboard" && (
           <div className="mb-12 animate-in fade-in slide-in-from-top-4 duration-300">
             <div className="max-w-4xl mx-auto bg-[#f9f9ff] rounded-3xl p-8 border border-slate-100 shadow-inner">
-              <div className="flex items-center justify-between mb-6">
+              <div className="flex items-center justify-between mb-4 flex-wrap gap-2">
                 <h2 className="text-3xl font-bold bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-transparent bg-clip-text">
                   Global Leaderboard
                 </h2>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setActiveTab("none")}
-                  className="text-slate-500 hover:text-slate-800"
-                >
-                  <X className="w-5 h-5" />
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    asChild
+                    className="border-[#3737A4] text-[#3737A4] hover:bg-[#3737A4]/5 text-xs"
+                  >
+                    <Link href="/leaderboard">Full view with filters</Link>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setActiveTab("none")}
+                    className="text-slate-500 hover:text-slate-800"
+                  >
+                    <X className="w-5 h-5" />
+                  </Button>
+                </div>
               </div>
               <LeaderboardTable huntId={1} />
             </div>

--- a/components/LeaderBoardTable.tsx
+++ b/components/LeaderBoardTable.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect, useState, useCallback, memo } from "react"
+import React, { useEffect, useState, useCallback, memo, useMemo } from "react"
 import { LeaderboardTableSkeleton } from "@/components/LoadingSkeletons"
 import { cn } from "@/lib/utils"
 import { get_hunt_leaderboard } from "@/lib/contracts/hunt"
@@ -8,16 +8,34 @@ import { logger } from "@/lib/logger"
 import Medal from "@/components/icons/Medal"
 import { EmptyState } from "@/components/EmptyState"
 import { Trophy } from "lucide-react"
-import type { LeaderboardDisplayEntry } from "@/lib/types"
+import type { LeaderboardDisplayEntry, LeaderboardFilters } from "@/lib/types"
+
+const DEFAULT_FILTERS: LeaderboardFilters = {
+  timePeriod: "all",
+  category: "all",
+  difficulty: "all",
+  metric: "points",
+}
+
+function getTimeCutoff(period: LeaderboardFilters["timePeriod"]): number {
+  const now = Math.floor(Date.now() / 1000)
+  if (period === "today") return now - 86400
+  if (period === "week") return now - 86400 * 7
+  if (period === "month") return now - 86400 * 30
+  return 0
+}
 
 interface LeaderboardTableProps {
   huntId?: number
   data?: LeaderboardDisplayEntry[]
   isLoading?: boolean
+  filters?: Partial<LeaderboardFilters>
 }
 
-function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initialLoading = false }: LeaderboardTableProps) {
-  const [data, setData] = useState<LeaderboardDisplayEntry[]>(initialData || [])
+function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initialLoading = false, filters: filterOverrides }: LeaderboardTableProps) {
+  const filters: LeaderboardFilters = { ...DEFAULT_FILTERS, ...filterOverrides }
+
+  const [rawData, setRawData] = useState(initialData || [])
   const [isLoading, setIsLoading] = useState(initialLoading)
   const [error, setError] = useState<string | null>(null)
 
@@ -30,23 +48,22 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
     if (huntId === undefined) return
 
     try {
-      // Only set loading on initial fetch to avoid flickering during polling
-      if (data.length === 0) setIsLoading(true)
+      if (rawData.length === 0) setIsLoading(true)
 
-      const rawData = await get_hunt_leaderboard(huntId)
+      const fetched = await get_hunt_leaderboard(huntId)
 
-      // Sort by points descending (Requirement: Do not assume contract returns pre-sorted)
-      const sortedData = [...rawData].sort((a, b) => b.points - a.points)
-
-      // Map to UI-friendly format (Requirement: Truncate wallet if no name)
-      const mappedData: LeaderboardDisplayEntry[] = sortedData.map((entry, index) => ({
+      const mapped: LeaderboardDisplayEntry[] = fetched.map((entry, index) => ({
         position: index + 1,
         name: entry.name || truncateAddress(entry.address),
         points: entry.points,
-        icon: <Medal position={index + 1} /> // Requirement: Top 3 Highlighting via Medal icons
+        completionCount: entry.completionCount,
+        completedAt: entry.completedAt,
+        category: entry.category,
+        difficulty: entry.difficulty,
+        icon: <Medal position={index + 1} />,
       }))
 
-      setData(mappedData)
+      setRawData(mapped)
       setError(null)
     } catch (err) {
       logger.error("Failed to fetch leaderboard:", err)
@@ -54,17 +71,36 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
     } finally {
       setIsLoading(false)
     }
-  }, [huntId, data.length])
+  }, [huntId, rawData.length])
 
   useEffect(() => {
     if (huntId !== undefined) {
       fetchLeaderboard()
-      const interval = setInterval(fetchLeaderboard, 30000) // Requirement: 30-second polling
+      const interval = setInterval(fetchLeaderboard, 30000)
       return () => clearInterval(interval)
     }
   }, [huntId, fetchLeaderboard])
 
-  const containerClass = "rounded-none max-w-2xl mx-auto";
+  const data = useMemo(() => {
+    const cutoff = getTimeCutoff(filters.timePeriod)
+
+    let filtered = rawData.filter((entry) => {
+      if (filters.timePeriod !== "all" && entry.completedAt !== undefined && entry.completedAt < cutoff) return false
+      if (filters.category !== "all" && entry.category !== filters.category) return false
+      if (filters.difficulty !== "all" && entry.difficulty !== filters.difficulty) return false
+      return true
+    })
+
+    if (filters.metric === "completions") {
+      filtered = [...filtered].sort((a, b) => (b.completionCount ?? 0) - (a.completionCount ?? 0))
+    } else {
+      filtered = [...filtered].sort((a, b) => b.points - a.points)
+    }
+
+    return filtered.map((entry, index) => ({ ...entry, position: index + 1, icon: <Medal position={index + 1} /> }))
+  }, [rawData, filters])
+
+  const containerClass = "rounded-none max-w-2xl mx-auto"
 
   if (error) {
     return (
@@ -85,13 +121,15 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
       <div className={cn(containerClass, "p-0")}>
         <EmptyState
           icon={<Trophy className="w-10 h-10 text-slate-500 dark:text-slate-400" />}
-          title="Be the first to complete!"
-          description="No players have finished this leaderboard yet. Jump into a hunt to claim the top spot."
-          action={{ label: "Explore hunts", href: "/" }}
+          title="No results for these filters"
+          description="Try adjusting the time period, category, or difficulty to see more players."
+          action={{ label: "Clear filters", href: "/leaderboard" }}
         />
       </div>
     )
   }
+
+  const metricLabel = filters.metric === "completions" ? "Completions" : "Points Won"
 
   return (
     <div className={containerClass}>
@@ -100,7 +138,7 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
           <tr className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white">
             <th className="px-4 py-2 text-center border border-r-2 border-white">Position</th>
             <th className="px-4 py-2 text-left border border-r-2 border-white">Display Name / Wallet Address</th>
-            <th className="px-4 py-2 text-center">Points Won</th>
+            <th className="px-4 py-2 text-center">{metricLabel}</th>
           </tr>
         </thead>
         <tbody>
@@ -108,18 +146,19 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
             <LeaderboardTableSkeleton />
           ) : (
             data.map((entry, index) => {
-              // Requirement: Visually distinguish rank 1, 2, and 3
-              const isTop3 = entry.position <= 3;
-              const rowClass = isTop3 ? "bg-slate-50 dark:bg-blue-900/10 font-bold" : "bg-white dark:bg-slate-900";
+              const isTop3 = entry.position <= 3
+              const rowClass = isTop3 ? "bg-slate-50 dark:bg-blue-900/10 font-bold" : "bg-white dark:bg-slate-900"
 
               return (
                 <tr key={index} className={rowClass}>
-                  <td className="px-4 py-2 flex items-center justify-center gap-2 text-center border-r-2 border-[#808080] dark:border-slate-700 border-b-2 ">
+                  <td className="px-4 py-2 flex items-center justify-center gap-2 text-center border-r-2 border-[#808080] dark:border-slate-700 border-b-2">
                     <span>{entry.icon}</span>
                     <span className="text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">{entry.position}</span>
                   </td>
                   <td className="px-4 py-2 border-r-2 border-[#808080] dark:border-slate-700 border-b-2 text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">{entry.name}</td>
-                  <td className="px-4 py-2 text-center border border-b-2 border-[#808080] dark:border-slate-700 text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">{entry.points}</td>
+                  <td className="px-4 py-2 text-center border border-b-2 border-[#808080] dark:border-slate-700 text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">
+                    {filters.metric === "completions" ? (entry.completionCount ?? 0) : entry.points}
+                  </td>
                 </tr>
               )
             })

--- a/components/LeaderboardFilterBar.tsx
+++ b/components/LeaderboardFilterBar.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { LeaderboardFilters, LeaderboardTimePeriod, LeaderboardMetric } from "@/lib/types"
+import type { ClueDifficulty } from "@/lib/types"
+
+const TIME_PERIODS: { value: LeaderboardTimePeriod; label: string }[] = [
+  { value: "today", label: "Today" },
+  { value: "week", label: "This Week" },
+  { value: "month", label: "This Month" },
+  { value: "all", label: "All Time" },
+]
+
+const HUNT_CATEGORIES = ["Outdoor", "Onboarding", "Trivia", "Campus", "Indoor", "Community"]
+
+const DIFFICULTIES: { value: ClueDifficulty | "all"; label: string }[] = [
+  { value: "all", label: "Any" },
+  { value: "Easy", label: "Easy" },
+  { value: "Medium", label: "Medium" },
+  { value: "Hard", label: "Hard" },
+]
+
+interface LeaderboardFilterBarProps {
+  filters: LeaderboardFilters
+  onChange: (updated: Partial<LeaderboardFilters>) => void
+  className?: string
+}
+
+export function LeaderboardFilterBar({ filters, onChange, className }: LeaderboardFilterBarProps) {
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      {/* Time period */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold text-slate-500 uppercase tracking-wide w-20 shrink-0">Period</span>
+        <div className="flex bg-slate-100 dark:bg-slate-800 p-1 rounded-xl gap-0.5">
+          {TIME_PERIODS.map(({ value, label }) => (
+            <button
+              key={value}
+              onClick={() => onChange({ timePeriod: value })}
+              className={cn(
+                "px-3 py-1 rounded-lg text-xs font-semibold transition-all whitespace-nowrap",
+                filters.timePeriod === value
+                  ? "bg-white dark:bg-slate-700 text-[#3737A4] shadow-sm"
+                  : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Category */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold text-slate-500 uppercase tracking-wide w-20 shrink-0">Category</span>
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            onClick={() => onChange({ category: "all" })}
+            className={cn(
+              "px-3 py-1 rounded-full text-xs font-semibold border transition-all",
+              filters.category === "all"
+                ? "bg-[#3737A4] text-white border-[#3737A4]"
+                : "bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600 hover:border-[#3737A4]"
+            )}
+          >
+            All
+          </button>
+          {HUNT_CATEGORIES.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => onChange({ category: cat })}
+              className={cn(
+                "px-3 py-1 rounded-full text-xs font-semibold border transition-all",
+                filters.category === cat
+                  ? "bg-[#3737A4] text-white border-[#3737A4]"
+                  : "bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600 hover:border-[#3737A4]"
+              )}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Difficulty + Metric toggle */}
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-slate-500 uppercase tracking-wide w-20 shrink-0">Difficulty</span>
+          <div className="flex bg-slate-100 dark:bg-slate-800 p-1 rounded-xl gap-0.5">
+            {DIFFICULTIES.map(({ value, label }) => (
+              <button
+                key={value}
+                onClick={() => onChange({ difficulty: value })}
+                className={cn(
+                  "px-3 py-1 rounded-lg text-xs font-semibold transition-all whitespace-nowrap",
+                  filters.difficulty === value
+                    ? "bg-white dark:bg-slate-700 text-[#3737A4] shadow-sm"
+                    : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 ml-auto">
+          <span className="text-xs font-semibold text-slate-500 uppercase tracking-wide shrink-0">Rank by</span>
+          <div className="flex bg-slate-100 dark:bg-slate-800 p-1 rounded-xl gap-0.5">
+            {(["points", "completions"] as LeaderboardMetric[]).map((m) => (
+              <button
+                key={m}
+                onClick={() => onChange({ metric: m })}
+                className={cn(
+                  "px-3 py-1 rounded-lg text-xs font-semibold transition-all capitalize",
+                  filters.metric === m
+                    ? "bg-white dark:bg-slate-700 text-[#3737A4] shadow-sm"
+                    : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+                )}
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/contracts/hunt.ts
+++ b/lib/contracts/hunt.ts
@@ -222,13 +222,16 @@ export async function get_hunt_leaderboard(huntId: number): Promise<LeaderboardE
   // Simulate network latency
   await new Promise((resolve) => setTimeout(resolve, 800))
 
+  const now = Math.floor(Date.now() / 1000)
+  const DAY = 86400
+
   const mockData: LeaderboardEntry[] = [
-    { address: "GDD...9X2", name: "StellarQuest", points: 45 },
-    { address: "GBX...A1B", points: 30 },
-    { address: "GCT...Z9Y", name: "AliceCrypto", points: 58 },
-    { address: "GDE...123", points: 15 },
-    { address: "GFA...789", name: "BobHunts", points: 41 },
-    { address: "GCA...HB2", points: 28 },
+    { address: "GDD...9X2", name: "StellarQuest", points: 45, completionCount: 12, completedAt: now - DAY * 0.5, category: "Trivia", difficulty: "Medium" },
+    { address: "GBX...A1B", points: 30, completionCount: 7, completedAt: now - DAY * 3, category: "Outdoor", difficulty: "Hard" },
+    { address: "GCT...Z9Y", name: "AliceCrypto", points: 58, completionCount: 18, completedAt: now - DAY * 1, category: "Campus", difficulty: "Easy" },
+    { address: "GDE...123", points: 15, completionCount: 4, completedAt: now - DAY * 20, category: "Indoor", difficulty: "Easy" },
+    { address: "GFA...789", name: "BobHunts", points: 41, completionCount: 10, completedAt: now - DAY * 6, category: "Onboarding", difficulty: "Medium" },
+    { address: "GCA...HB2", points: 28, completionCount: 6, completedAt: now - DAY * 45, category: "Community", difficulty: "Hard" },
   ]
 
   if (typeof window !== "undefined") {
@@ -237,7 +240,7 @@ export async function get_hunt_leaderboard(huntId: number): Promise<LeaderboardE
       if (myPointsStr) {
         const myPoints = parseInt(myPointsStr, 10)
         if (myPoints > 0) {
-          mockData.push({ address: "YOU...PLYR", name: "You (Current Player)", points: myPoints })
+          mockData.push({ address: "YOU...PLYR", name: "You (Current Player)", points: myPoints, completionCount: 1, completedAt: now - DAY * 0.1 })
         }
       }
     } catch (e) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -128,10 +128,24 @@ export type ExtendHuntResult = {
 
 // ─── Leaderboard ─────────────────────────────────────────────────────────────
 
+export type LeaderboardTimePeriod = "today" | "week" | "month" | "all"
+export type LeaderboardMetric = "points" | "completions"
+
 export type LeaderboardEntry = {
   address: string
   name?: string
   points: number
+  completionCount?: number
+  completedAt?: number
+  category?: string
+  difficulty?: ClueDifficulty
+}
+
+export interface LeaderboardFilters {
+  timePeriod: LeaderboardTimePeriod
+  category: string
+  difficulty: ClueDifficulty | "all"
+  metric: LeaderboardMetric
 }
 
 export type FastestPlayerEntry = {
@@ -146,6 +160,10 @@ export interface LeaderboardDisplayEntry {
   name: string
   points: number
   icon: ReactNode
+  completionCount?: number
+  completedAt?: number
+  category?: string
+  difficulty?: ClueDifficulty
 }
 
 export interface FastestPlayerDisplayEntry {


### PR DESCRIPTION
## Summary

Closes #611

- Added `LeaderboardFilterBar` component with controls for time period (Today/This Week/This Month/All Time), hunt category, difficulty (Easy/Medium/Hard), and a points-vs-completions metric toggle
- Updated `LeaderBoardTable` to accept an optional `filters` prop and apply all active filters client-side using `useMemo`; the metric column header and displayed values update dynamically
- Created a dedicated `/leaderboard` page that reads and writes filter state to URL search params (`?period=`, `?category=`, `?difficulty=`, `?metric=`) with a "Share filtered view" button that copies the current URL to clipboard
- Extended `LeaderboardEntry` and `LeaderboardDisplayEntry` types with `completionCount`, `completedAt`, `category`, and `difficulty`; updated mock data to include realistic values across all filter dimensions
- Added a "Full view with filters" link in the inline leaderboard section on the home page

## Test plan

- [ ] Open `/leaderboard` - confirm default "All Time / All / Any / Points" view loads with ranked entries
- [ ] Toggle each time period button and verify the table entries change (entries older than the cutoff are hidden)
- [ ] Select a category chip (e.g. "Trivia") and confirm only matching entries appear
- [ ] Select a difficulty (e.g. "Hard") and confirm only matching entries appear
- [ ] Switch metric to "Completions" and verify the column header changes and rows re-sort by completion count
- [ ] Combine multiple filters and confirm they all apply together
- [ ] Click "Share filtered view" - paste the copied URL into a new tab and confirm the same filters are pre-applied
- [ ] Click "Clear all" - confirm filters reset and URL loses all query params
- [ ] On the home page, open the Leaderboard toggle and click "Full view with filters" - confirm it navigates to `/leaderboard`