### PR TITLE
feat: add hunt favoriting and bookmarks (#598)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react"
 import "./globals.css"
 import { hankenGrotesk } from "@/lib/font"
 import { TxToaster } from "@/components/TxToaster"
+import { FavoriteNotifications } from "@/components/FavoriteNotifications"
 import { PageSkeleton } from "@/components/PageSkeleton"
 import { PageTransitionWrapper } from "@/components/PageTransitionWrapper"
 import Providers from "./providers"
@@ -121,6 +122,7 @@ export default async function RootLayout({
             Skip to content
           </a>
           <TxToaster />
+          <FavoriteNotifications />
           <PWAInstallPrompt />
           <main id="main-content">
             <Suspense fallback={<PageSkeleton />}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import { usePlayerCounts } from "@/hooks/usePlayerCounts"
 import { useRecentlyCompleted } from "@/hooks/useRecentlyCompleted"
 import type { PlayerCountResult } from "@/lib/types"
 import { queryCachePolicy, queryKeys } from "@/lib/queryKeys"
+import { FavoriteButton } from "@/components/FavoriteButton"
 
 const OnboardingTour = dynamic(() => import("@/components/OnboardingTour"), {
   ssr: false,
@@ -97,7 +98,10 @@ function ActiveHuntCard({
   playerCount?: PlayerCountResult
 }) {
   return (
-    <Card className="h-full overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm hover:shadow-md transition-shadow">
+    <Card className="h-full overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm hover:shadow-md transition-shadow relative">
+      <div className="absolute top-3 right-3 z-10">
+        <FavoriteButton huntId={hunt.id} />
+      </div>
       <HuntCoverImage
         src={hunt.coverImageCid}
         alt={`${hunt.title} cover`}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -18,6 +18,9 @@ import { RewardHistorySection } from "@/components/RewardHistorySection"
 import { fetchPlayerRewardHistory } from "@/lib/rewardHistory"
 import { getPlayerAttempts } from "@/lib/huntAttemptHistory"
 import type { HuntAttemptRecord } from "@/lib/types"
+import { useFavorites } from "@/hooks/useFavorites"
+import { getAllHunts, type StoredHunt } from "@/lib/huntStore"
+import { FavoriteButton } from "@/components/FavoriteButton"
 
 // ---------------------------------------------------------------------------
 // #355 — Registered Hunts types and fetcher
@@ -184,6 +187,10 @@ export default function UserProfilePage() {
   const [attemptHistory, setAttemptHistory] = useState<HuntAttemptRecord[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  
+  const { favorites } = useFavorites()
+  const allHunts = useMemo(() => getAllHunts(), [])
+  const favoriteHunts = useMemo(() => allHunts.filter((h) => favorites.includes(h.id)), [allHunts, favorites])
 
   useEffect(() => {
     if (!connected || !publicKey) {
@@ -405,6 +412,43 @@ export default function UserProfilePage() {
 
             <section aria-label="Achievements" className="mt-8">
               <BadgeWall playerAddress={publicKey} />
+            </section>
+
+            {/* Favorites Section */}
+            <section aria-label="Favorite hunts" className="mt-10">
+              <div className="flex items-center justify-between gap-2 mb-4">
+                <div>
+                  <h2 className="text-xl md:text-2xl font-bold bg-linear-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-transparent">
+                    Favorite Hunts
+                  </h2>
+                  <p className="text-xs text-slate-500 mt-1">
+                    Hunts you've bookmarked for later
+                  </p>
+                </div>
+                <span className="bg-pink-50 text-pink-600 px-3 py-1 rounded-full text-xs font-bold">
+                  {favoriteHunts.length} saved
+                </span>
+              </div>
+
+              {favoriteHunts.length === 0 ? (
+                <div
+                  className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 py-10 text-center text-slate-600"
+                >
+                  You haven't favorited any hunts yet.{" "}
+                  <Link href="/" className="text-pink-600 underline underline-offset-2">
+                    Browse the arcade
+                  </Link>{" "}
+                  to find your next challenge.
+                </div>
+              ) : (
+                <ul className="space-y-3">
+                  {favoriteHunts.map((hunt) => (
+                    <li key={hunt.id}>
+                      <FavoriteHuntCard hunt={hunt} />
+                    </li>
+                  ))}
+                </ul>
+              )}
             </section>
 
             {/* #355 — Registered Hunts */}
@@ -699,3 +743,46 @@ function HuntCard({
   )
 }
 
+function FavoriteHuntCard({ hunt }: { hunt: StoredHunt }) {
+  return (
+    <Card className="border border-slate-200 bg-white/80 shadow-sm relative pr-12">
+      <div className="absolute top-4 right-4 z-10">
+        <FavoriteButton huntId={hunt.id} />
+      </div>
+      <CardContent className="py-4 px-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <span
+            className={`mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full bg-pink-400`}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-semibold text-slate-900 text-sm md:text-base">
+              {hunt.title}
+            </p>
+            <p className="text-xs text-slate-500 mt-0.5">
+              Reward:{" "}
+              <span className="font-medium text-slate-700">
+                {hunt.rewardType}
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 self-end sm:self-center">
+          <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium bg-slate-100 text-slate-700`}>
+            {hunt.status}
+          </span>
+
+          <Link href={`/hunt/${hunt.id}`}>
+            <Button
+              size="sm"
+              className="text-xs rounded-full bg-gradient-to-r from-[#3737A4] to-[#0C0C4F] hover:opacity-90 text-white"
+            >
+              View Hunt
+            </Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/FavoriteButton.tsx
+++ b/components/FavoriteButton.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import React from "react"
+import { Heart } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useFavorites } from "@/hooks/useFavorites"
+
+interface FavoriteButtonProps {
+  huntId: number
+  className?: string
+  iconClassName?: string
+}
+
+export function FavoriteButton({ huntId, className, iconClassName }: FavoriteButtonProps) {
+  const { isFavorite, toggleFavorite, isLoaded } = useFavorites()
+
+  if (!isLoaded) return null
+
+  const favorited = isFavorite(huntId)
+
+  return (
+    <button
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        toggleFavorite(huntId)
+      }}
+      className={cn(
+        "flex items-center justify-center rounded-full p-1.5 transition-all active:scale-90",
+        favorited 
+          ? "bg-pink-100 dark:bg-pink-900/30 text-pink-500 dark:text-pink-400" 
+          : "bg-white/80 dark:bg-slate-800/80 text-slate-400 hover:text-pink-400 backdrop-blur-sm shadow-sm",
+        className
+      )}
+      aria-label={favorited ? "Remove from favorites" : "Add to favorites"}
+      title={favorited ? "Remove from favorites" : "Add to favorites"}
+    >
+      <Heart 
+        className={cn("w-4 h-4 transition-transform", favorited && "fill-current", iconClassName)} 
+      />
+    </button>
+  )
+}

--- a/components/FavoriteNotifications.tsx
+++ b/components/FavoriteNotifications.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useEffect, useContext, useRef } from "react"
+import { toast } from "sonner"
+import { useFavorites } from "@/hooks/useFavorites"
+import { getAllHunts } from "@/lib/huntStore"
+import { WalletContext } from "@/lib/context/WalletContext"
+
+export function FavoriteNotifications() {
+  const { favorites, isLoaded } = useFavorites()
+  const wallet = useContext(WalletContext)
+  const publicKey = wallet?.publicKey ?? "anonymous"
+  const storageKey = `notified_favorites_${publicKey}`
+  const checkedRef = useRef<Set<number>>(new Set())
+
+  useEffect(() => {
+    if (!isLoaded || typeof window === "undefined" || favorites.length === 0) return
+
+    const checkNotifications = () => {
+      try {
+        const storedNotified = localStorage.getItem(storageKey)
+        const notifiedSet = new Set<number>(storedNotified ? JSON.parse(storedNotified) : [])
+        let hasNewNotifications = false
+
+        const allHunts = getAllHunts()
+        const now = Math.floor(Date.now() / 1000)
+
+        for (const huntId of favorites) {
+          // If we already checked this in memory or it's marked notified, skip
+          if (checkedRef.current.has(huntId) || notifiedSet.has(huntId)) continue
+          
+          checkedRef.current.add(huntId)
+
+          const hunt = allHunts.find((h) => h.id === huntId)
+          if (!hunt) continue
+
+          // If the hunt has started
+          if (hunt.startTime && hunt.startTime <= now) {
+            toast.success(`A hunt you favorited has started!`, {
+              description: `"${hunt.title}" is now active.`,
+              action: {
+                label: "Play Now",
+                onClick: () => {
+                  window.location.href = `/hunt/${hunt.id}`
+                }
+              },
+              duration: 10000,
+            })
+
+            notifiedSet.add(huntId)
+            hasNewNotifications = true
+          }
+        }
+
+        if (hasNewNotifications) {
+          localStorage.setItem(storageKey, JSON.stringify(Array.from(notifiedSet)))
+        }
+      } catch (e) {
+        console.error("Failed to process favorite notifications", e)
+      }
+    }
+
+    checkNotifications()
+    // Check every minute just in case a hunt starts while the user is on the page
+    const interval = setInterval(checkNotifications, 60000)
+    return () => clearInterval(interval)
+  }, [favorites, isLoaded, storageKey])
+
+  return null
+}

--- a/components/FeaturedHunts.tsx
+++ b/components/FeaturedHunts.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { HuntCoverImage } from "@/components/HuntCoverImage"
 import { queryCachePolicy, queryKeys } from "@/lib/queryKeys"
 import { cn } from "@/lib/utils"
+import { FavoriteButton } from "@/components/FavoriteButton"
 
 function timeRemaining(endTime?: number): string {
   if (!endTime) return ""
@@ -71,6 +72,9 @@ export function FeaturedHunts() {
                     Top Pick
                   </span>
                 )}
+                <div className={cn("absolute z-10", idx === 0 ? "top-12 right-3" : "top-3 right-3")}>
+                  <FavoriteButton huntId={hunt.id} />
+                </div>
 
                 <h3 className="text-lg font-bold text-slate-900 dark:text-white mb-1 pr-16 line-clamp-1">
                   {hunt.title}

--- a/hooks/useFavorites.ts
+++ b/hooks/useFavorites.ts
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState, useEffect, useContext, useCallback } from "react"
+import { WalletContext } from "@/lib/context/WalletContext"
+
+export function useFavorites() {
+  const wallet = useContext(WalletContext)
+  const publicKey = wallet?.publicKey ?? "anonymous"
+  const storageKey = `favorites_${publicKey}`
+
+  const [favorites, setFavorites] = useState<number[]>([])
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  // Load favorites from local storage on mount or when the account changes
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (stored) {
+        setFavorites(JSON.parse(stored))
+      } else {
+        setFavorites([])
+      }
+    } catch (e) {
+      console.error("Failed to parse favorites from local storage", e)
+      setFavorites([])
+    } finally {
+      setIsLoaded(true)
+    }
+  }, [storageKey])
+
+  const toggleFavorite = useCallback((huntId: number) => {
+    setFavorites((prev) => {
+      let nextFavorites
+      if (prev.includes(huntId)) {
+        nextFavorites = prev.filter((id) => id !== huntId)
+      } else {
+        nextFavorites = [...prev, huntId]
+      }
+      
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(nextFavorites))
+      } catch (e) {
+        console.error("Failed to save favorites to local storage", e)
+      }
+      
+      return nextFavorites
+    })
+  }, [storageKey])
+
+  const isFavorite = useCallback((huntId: number) => {
+    return favorites.includes(huntId)
+  }, [favorites])
+
+  return { favorites, toggleFavorite, isFavorite, isLoaded }
+}


### PR DESCRIPTION
Resolves #598

## Description
This PR implements the hunt favoriting and bookmarks feature for players.

### What was accomplished:
- **Favorite Toggle on Cards**: Added a heart toggle button to the `ActiveHuntCard` (in `app/page.tsx`) and the `FeaturedHunts` component.
- **Favorites Profile Section**: Modified the player profile (`app/profile/page.tsx`) to display a newly minted "Favorite Hunts" list allowing players to easily view their bookmarked hunts.
- **Wallet-Linked Storage**: Created a custom React hook `useFavorites` that stores a player's favorites natively in `localStorage` securely linked to their connected wallet's `publicKey`.
- **Active Hunt Notifications**: Created a `FavoriteNotifications` background component located at the global layout level that monitors favorited hunts and issues a global toast notification (via `sonner`) as soon as a favorited hunt starts.

All requirements from the issue have been met and tested successfully.
