### PR TITLE
Add comprehensive API route error handling

### DIFF
--- a/app/.well-known/apple-app-site-association/route.ts
+++ b/app/.well-known/apple-app-site-association/route.ts
@@ -1,16 +1,14 @@
 import { NextResponse } from "next/server"
+import { ServiceUnavailableError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
 const APPLE_TEAM_ID = process.env.APPLE_TEAM_ID
 const IOS_BUNDLE_ID = process.env.IOS_BUNDLE_ID || "com.yourorg.hunty"
 
-export function GET() {
+export const GET = withErrorHandling(async () => {
   if (!APPLE_TEAM_ID) {
-    return NextResponse.json(
-      {
-        error:
-          "Apple Universal Links are not configured. Add APPLE_TEAM_ID (your 10-character Apple Team ID) to environment variables.",
-      },
-      { status: 503 }
+    throw new ServiceUnavailableError(
+      "Apple Universal Links are not configured. Add APPLE_TEAM_ID (your 10-character Apple Team ID) to environment variables."
     )
   }
 
@@ -32,5 +30,4 @@ export function GET() {
       },
     }
   )
-}
-
+})

--- a/app/.well-known/assetlinks.json/route.ts
+++ b/app/.well-known/assetlinks.json/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server"
+import { ServiceUnavailableError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
 const ANDROID_SHA256_CERT_FINGERPRINTS = process.env.ANDROID_SHA256_CERT_FINGERPRINTS
 const ANDROID_PACKAGE_NAME = process.env.ANDROID_PACKAGE_NAME || "com.yourorg.hunty"
@@ -10,24 +12,17 @@ function parseFingerprints(value: string) {
     .filter(Boolean)
 }
 
-export function GET() {
+export const GET = withErrorHandling(async () => {
   if (!ANDROID_SHA256_CERT_FINGERPRINTS) {
-    return NextResponse.json(
-      {
-        error:
-          "Android App Links are not configured. Add ANDROID_SHA256_CERT_FINGERPRINTS (comma-separated SHA-256 cert fingerprints) to environment variables.",
-      },
-      { status: 503 }
+    throw new ServiceUnavailableError(
+      "Android App Links are not configured. Add ANDROID_SHA256_CERT_FINGERPRINTS (comma-separated SHA-256 cert fingerprints) to environment variables."
     )
   }
 
   const fingerprints = parseFingerprints(ANDROID_SHA256_CERT_FINGERPRINTS)
 
   if (fingerprints.length === 0) {
-    return NextResponse.json(
-      { error: "ANDROID_SHA256_CERT_FINGERPRINTS is set but empty." },
-      { status: 503 }
-    )
+    throw new ServiceUnavailableError("ANDROID_SHA256_CERT_FINGERPRINTS is set but empty.")
   }
 
   return NextResponse.json(
@@ -47,5 +42,4 @@ export function GET() {
       },
     }
   )
-}
-
+})

--- a/app/api/admin/anti-cheat/route.ts
+++ b/app/api/admin/anti-cheat/route.ts
@@ -9,8 +9,10 @@ import {
   getConfig,
   setConfig,
 } from "@/lib/anti-cheat"
+import { NotFoundError, ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
-export async function GET(req: Request) {
+export const GET = withErrorHandling(async (req: Request) => {
   const { searchParams } = new URL(req.url)
   const type = searchParams.get("type") || "flagged"
   const wallet = searchParams.get("wallet") || undefined
@@ -27,23 +29,23 @@ export async function GET(req: Request) {
     case "config":
       return NextResponse.json({ config: getConfig() })
     default:
-      return NextResponse.json({ error: "Invalid type parameter" }, { status: 400 })
+      throw new ValidationError("Invalid type parameter", { type })
   }
-}
+})
 
-export async function POST(req: Request) {
+export const POST = withErrorHandling(async (req: Request) => {
   let body: { action?: string; wallet?: string; ip?: string; reason?: string; bannedBy?: string; config?: Record<string, unknown> }
   try {
     body = await req.json()
   } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+    throw new ValidationError("Invalid request body")
   }
 
   const { action } = body
 
   if (action === "ban") {
     if (!body.wallet) {
-      return NextResponse.json({ error: "wallet is required to ban" }, { status: 400 })
+      throw new ValidationError("wallet is required to ban", { field: "wallet" })
     }
     banUser(body.wallet, body.ip || "", body.reason || "Manual ban by admin", body.bannedBy || "admin")
     return NextResponse.json({ success: true })
@@ -51,11 +53,11 @@ export async function POST(req: Request) {
 
   if (action === "unban") {
     if (!body.wallet) {
-      return NextResponse.json({ error: "wallet is required to unban" }, { status: 400 })
+      throw new ValidationError("wallet is required to unban", { field: "wallet" })
     }
     const result = unbanUser(body.wallet)
     if (!result) {
-      return NextResponse.json({ error: "User not found in bans" }, { status: 404 })
+      throw new NotFoundError("User not found in bans", { wallet: body.wallet })
     }
     return NextResponse.json({ success: true })
   }
@@ -65,8 +67,8 @@ export async function POST(req: Request) {
       setConfig(body.config as Parameters<typeof setConfig>[0])
       return NextResponse.json({ success: true, config: getConfig() })
     }
-    return NextResponse.json({ error: "config is required" }, { status: 400 })
+    throw new ValidationError("config is required", { field: "config" })
   }
 
-  return NextResponse.json({ error: "Invalid action" }, { status: 400 })
-}
+  throw new ValidationError("Invalid action", { action })
+})

--- a/app/api/admin/featured/rotate/route.ts
+++ b/app/api/admin/featured/rotate/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server"
 import fs from "fs"
 import path from "path"
 import { SEED_HUNTS } from "@/lib/huntStore"
+import { NotFoundError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
 const FILE_PATH = path.join(process.cwd(), "lib", "featuredHuntServer.json")
 
@@ -30,33 +32,29 @@ function writeFeaturedId(id: number | null): void {
   }
 }
 
-export async function POST() {
-  try {
-    // Only rotate amongst active seeded hunts
-    const activeSeedHunts = SEED_HUNTS.filter((h) => h.status === "Active")
-    if (activeSeedHunts.length === 0) {
-      return NextResponse.json({ error: "No active seeded hunts available to rotate" }, { status: 404 })
-    }
-
-    const currentId = readFeaturedId()
-    let nextIndex = 0
-
-    if (currentId !== null) {
-      const currentIndex = activeSeedHunts.findIndex((h) => h.id === currentId)
-      if (currentIndex !== -1) {
-        nextIndex = (currentIndex + 1) % activeSeedHunts.length
-      }
-    }
-
-    const nextHunt = activeSeedHunts[nextIndex]
-    writeFeaturedId(nextHunt.id)
-
-    return NextResponse.json({
-      success: true,
-      rotatedTo: nextHunt.id,
-      hunt: nextHunt
-    })
-  } catch {
-    return NextResponse.json({ error: "Failed to rotate featured hunt" }, { status: 500 })
+export const POST = withErrorHandling(async () => {
+  // Only rotate amongst active seeded hunts
+  const activeSeedHunts = SEED_HUNTS.filter((h) => h.status === "Active")
+  if (activeSeedHunts.length === 0) {
+    throw new NotFoundError("No active seeded hunts available to rotate")
   }
-}
+
+  const currentId = readFeaturedId()
+  let nextIndex = 0
+
+  if (currentId !== null) {
+    const currentIndex = activeSeedHunts.findIndex((h) => h.id === currentId)
+    if (currentIndex !== -1) {
+      nextIndex = (currentIndex + 1) % activeSeedHunts.length
+    }
+  }
+
+  const nextHunt = activeSeedHunts[nextIndex]
+  writeFeaturedId(nextHunt.id)
+
+  return NextResponse.json({
+    success: true,
+    rotatedTo: nextHunt.id,
+    hunt: nextHunt
+  })
+})

--- a/app/api/admin/featured/route.ts
+++ b/app/api/admin/featured/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server"
 import { logger } from "@/lib/logger"
 import fs from "fs"
 import path from "path"
+import { ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
 const FILE_PATH = path.join(process.cwd(), "lib", "featuredHuntServer.json")
 
@@ -31,17 +33,20 @@ function writeFeaturedId(id: number | null): void {
   }
 }
 
-export async function GET() {
+export const GET = withErrorHandling(async () => {
   const featuredHuntId = readFeaturedId()
   return NextResponse.json({ featuredHuntId })
-}
+})
 
-export async function POST(req: NextRequest) {
+export const POST = withErrorHandling(async (req: NextRequest) => {
+  let body: { huntId?: number | null }
   try {
-    const { huntId } = await req.json() as { huntId: number | null }
-    writeFeaturedId(huntId)
-    return NextResponse.json({ success: true, featuredHuntId: huntId })
+    body = (await req.json()) as { huntId: number | null }
   } catch {
-    return NextResponse.json({ error: "Invalid request payload" }, { status: 400 })
+    throw new ValidationError("Invalid request payload")
   }
-}
+
+  const { huntId } = body
+  writeFeaturedId(huntId ?? null)
+  return NextResponse.json({ success: true, featuredHuntId: huntId ?? null })
+})

--- a/app/api/analytics/hunt-view/route.ts
+++ b/app/api/analytics/hunt-view/route.ts
@@ -1,26 +1,28 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getAllHuntViewCounts, getHuntViewCount, recordHuntView } from "@/lib/analytics"
+import { ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
-export async function POST(request: NextRequest) {
+export const POST = withErrorHandling(async (request: NextRequest) => {
   const body = await request.json().catch(() => null)
   const huntId = typeof body?.huntId === "number" ? body.huntId : Number(body?.huntId)
 
   if (!Number.isFinite(huntId) || huntId <= 0) {
-    return NextResponse.json({ error: "Invalid huntId" }, { status: 400 })
+    throw new ValidationError("Invalid huntId", { huntId: body?.huntId })
   }
 
   const result = await recordHuntView(Math.floor(huntId))
   return NextResponse.json(result)
-}
+})
 
-export async function GET(request: NextRequest) {
+export const GET = withErrorHandling(async (request: NextRequest) => {
   const url = new URL(request.url)
   const huntIdParam = url.searchParams.get("huntId")
 
   if (huntIdParam) {
     const huntId = Number(huntIdParam)
     if (!Number.isFinite(huntId) || huntId <= 0) {
-      return NextResponse.json({ error: "Invalid huntId" }, { status: 400 })
+      throw new ValidationError("Invalid huntId", { huntId: huntIdParam })
     }
 
     const views = await getHuntViewCount(Math.floor(huntId))
@@ -29,4 +31,4 @@ export async function GET(request: NextRequest) {
 
   const counts = await getAllHuntViewCounts()
   return NextResponse.json({ counts })
-}
+})

--- a/app/api/analytics/performance/route.ts
+++ b/app/api/analytics/performance/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { promises as fs } from "fs"
 import path from "path"
+import { ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
 const PERFORMANCE_STORE_PATH = path.join(
   process.cwd(),
@@ -82,49 +84,44 @@ function summarizeMetrics(metrics: StoredMetric[]) {
   })
 }
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = (await request.json()) as {
-      name?: string
-      value?: number
-      rating?: string
-      timestamp?: number
-      url?: string
-    }
-    const { name, value, rating, timestamp, url } = body
-
-    if (!name || typeof value !== "number") {
-      return NextResponse.json(
-        { error: "Invalid metric payload" },
-        { status: 400 }
-      )
-    }
-
-    const store = await readStore()
-    store.metrics.push({
-      name,
-      value,
-      rating: rating ?? "needs-improvement",
-      timestamp: timestamp ?? Date.now(),
-      url: url ?? "unknown",
-    })
-
-    if (store.metrics.length > 10000) {
-      store.metrics = store.metrics.slice(-10000)
-    }
-
-    await writeStore(store)
-
-    return NextResponse.json({ success: true })
-  } catch {
-    return NextResponse.json(
-      { error: "Failed to record metric" },
-      { status: 500 }
-    )
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  let body: {
+    name?: string
+    value?: number
+    rating?: string
+    timestamp?: number
+    url?: string
   }
-}
+  try {
+    body = await request.json()
+  } catch {
+    throw new ValidationError("Invalid metric payload")
+  }
+  const { name, value, rating, timestamp, url } = body
 
-export async function GET(request: NextRequest) {
+  if (!name || typeof value !== "number") {
+    throw new ValidationError("Invalid metric payload", { name, value })
+  }
+
+  const store = await readStore()
+  store.metrics.push({
+    name,
+    value,
+    rating: rating ?? "needs-improvement",
+    timestamp: timestamp ?? Date.now(),
+    url: url ?? "unknown",
+  })
+
+  if (store.metrics.length > 10000) {
+    store.metrics = store.metrics.slice(-10000)
+  }
+
+  await writeStore(store)
+
+  return NextResponse.json({ success: true })
+})
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
   const url = new URL(request.url)
   const metricName = url.searchParams.get("metric")
   const limit = Math.min(Number(url.searchParams.get("limit")) || 100, 1000)
@@ -140,4 +137,4 @@ export async function GET(request: NextRequest) {
   const summary = summarizeMetrics(store.metrics)
 
   return NextResponse.json({ metrics: recent, summary })
-}
+})

--- a/app/api/csp-report/route.ts
+++ b/app/api/csp-report/route.ts
@@ -1,31 +1,33 @@
 import { NextRequest, NextResponse } from "next/server"
+import { ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
-export async function POST(req: NextRequest) {
-  try {
-    const rawBody = await req.text()
-    if (!rawBody) {
-      return NextResponse.json({ error: "Empty body" }, { status: 400 })
-    }
-
-    const data = JSON.parse(rawBody)
-    const report = data["csp-report"]
-
-    if (report) {
-      console.warn("CSP Violation Detected:", {
-        documentUri: report["document-uri"],
-        referrer: report["referrer"],
-        blockedUri: report["blocked-uri"],
-        violatedDirective: report["violated-directive"],
-        originalPolicy: report["original-policy"],
-        disposition: report["disposition"],
-      })
-    } else {
-      console.warn("Received report payload without 'csp-report' field:", data)
-    }
-
-    return new NextResponse(null, { status: 204 })
-  } catch (error) {
-    console.error("Failed to process CSP report:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+export const POST = withErrorHandling(async (req: NextRequest) => {
+  const rawBody = await req.text()
+  if (!rawBody) {
+    throw new ValidationError("Empty body")
   }
-}
+
+  let data: Record<string, unknown>
+  try {
+    data = JSON.parse(rawBody)
+  } catch {
+    throw new ValidationError("Invalid JSON body")
+  }
+  const report = data["csp-report"]
+
+  if (report) {
+    console.warn("CSP Violation Detected:", {
+      documentUri: report["document-uri"],
+      referrer: report["referrer"],
+      blockedUri: report["blocked-uri"],
+      violatedDirective: report["violated-directive"],
+      originalPolicy: report["original-policy"],
+      disposition: report["disposition"],
+    })
+  } else {
+    console.warn("Received report payload without 'csp-report' field:", data)
+  }
+
+  return new NextResponse(null, { status: 204 })
+})

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export const GET = withErrorHandling(async () => {
   return NextResponse.json(
     {
       status: "ok",
@@ -15,4 +16,4 @@ export async function GET() {
       },
     }
   );
-}
+});

--- a/app/api/ipfs/route.ts
+++ b/app/api/ipfs/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { logger } from "@/lib/logger"
+import { BadGatewayError, RateLimitError, ServiceUnavailableError, ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
 const PINATA_JWT = process.env.PINATA_JWT
 
@@ -24,18 +26,17 @@ function checkRateLimit(ip: string): boolean {
   return true
 }
 
-export async function POST(req: NextRequest) {
+export const POST = withErrorHandling(async (req: NextRequest) => {
   if (!PINATA_JWT) {
-    return NextResponse.json(
-      { error: "IPFS uploads are not configured. Add PINATA_JWT to your environment variables." },
-      { status: 503 }
+    throw new ServiceUnavailableError(
+      "IPFS uploads are not configured. Add PINATA_JWT to your environment variables."
     )
   }
 
   // Wallet address validation
   const wallet = req.headers.get("x-wallet-address")
   if (!wallet) {
-    return NextResponse.json({ error: "Wallet address required" }, { status: 400 })
+    throw new ValidationError("Wallet address required", { header: "x-wallet-address" })
   }
 
   // Rate limiting by IP
@@ -45,17 +46,14 @@ export async function POST(req: NextRequest) {
     "unknown"
 
   if (!checkRateLimit(ip)) {
-    return NextResponse.json(
-      { error: "Too many requests. Limit is 10 uploads per hour." },
-      { status: 429 }
-    )
+    throw new RateLimitError("Too many requests. Limit is 10 uploads per hour.")
   }
 
   const formData = await req.formData()
   const file = formData.get("file")
 
   if (!file || !(file instanceof Blob)) {
-    return NextResponse.json({ error: "No file provided" }, { status: 400 })
+    throw new ValidationError("No file provided", { field: "file" })
   }
 
   // Forward to Pinata's pinFileToIPFS endpoint
@@ -73,9 +71,9 @@ export async function POST(req: NextRequest) {
   if (!pinataRes.ok) {
     const errText = await pinataRes.text()
     logger.error("Pinata upload error:", pinataRes.status, errText)
-    return NextResponse.json({ error: "Failed to pin file to IPFS" }, { status: 502 })
+    throw new BadGatewayError("Failed to pin file to IPFS")
   }
 
   const data = (await pinataRes.json()) as { IpfsHash: string }
   return NextResponse.json({ cid: data.IpfsHash })
-}
+})

--- a/app/api/notifications/complete/route.tsx
+++ b/app/api/notifications/complete/route.tsx
@@ -1,31 +1,33 @@
 import { Resend } from 'resend';
 import { HuntCompletionEmail } from '@/components/emails/HuntCompletionEmail';
 import { NextResponse } from 'next/server';
-import { logger } from '@/lib/logger';
+import { ValidationError } from '@/lib/api/errors';
+import { withErrorHandling } from '@/lib/api/withErrorHandling';
 
-export async function POST(request: Request) {
+export const POST = withErrorHandling(async (request: Request) => {
   const resend = new Resend(process.env.RESEND_API_KEY);
 
+  let body: { huntName: string; creatorEmail?: string; completionTime: string };
   try {
-    const { huntName, creatorEmail, completionTime } = await request.json();
-
-    if (!creatorEmail) {
-      return NextResponse.json({ error: 'Missing creator email' }, { status: 400 });
-    }
-
-    const data = await resend.emails.send({
-      from: 'Hunty <onboarding@resend.dev>', // Replace with your verified domain in production
-      to: [creatorEmail],
-      subject: 'Your hunt was just completed 🎉',
-      react: <HuntCompletionEmail
-        huntName={huntName}
-        completionTime={completionTime}
-      />,
-    });
-
-    return NextResponse.json(data);
-  } catch (error) {
-    logger.error('Email notification error:', error);
-    return NextResponse.json({ error: 'Failed to send email' }, { status: 500 });
+    body = await request.json();
+  } catch {
+    throw new ValidationError('Invalid request body');
   }
-}
+  const { huntName, creatorEmail, completionTime } = body;
+
+  if (!creatorEmail) {
+    throw new ValidationError('Missing creator email', { field: 'creatorEmail' });
+  }
+
+  const data = await resend.emails.send({
+    from: 'Hunty <onboarding@resend.dev>', // Replace with your verified domain in production
+    to: [creatorEmail],
+    subject: 'Your hunt was just completed 🎉',
+    react: <HuntCompletionEmail
+      huntName={huntName}
+      completionTime={completionTime}
+    />,
+  });
+
+  return NextResponse.json(data);
+});

--- a/app/api/push-tokens/route.ts
+++ b/app/api/push-tokens/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
-import { logger } from "@/lib/logger"
+import { ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
 interface PushTokenRecord {
   token: string
@@ -9,86 +10,63 @@ interface PushTokenRecord {
 
 const tokensStore: PushTokenRecord[] = []
 
-export async function POST(request: NextRequest) {
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  let body: { token?: string; walletAddress?: string }
   try {
-    const body = await request.json()
-    const { token, walletAddress } = body
-
-    if (!token || typeof token !== "string") {
-      return NextResponse.json(
-        { error: "Push token is required" },
-        { status: 400 }
-      )
-    }
-
-    if (!walletAddress || typeof walletAddress !== "string") {
-      return NextResponse.json(
-        { error: "Wallet address is required" },
-        { status: 400 }
-      )
-    }
-
-    const existingIndex = tokensStore.findIndex(
-      (t) => t.token === token || t.walletAddress === walletAddress
-    )
-
-    if (existingIndex !== -1) {
-      tokensStore[existingIndex] = { token, walletAddress, registeredAt: Date.now() }
-    } else {
-      tokensStore.push({ token, walletAddress, registeredAt: Date.now() })
-    }
-
-    return NextResponse.json({ success: true })
-  } catch (error) {
-    logger.error("Failed to register push token:", error)
-    return NextResponse.json(
-      { error: "Failed to register push token" },
-      { status: 500 }
-    )
+    body = await request.json()
+  } catch {
+    throw new ValidationError("Invalid request body")
   }
-}
+  const { token, walletAddress } = body
 
-export async function DELETE(request: NextRequest) {
+  if (!token || typeof token !== "string") {
+    throw new ValidationError("Push token is required", { field: "token" })
+  }
+
+  if (!walletAddress || typeof walletAddress !== "string") {
+    throw new ValidationError("Wallet address is required", { field: "walletAddress" })
+  }
+
+  const existingIndex = tokensStore.findIndex(
+    (t) => t.token === token || t.walletAddress === walletAddress
+  )
+
+  if (existingIndex !== -1) {
+    tokensStore[existingIndex] = { token, walletAddress, registeredAt: Date.now() }
+  } else {
+    tokensStore.push({ token, walletAddress, registeredAt: Date.now() })
+  }
+
+  return NextResponse.json({ success: true })
+})
+
+export const DELETE = withErrorHandling(async (request: NextRequest) => {
+  let body: { token?: string; walletAddress?: string }
   try {
-    const body = await request.json()
-    const { token, walletAddress } = body
+    body = await request.json()
+  } catch {
+    throw new ValidationError("Invalid request body")
+  }
+  const { token, walletAddress } = body
 
-    if (!token && !walletAddress) {
-      return NextResponse.json(
-        { error: "Token or wallet address is required" },
-        { status: 400 }
-      )
-    }
+  if (!token && !walletAddress) {
+    throw new ValidationError("Token or wallet address is required")
+  }
 
-    if (token) {
-      const idx = tokensStore.findIndex((t) => t.token === token)
-      if (idx !== -1) tokensStore.splice(idx, 1)
-    } else if (walletAddress) {
-      for (let i = tokensStore.length - 1; i >= 0; i--) {
-        if (tokensStore[i].walletAddress === walletAddress) {
-          tokensStore.splice(i, 1)
-        }
+  if (token) {
+    const idx = tokensStore.findIndex((t) => t.token === token)
+    if (idx !== -1) tokensStore.splice(idx, 1)
+  } else if (walletAddress) {
+    for (let i = tokensStore.length - 1; i >= 0; i--) {
+      if (tokensStore[i].walletAddress === walletAddress) {
+        tokensStore.splice(i, 1)
       }
     }
-
-    return NextResponse.json({ success: true })
-  } catch (error) {
-    logger.error("Failed to unregister push token:", error)
-    return NextResponse.json(
-      { error: "Failed to unregister push token" },
-      { status: 500 }
-    )
   }
-}
 
-export async function GET() {
-  try {
-    return NextResponse.json({ tokens: tokensStore })
-  } catch (error) {
-    logger.error("Failed to fetch push tokens:", error)
-    return NextResponse.json(
-      { error: "Failed to fetch push tokens" },
-      { status: 500 }
-    )
-  }
-}
+  return NextResponse.json({ success: true })
+})
+
+export const GET = withErrorHandling(async () => {
+  return NextResponse.json({ tokens: tokensStore })
+})

--- a/app/api/v1/answers/route.ts
+++ b/app/api/v1/answers/route.ts
@@ -11,8 +11,10 @@ import {
   getConfig,
 } from "@/lib/anti-cheat"
 import { getServerClue } from "@/lib/server/seedClues"
+import { ForbiddenError, NotFoundError, RateLimitError, ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
 
-export async function POST(req: Request) {
+export const POST = withErrorHandling(async (req: Request) => {
   const ip = getIP(req)
 
   const { success: ipSuccess, reset: ipReset } = rateLimit(ip, {
@@ -27,39 +29,38 @@ export async function POST(req: Request) {
   try {
     body = await req.json()
   } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+    throw new ValidationError("Invalid request body")
   }
 
   const { huntId, clueId, answer, wallet, clientTimestamp } = body
 
   if (!huntId || typeof huntId !== "number") {
-    return NextResponse.json({ error: "huntId is required" }, { status: 400 })
+    throw new ValidationError("huntId is required", { field: "huntId" })
   }
   if (!clueId || typeof clueId !== "number") {
-    return NextResponse.json({ error: "clueId is required" }, { status: 400 })
+    throw new ValidationError("clueId is required", { field: "clueId" })
   }
   if (!answer || typeof answer !== "string" || answer.trim().length === 0) {
-    return NextResponse.json({ error: "answer is required" }, { status: 400 })
+    throw new ValidationError("answer is required", { field: "answer" })
   }
   if (!wallet || typeof wallet !== "string" || wallet.trim().length === 0) {
-    return NextResponse.json({ error: "wallet is required" }, { status: 400 })
+    throw new ValidationError("wallet is required", { field: "wallet" })
   }
 
   if (isBanned(wallet, ip)) {
-    return NextResponse.json({ error: "Account is banned due to suspicious activity" }, { status: 403 })
+    throw new ForbiddenError("Account is banned due to suspicious activity")
   }
 
   const clue = getServerClue(huntId, clueId)
   if (!clue) {
-    return NextResponse.json({ error: "Clue not found" }, { status: 404 })
+    throw new NotFoundError("Clue not found", { huntId, clueId })
   }
 
   const { allowed: intervalAllowed, waitMs } = checkMinInterval(wallet, huntId, clueId)
   if (!intervalAllowed) {
-    return NextResponse.json(
-      { error: `Please wait ${Math.ceil(waitMs / 1000)} seconds before submitting again` },
-      { status: 429 },
-    )
+    throw new RateLimitError(`Please wait ${Math.ceil(waitMs / 1000)} seconds before submitting again`, {
+      waitMs,
+    })
   }
 
   trackClueSubmission(wallet, huntId, clueId)
@@ -99,4 +100,4 @@ export async function POST(req: Request) {
     serverTimestamp: Date.now(),
     flags: anomalyFlags,
   })
-}
+})

--- a/app/api/v1/hunts/[id]/leaderboard/export/route.ts
+++ b/app/api/v1/hunts/[id]/leaderboard/export/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { get_hunt_leaderboard, get_hunt_fastest_players } from "@/lib/contracts/hunt";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/hunts/[id]/leaderboard/export
@@ -16,10 +18,7 @@ import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
  * Each row contains: rank, wallet, score, time, date.
  * The export also includes aggregate statistics.
  */
-export async function GET(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const GET = withErrorHandling<{ params: Promise<{ id: string }> }>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 30, windowMs: 60 * 1000 });
 
@@ -31,7 +30,7 @@ export async function GET(
   const huntId = parseInt(id, 10);
 
   if (Number.isNaN(huntId)) {
-    return NextResponse.json({ error: "Invalid hunt ID" }, { status: 400 });
+    throw new ValidationError("Invalid hunt ID", { id });
   }
 
   const { searchParams } = new URL(req.url);
@@ -40,7 +39,7 @@ export async function GET(
   const toParam = searchParams.get("to");
 
   if (format !== "csv" && format !== "json") {
-    return NextResponse.json({ error: "Invalid format. Use 'csv' or 'json'." }, { status: 400 });
+    throw new ValidationError("Invalid format. Use 'csv' or 'json'.", { format });
   }
 
   let fromMs: number | null = null;
@@ -59,91 +58,85 @@ export async function GET(
       toMs = /^\d{4}-\d{2}-\d{2}$/.test(toParam) ? to + 24 * 60 * 60 * 1000 - 1 : to;
     }
   } catch {
-    return NextResponse.json(
-      { error: "Invalid date range. Use ISO 8601 dates (e.g. 2026-01-01 or 2026-01-01T00:00:00Z)." },
-      { status: 400 }
+    throw new ValidationError(
+      "Invalid date range. Use ISO 8601 dates (e.g. 2026-01-01 or 2026-01-01T00:00:00Z).",
+      { from: fromParam, to: toParam }
     );
   }
 
-  try {
-    const [leaderboard, fastest] = await Promise.all([
-      get_hunt_leaderboard(huntId),
-      get_hunt_fastest_players(huntId).catch(() => []),
-    ]);
+  const [leaderboard, fastest] = await Promise.all([
+    get_hunt_leaderboard(huntId),
+    get_hunt_fastest_players(huntId).catch(() => []),
+  ]);
 
-    // Map wallet -> completion time (ms) from fastest players data when available.
-    const completionTimeByWallet = new Map<string, number>();
-    for (const entry of fastest) {
-      if (entry.address && typeof entry.completionTimeSeconds === "number") {
-        // Completion time is a duration in seconds; we treat the fastest
-        // completion row timestamp (when provided by the indexer) as the
-        // completion moment. Fall back to the duration as the "time" field.
-        completionTimeByWallet.set(entry.address, entry.completionTimeSeconds * 1000);
-      }
+  // Map wallet -> completion time (ms) from fastest players data when available.
+  const completionTimeByWallet = new Map<string, number>();
+  for (const entry of fastest) {
+    if (entry.address && typeof entry.completionTimeSeconds === "number") {
+      // Completion time is a duration in seconds; we treat the fastest
+      // completion row timestamp (when provided by the indexer) as the
+      // completion moment. Fall back to the duration as the "time" field.
+      completionTimeByWallet.set(entry.address, entry.completionTimeSeconds * 1000);
     }
-
-    const now = Date.now();
-    const sorted = [...leaderboard].sort((a, b) => b.points - a.points);
-
-    const rows = sorted
-      .map((entry, index) => {
-        const completionMs = completionTimeByWallet.get(entry.address) ?? now;
-        return {
-          rank: index + 1,
-          wallet: entry.address,
-          score: entry.points,
-          time: new Date(completionMs).toISOString(),
-          date: new Date(completionMs).toISOString().slice(0, 10),
-        };
-      })
-      .filter((row) => {
-        if (fromMs != null && new Date(row.time).getTime() < fromMs) return false;
-        if (toMs != null && new Date(row.time).getTime() > toMs) return false;
-        return true;
-      });
-
-    const totalScore = rows.reduce((sum, row) => sum + row.score, 0);
-    const aggregation = {
-      huntId,
-      exportedAt: new Date().toISOString(),
-      rowCount: rows.length,
-      totalScore,
-      averageScore: rows.length > 0 ? Math.round((totalScore / rows.length) * 100) / 100 : 0,
-      highestScore: rows.length > 0 ? rows[0].score : 0,
-      lowestScore: rows.length > 0 ? rows[rows.length - 1].score : 0,
-      filter: {
-        from: fromMs != null ? new Date(fromMs).toISOString() : null,
-        to: toMs != null ? new Date(toMs).toISOString() : null,
-      },
-    };
-
-    if (format === "json") {
-      return NextResponse.json(
-        { aggregation, rows },
-        {
-          status: 200,
-          headers: {
-            "content-type": "application/json",
-            "content-disposition": `attachment; filename="hunt-${huntId}-leaderboard.json"`,
-          },
-        }
-      );
-    }
-
-    const csv = toCsv(rows, aggregation);
-    return new NextResponse(csv, {
-      status: 200,
-      headers: {
-        "content-type": "text/csv; charset=utf-8",
-        "content-disposition": `attachment; filename="hunt-${huntId}-leaderboard.csv"`,
-      },
-    });
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(`Error exporting leaderboard for hunt ${huntId}:`, error);
-    return NextResponse.json({ error: "Failed to export leaderboard" }, { status: 500 });
   }
-}
+
+  const now = Date.now();
+  const sorted = [...leaderboard].sort((a, b) => b.points - a.points);
+
+  const rows = sorted
+    .map((entry, index) => {
+      const completionMs = completionTimeByWallet.get(entry.address) ?? now;
+      return {
+        rank: index + 1,
+        wallet: entry.address,
+        score: entry.points,
+        time: new Date(completionMs).toISOString(),
+        date: new Date(completionMs).toISOString().slice(0, 10),
+      };
+    })
+    .filter((row) => {
+      if (fromMs != null && new Date(row.time).getTime() < fromMs) return false;
+      if (toMs != null && new Date(row.time).getTime() > toMs) return false;
+      return true;
+    });
+
+  const totalScore = rows.reduce((sum, row) => sum + row.score, 0);
+  const aggregation = {
+    huntId,
+    exportedAt: new Date().toISOString(),
+    rowCount: rows.length,
+    totalScore,
+    averageScore: rows.length > 0 ? Math.round((totalScore / rows.length) * 100) / 100 : 0,
+    highestScore: rows.length > 0 ? rows[0].score : 0,
+    lowestScore: rows.length > 0 ? rows[rows.length - 1].score : 0,
+    filter: {
+      from: fromMs != null ? new Date(fromMs).toISOString() : null,
+      to: toMs != null ? new Date(toMs).toISOString() : null,
+    },
+  };
+
+  if (format === "json") {
+    return NextResponse.json(
+      { aggregation, rows },
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "content-disposition": `attachment; filename="hunt-${huntId}-leaderboard.json"`,
+        },
+      }
+    );
+  }
+
+  const csv = toCsv(rows, aggregation);
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "content-type": "text/csv; charset=utf-8",
+      "content-disposition": `attachment; filename="hunt-${huntId}-leaderboard.csv"`,
+    },
+  });
+});
 
 interface ExportRow {
   rank: number;

--- a/app/api/v1/hunts/[id]/leaderboard/route.ts
+++ b/app/api/v1/hunts/[id]/leaderboard/route.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from "next/server";
 import { get_hunt_leaderboard } from "@/lib/contracts/hunt";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/hunts/[id]/leaderboard
  * Get hunt leaderboard with cursor pagination.
  */
-export async function GET(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const GET = withErrorHandling<{ params: Promise<{ id: string }> }>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -21,7 +20,7 @@ export async function GET(
   const huntId = parseInt(id, 10);
 
   if (isNaN(huntId)) {
-    return NextResponse.json({ error: "Invalid hunt ID" }, { status: 400 });
+    throw new ValidationError("Invalid hunt ID", { id });
   }
 
   const { searchParams } = new URL(req.url);
@@ -30,33 +29,27 @@ export async function GET(
   const limit = Math.max(1, Math.min(100, parseInt(searchParams.get("limit") || "10", 10)));
 
   if (cursorParam && (cursor == null || Number.isNaN(cursor))) {
-    return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+    throw new ValidationError("Invalid cursor", { cursor: cursorParam });
   }
 
-  try {
-    const leaderboard = await get_hunt_leaderboard(huntId);
-    
-    // get_hunt_leaderboard might return unsorted or current-player augmented data.
-    // We sort by points descending to ensure a consistent leaderboard order.
-    const sorted = [...leaderboard].sort((a, b) => b.points - a.points);
-    
-    const total = sorted.length;
-    const pageStart = cursor == null ? 0 : Math.max(0, cursor);
-    const paginated = sorted.slice(pageStart, pageStart + limit);
-    const nextCursor = paginated.length === limit ? pageStart + paginated.length : null;
+  const leaderboard = await get_hunt_leaderboard(huntId);
 
-    return NextResponse.json({
-      data: paginated,
-      pagination: {
-        total,
-        limit,
-        cursor,
-        nextCursor,
-      },
-    });
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(`Error fetching leaderboard for hunt ${huntId}:`, error);
-    return NextResponse.json({ error: "Failed to fetch leaderboard" }, { status: 500 });
-  }
-}
+  // get_hunt_leaderboard might return unsorted or current-player augmented data.
+  // We sort by points descending to ensure a consistent leaderboard order.
+  const sorted = [...leaderboard].sort((a, b) => b.points - a.points);
+
+  const total = sorted.length;
+  const pageStart = cursor == null ? 0 : Math.max(0, cursor);
+  const paginated = sorted.slice(pageStart, pageStart + limit);
+  const nextCursor = paginated.length === limit ? pageStart + paginated.length : null;
+
+  return NextResponse.json({
+    data: paginated,
+    pagination: {
+      total,
+      limit,
+      cursor,
+      nextCursor,
+    },
+  });
+});

--- a/app/api/v1/hunts/[id]/route.ts
+++ b/app/api/v1/hunts/[id]/route.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from "next/server";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
 import { getPublicHuntByIdOptimized } from "@/lib/db/queryOptimizer";
+import { NotFoundError, ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/hunts/[id]
  * Get hunt details by ID.
  */
-export async function GET(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const GET = withErrorHandling<{ params: Promise<{ id: string }> }>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -21,15 +20,15 @@ export async function GET(
   const huntId = parseInt(id, 10);
 
   if (isNaN(huntId)) {
-    return NextResponse.json({ error: "Invalid hunt ID" }, { status: 400 });
+    throw new ValidationError("Invalid hunt ID", { id });
   }
 
   const requestId = req.headers.get("x-request-id") ?? undefined;
   const hunt = getPublicHuntByIdOptimized(huntId, requestId);
 
   if (!hunt) {
-    return NextResponse.json({ error: "Hunt not found" }, { status: 404 });
+    throw new NotFoundError("Hunt not found", { huntId });
   }
 
   return NextResponse.json({ data: hunt });
-}
+});

--- a/app/api/v1/hunts/id/route.ts
+++ b/app/api/v1/hunts/id/route.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from "next/server";
 import { getHuntById } from "@/lib/huntStore";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { ForbiddenError, NotFoundError, ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/hunts/[id]
  * Get hunt details by ID.
  */
-export async function GET(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const GET = withErrorHandling<{ params: Promise<{ id: string }> }>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -21,19 +20,19 @@ export async function GET(
   const huntId = parseInt(id, 10);
 
   if (isNaN(huntId)) {
-    return NextResponse.json({ error: "Invalid hunt ID" }, { status: 400 });
+    throw new ValidationError("Invalid hunt ID", { id });
   }
 
   const hunt = getHuntById(huntId);
 
   if (!hunt) {
-    return NextResponse.json({ error: "Hunt not found" }, { status: 404 });
+    throw new NotFoundError("Hunt not found", { huntId });
   }
 
   // Public endpoint should only expose public hunts if we follow the list's logic.
   if (hunt.is_private) {
-    return NextResponse.json({ error: "Access denied. This hunt is private." }, { status: 403 });
+    throw new ForbiddenError("Access denied. This hunt is private.", { huntId });
   }
 
   return NextResponse.json({ data: hunt });
-}
+});

--- a/app/api/v1/hunts/route.ts
+++ b/app/api/v1/hunts/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
 import { listPublicActiveHuntsByCursorOptimized } from "@/lib/db/queryOptimizer";
+import { ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/hunts
  * List all public active hunts with cursor pagination.
  */
-export async function GET(req: Request) {
+export const GET = withErrorHandling(async (req: Request) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -25,7 +27,7 @@ export async function GET(req: Request) {
   const requestId = req.headers.get("x-request-id") ?? undefined;
 
   if (cursorParam && cursorParam !== "null" && cursorParam !== "" && (cursor == null || Number.isNaN(cursor))) {
-    return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+    throw new ValidationError("Invalid cursor", { cursor: cursorParam });
   }
 
   const { data, nextCursor, total } = listPublicActiveHuntsByCursorOptimized({
@@ -47,4 +49,4 @@ export async function GET(req: Request) {
       nextCursor,
     },
   });
-}
+});

--- a/app/api/v1/seasons/[id]/route.ts
+++ b/app/api/v1/seasons/[id]/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from "next/server";
 import { getSeasonById, updateSeasonStatus, archiveSeason, getCurrentSeasonLeaderboard } from "@/lib/seasonStore";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { NotFoundError, ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
+
+type Context = { params: Promise<{ id: string }> };
 
 /**
  * GET /api/v1/seasons/[id]
  * Get a specific season by ID
  */
-export async function GET(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const GET = withErrorHandling<Context>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -21,38 +22,30 @@ export async function GET(
   const seasonId = parseInt(id, 10);
 
   if (isNaN(seasonId)) {
-    return NextResponse.json({ error: "Invalid season ID" }, { status: 400 });
+    throw new ValidationError("Invalid season ID", { id });
   }
 
-  try {
-    const season = getSeasonById(seasonId);
-    if (!season) {
-      return NextResponse.json({ error: "Season not found" }, { status: 404 });
-    }
-
-    const leaderboard = getCurrentSeasonLeaderboard();
-    const now = Math.floor(Date.now() / 1000);
-    const timeRemaining = season.status === "Active" ? Math.max(0, season.endTime - now) : 0;
-
-    return NextResponse.json({
-      season,
-      leaderboard,
-      timeRemaining,
-    });
-  } catch (error) {
-    console.error(`Error fetching season ${seasonId}:`, error);
-    return NextResponse.json({ error: "Failed to fetch season" }, { status: 500 });
+  const season = getSeasonById(seasonId);
+  if (!season) {
+    throw new NotFoundError("Season not found", { seasonId });
   }
-}
+
+  const leaderboard = getCurrentSeasonLeaderboard();
+  const now = Math.floor(Date.now() / 1000);
+  const timeRemaining = season.status === "Active" ? Math.max(0, season.endTime - now) : 0;
+
+  return NextResponse.json({
+    season,
+    leaderboard,
+    timeRemaining,
+  });
+});
 
 /**
  * PATCH /api/v1/seasons/[id]
  * Update season status or other fields (admin only)
  */
-export async function PATCH(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const PATCH = withErrorHandling<Context>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 10, windowMs: 60 * 1000 });
 
@@ -64,33 +57,34 @@ export async function PATCH(
   const seasonId = parseInt(id, 10);
 
   if (isNaN(seasonId)) {
-    return NextResponse.json({ error: "Invalid season ID" }, { status: 400 });
+    throw new ValidationError("Invalid season ID", { id });
   }
 
+  let body: { status?: string };
   try {
-    const body = await req.json();
-    const { status } = body;
-
-    if (status) {
-      updateSeasonStatus(seasonId, status);
-    }
-
-    const updatedSeason = getSeasonById(seasonId);
-    return NextResponse.json({ season: updatedSeason });
-  } catch (error) {
-    console.error(`Error updating season ${seasonId}:`, error);
-    return NextResponse.json({ error: "Failed to update season" }, { status: 500 });
+    body = await req.json();
+  } catch {
+    throw new ValidationError("Invalid request body");
   }
-}
+  const { status } = body;
+
+  if (status) {
+    updateSeasonStatus(seasonId, status);
+  }
+
+  const updatedSeason = getSeasonById(seasonId);
+  if (!updatedSeason) {
+    throw new NotFoundError("Season not found", { seasonId });
+  }
+
+  return NextResponse.json({ season: updatedSeason });
+});
 
 /**
  * POST /api/v1/seasons/[id]/archive
  * Archive a season with its final leaderboard
  */
-export async function POST(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const POST = withErrorHandling<Context>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 5, windowMs: 60 * 1000 });
 
@@ -102,21 +96,21 @@ export async function POST(
   const seasonId = parseInt(id, 10);
 
   if (isNaN(seasonId)) {
-    return NextResponse.json({ error: "Invalid season ID" }, { status: 400 });
+    throw new ValidationError("Invalid season ID", { id });
   }
 
+  let body: { finalLeaderboard?: unknown };
   try {
-    const body = await req.json();
-    const { finalLeaderboard } = body;
-
-    if (!Array.isArray(finalLeaderboard)) {
-      return NextResponse.json({ error: "finalLeaderboard must be an array" }, { status: 400 });
-    }
-
-    const archived = archiveSeason(seasonId, finalLeaderboard);
-    return NextResponse.json({ archived }, { status: 200 });
-  } catch (error) {
-    console.error(`Error archiving season ${seasonId}:`, error);
-    return NextResponse.json({ error: "Failed to archive season" }, { status: 500 });
+    body = await req.json();
+  } catch {
+    throw new ValidationError("Invalid request body");
   }
-}
+  const { finalLeaderboard } = body;
+
+  if (!Array.isArray(finalLeaderboard)) {
+    throw new ValidationError("finalLeaderboard must be an array", { field: "finalLeaderboard" });
+  }
+
+  const archived = archiveSeason(seasonId, finalLeaderboard);
+  return NextResponse.json({ archived }, { status: 200 });
+});

--- a/app/api/v1/seasons/archived/route.ts
+++ b/app/api/v1/seasons/archived/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { getArchivedSeasons, getArchivedSeasonById } from "@/lib/seasonStore";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { NotFoundError, ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/seasons/archived
  * Get all archived seasons
  */
-export async function GET(req: Request) {
+export const GET = withErrorHandling(async (req: Request) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -17,25 +19,20 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const seasonId = searchParams.get("id");
 
-  try {
-    if (seasonId) {
-      const id = parseInt(seasonId, 10);
-      if (isNaN(id)) {
-        return NextResponse.json({ error: "Invalid season ID" }, { status: 400 });
-      }
-
-      const archived = getArchivedSeasonById(id);
-      if (!archived) {
-        return NextResponse.json({ error: "Archived season not found" }, { status: 404 });
-      }
-
-      return NextResponse.json({ archived });
+  if (seasonId) {
+    const id = parseInt(seasonId, 10);
+    if (isNaN(id)) {
+      throw new ValidationError("Invalid season ID", { id: seasonId });
     }
 
-    const archived = getArchivedSeasons();
+    const archived = getArchivedSeasonById(id);
+    if (!archived) {
+      throw new NotFoundError("Archived season not found", { seasonId: id });
+    }
+
     return NextResponse.json({ archived });
-  } catch (error) {
-    console.error("Error fetching archived seasons:", error);
-    return NextResponse.json({ error: "Failed to fetch archived seasons" }, { status: 500 });
   }
-}
+
+  const archived = getArchivedSeasons();
+  return NextResponse.json({ archived });
+});

--- a/app/api/v1/seasons/badges/route.ts
+++ b/app/api/v1/seasons/badges/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { getPlayerSeasonBadges, getAllSeasonBadges, awardSeasonBadge } from "@/lib/seasonStore";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/seasons/badges
  * Get season badges for a player or all badges
  */
-export async function GET(req: Request) {
+export const GET = withErrorHandling(async (req: Request) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -17,25 +19,20 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const address = searchParams.get("address");
 
-  try {
-    if (address) {
-      const badges = getPlayerSeasonBadges(address);
-      return NextResponse.json({ badges });
-    }
-
-    const badges = getAllSeasonBadges();
+  if (address) {
+    const badges = getPlayerSeasonBadges(address);
     return NextResponse.json({ badges });
-  } catch (error) {
-    console.error("Error fetching season badges:", error);
-    return NextResponse.json({ error: "Failed to fetch season badges" }, { status: 500 });
   }
-}
+
+  const badges = getAllSeasonBadges();
+  return NextResponse.json({ badges });
+});
 
 /**
  * POST /api/v1/seasons/badges
  * Award a season badge to a player (admin only)
  */
-export async function POST(req: Request) {
+export const POST = withErrorHandling(async (req: Request) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 10, windowMs: 60 * 1000 });
 
@@ -43,18 +40,18 @@ export async function POST(req: Request) {
     return rateLimitResponse(reset);
   }
 
+  let body: { seasonId?: number; address?: string; name?: string; rank?: number };
   try {
-    const body = await req.json();
-    const { seasonId, address, name, rank } = body;
-
-    if (!seasonId || !address) {
-      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
-    }
-
-    const badge = awardSeasonBadge(seasonId, address, name, rank);
-    return NextResponse.json({ badge }, { status: 201 });
-  } catch (error) {
-    console.error("Error awarding season badge:", error);
-    return NextResponse.json({ error: "Failed to award season badge" }, { status: 500 });
+    body = await req.json();
+  } catch {
+    throw new ValidationError("Invalid request body");
   }
-}
+  const { seasonId, address, name, rank } = body;
+
+  if (!seasonId || !address) {
+    throw new ValidationError("Missing required fields", { required: ["seasonId", "address"] });
+  }
+
+  const badge = awardSeasonBadge(seasonId, address, name, rank);
+  return NextResponse.json({ badge }, { status: 201 });
+});

--- a/app/api/v1/seasons/route.ts
+++ b/app/api/v1/seasons/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
-import { getAllSeasons, getActiveSeason, createSeason, checkSeasonReset, archiveSeason, getCurrentSeasonLeaderboard } from "@/lib/seasonStore";
+import { getAllSeasons, getActiveSeason, createSeason, getCurrentSeasonLeaderboard } from "@/lib/seasonStore";
 import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { NotFoundError, ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
 
 /**
  * GET /api/v1/seasons
  * Get all seasons or the active season
  */
-export async function GET(req: Request) {
+export const GET = withErrorHandling(async (req: Request) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -17,34 +19,29 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const activeOnly = searchParams.get("active") === "true";
 
-  try {
-    if (activeOnly) {
-      const activeSeason = getActiveSeason();
-      if (!activeSeason) {
-        return NextResponse.json({ error: "No active season" }, { status: 404 });
-      }
-      
-      const leaderboard = getCurrentSeasonLeaderboard();
-      return NextResponse.json({
-        season: activeSeason,
-        leaderboard,
-        timeRemaining: activeSeason.endTime - Math.floor(Date.now() / 1000),
-      });
+  if (activeOnly) {
+    const activeSeason = getActiveSeason();
+    if (!activeSeason) {
+      throw new NotFoundError("No active season");
     }
 
-    const seasons = getAllSeasons();
-    return NextResponse.json({ seasons });
-  } catch (error) {
-    console.error("Error fetching seasons:", error);
-    return NextResponse.json({ error: "Failed to fetch seasons" }, { status: 500 });
+    const leaderboard = getCurrentSeasonLeaderboard();
+    return NextResponse.json({
+      season: activeSeason,
+      leaderboard,
+      timeRemaining: activeSeason.endTime - Math.floor(Date.now() / 1000),
+    });
   }
-}
+
+  const seasons = getAllSeasons();
+  return NextResponse.json({ seasons });
+});
 
 /**
  * POST /api/v1/seasons
  * Create a new season (admin only)
  */
-export async function POST(req: Request) {
+export const POST = withErrorHandling(async (req: Request) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 10, windowMs: 60 * 1000 });
 
@@ -52,25 +49,27 @@ export async function POST(req: Request) {
     return rateLimitResponse(reset);
   }
 
+  let body: { name?: string; startTime?: string; endTime?: string; rewards?: unknown };
   try {
-    const body = await req.json();
-    const { name, startTime, endTime, rewards } = body;
-
-    if (!name || !startTime || !endTime) {
-      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
-    }
-
-    const season = createSeason({
-      name,
-      startTime: Math.floor(new Date(startTime).getTime() / 1000),
-      endTime: Math.floor(new Date(endTime).getTime() / 1000),
-      status: "Upcoming",
-      rewards,
-    });
-
-    return NextResponse.json({ season }, { status: 201 });
-  } catch (error) {
-    console.error("Error creating season:", error);
-    return NextResponse.json({ error: "Failed to create season" }, { status: 500 });
+    body = await req.json();
+  } catch {
+    throw new ValidationError("Invalid request body");
   }
-}
+  const { name, startTime, endTime, rewards } = body;
+
+  if (!name || !startTime || !endTime) {
+    throw new ValidationError("Missing required fields", {
+      required: ["name", "startTime", "endTime"],
+    });
+  }
+
+  const season = createSeason({
+    name,
+    startTime: Math.floor(new Date(startTime).getTime() / 1000),
+    endTime: Math.floor(new Date(endTime).getTime() / 1000),
+    status: "Upcoming",
+    rewards,
+  });
+
+  return NextResponse.json({ season }, { status: 201 });
+});

--- a/lib/__tests__/rate-limit.test.ts
+++ b/lib/__tests__/rate-limit.test.ts
@@ -162,11 +162,14 @@ describe("rateLimitResponse", () => {
     vi.useRealTimers();
   });
 
-  it("returns an error message in the JSON body", async () => {
+  it("returns an error message and code in the JSON body", async () => {
     const reset = Date.now() + 60000;
     const response = rateLimitResponse(reset);
     const body = await response.json();
-    expect(body).toEqual({ error: "Too many requests. Please try again later." });
+    expect(body).toEqual({
+      error: "Too many requests. Please try again later.",
+      code: "RATE_LIMITED",
+    });
   });
 
   it("returns a JSON content-type header", () => {

--- a/lib/api/errors.test.ts
+++ b/lib/api/errors.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { NextResponse } from "next/server"
+import {
+  AppError,
+  ValidationError,
+  AuthError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+  RateLimitError,
+  BadGatewayError,
+  ServiceUnavailableError,
+  InternalError,
+  isAppError,
+} from "./errors"
+import { errorResponse, REQUEST_ID_HEADER } from "./response"
+import { withErrorHandling } from "./withErrorHandling"
+
+describe("AppError subclasses", () => {
+  it.each([
+    [ValidationError, 400, "VALIDATION_ERROR"],
+    [AuthError, 401, "UNAUTHORIZED"],
+    [ForbiddenError, 403, "FORBIDDEN"],
+    [NotFoundError, 404, "NOT_FOUND"],
+    [ConflictError, 409, "CONFLICT"],
+    [RateLimitError, 429, "RATE_LIMITED"],
+    [BadGatewayError, 502, "BAD_GATEWAY"],
+    [ServiceUnavailableError, 503, "SERVICE_UNAVAILABLE"],
+    [InternalError, 500, "INTERNAL_ERROR"],
+  ] as const)("%s maps to status %i and code %s", (ErrorClass, status, code) => {
+    const err = new ErrorClass("boom", { field: "x" })
+    expect(err).toBeInstanceOf(AppError)
+    expect(err.statusCode).toBe(status)
+    expect(err.code).toBe(code)
+    expect(err.message).toBe("boom")
+    expect(err.details).toEqual({ field: "x" })
+  })
+
+  it("isAppError narrows AppError instances only", () => {
+    expect(isAppError(new NotFoundError())).toBe(true)
+    expect(isAppError(new Error("plain"))).toBe(false)
+    expect(isAppError("not an error")).toBe(false)
+  })
+})
+
+describe("errorResponse", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("serializes an AppError into { error, code } with matching status", async () => {
+    const res = errorResponse(new NotFoundError("Hunt not found"), "req-1")
+    expect(res.status).toBe(404)
+    expect(res.headers.get(REQUEST_ID_HEADER)).toBe("req-1")
+    const body = await res.json()
+    expect(body).toEqual({ error: "Hunt not found", code: "NOT_FOUND" })
+  })
+
+  it("includes details when present", async () => {
+    const res = errorResponse(new ValidationError("Bad input", { field: "huntId" }), "req-2")
+    const body = await res.json()
+    expect(body).toEqual({
+      error: "Bad input",
+      code: "VALIDATION_ERROR",
+      details: { field: "huntId" },
+    })
+  })
+
+  it("maps unknown thrown errors to a 500 INTERNAL_ERROR", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    const res = errorResponse(new Error("db exploded"), "req-3")
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.code).toBe("INTERNAL_ERROR")
+    expect(body.error).toBe("db exploded")
+  })
+
+  it("hides the raw error message in production", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    const res = errorResponse(new Error("leaky stack trace details"), "req-4")
+    const body = await res.json()
+    expect(body.error).toBe("Internal server error")
+    expect(body.error).not.toContain("leaky")
+  })
+
+  it("handles non-Error thrown values", async () => {
+    const res = errorResponse("just a string", "req-5")
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.code).toBe("INTERNAL_ERROR")
+  })
+})
+
+describe("withErrorHandling", () => {
+  it("passes through a successful response and stamps a request id", async () => {
+    const handler = withErrorHandling(async () => NextResponse.json({ ok: true }))
+    const res = await handler(new Request("http://localhost/api/test"), undefined)
+    expect(res.status).toBe(200)
+    expect(res.headers.get(REQUEST_ID_HEADER)).toBeTruthy()
+    expect(await res.json()).toEqual({ ok: true })
+  })
+
+  it("reuses an inbound x-request-id header", async () => {
+    const handler = withErrorHandling(async () => NextResponse.json({ ok: true }))
+    const res = await handler(
+      new Request("http://localhost/api/test", { headers: { "x-request-id": "client-supplied" } }),
+      undefined,
+    )
+    expect(res.headers.get(REQUEST_ID_HEADER)).toBe("client-supplied")
+  })
+
+  it("catches a thrown AppError and formats it", async () => {
+    const handler = withErrorHandling(async () => {
+      throw new ForbiddenError("nope")
+    })
+    const res = await handler(new Request("http://localhost/api/test"), undefined)
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ error: "nope", code: "FORBIDDEN" })
+    expect(res.headers.get(REQUEST_ID_HEADER)).toBeTruthy()
+  })
+
+  it("catches an unexpected thrown error and returns a 500", async () => {
+    const handler = withErrorHandling(async () => {
+      throw new Error("kaboom")
+    })
+    const res = await handler(new Request("http://localhost/api/test"), undefined)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.code).toBe("INTERNAL_ERROR")
+  })
+
+  it("tolerates being invoked without a Request (e.g. static handlers called directly in tests)", async () => {
+    const handler = withErrorHandling(async () => NextResponse.json({ ok: true }))
+    // @ts-expect-error - simulating a caller that omits the request argument
+    const res = await handler(undefined, undefined)
+    expect(res.status).toBe(200)
+    expect(res.headers.get(REQUEST_ID_HEADER)).toBeTruthy()
+  })
+
+  it("forwards the route context through to the handler", async () => {
+    const handler = withErrorHandling<{ params: Promise<{ id: string }> }>(async (_req, { params }) => {
+      const { id } = await params
+      return NextResponse.json({ id })
+    })
+    const res = await handler(new Request("http://localhost/api/test/42"), {
+      params: Promise.resolve({ id: "42" }),
+    })
+    expect(await res.json()).toEqual({ id: "42" })
+  })
+})

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -1,0 +1,96 @@
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "BAD_GATEWAY"
+  | "SERVICE_UNAVAILABLE"
+  | "INTERNAL_ERROR"
+
+/**
+ * Base class for all expected/typed API errors. Thrown from route handlers
+ * (or the lib/ code they call) and translated into a consistent JSON
+ * response by `errorResponse`/`withErrorHandling`.
+ */
+export class AppError extends Error {
+  readonly statusCode: number
+  readonly code: ApiErrorCode
+  readonly details?: Record<string, unknown>
+
+  constructor(message: string, statusCode: number, code: ApiErrorCode, details?: Record<string, unknown>) {
+    super(message)
+    this.name = this.constructor.name
+    this.statusCode = statusCode
+    this.code = code
+    this.details = details
+  }
+}
+
+/** 400 - the request payload or query params failed validation. */
+export class ValidationError extends AppError {
+  constructor(message = "Validation failed", details?: Record<string, unknown>) {
+    super(message, 400, "VALIDATION_ERROR", details)
+  }
+}
+
+/** 401 - caller could not be authenticated. */
+export class AuthError extends AppError {
+  constructor(message = "Authentication required", details?: Record<string, unknown>) {
+    super(message, 401, "UNAUTHORIZED", details)
+  }
+}
+
+/** 403 - caller is known but not allowed to perform this action. */
+export class ForbiddenError extends AppError {
+  constructor(message = "Access denied", details?: Record<string, unknown>) {
+    super(message, 403, "FORBIDDEN", details)
+  }
+}
+
+/** 404 - the requested resource does not exist. */
+export class NotFoundError extends AppError {
+  constructor(message = "Resource not found", details?: Record<string, unknown>) {
+    super(message, 404, "NOT_FOUND", details)
+  }
+}
+
+/** 409 - the request conflicts with the current state of the resource. */
+export class ConflictError extends AppError {
+  constructor(message = "Conflict", details?: Record<string, unknown>) {
+    super(message, 409, "CONFLICT", details)
+  }
+}
+
+/** 429 - caller has exceeded a rate or frequency limit. */
+export class RateLimitError extends AppError {
+  constructor(message = "Too many requests", details?: Record<string, unknown>) {
+    super(message, 429, "RATE_LIMITED", details)
+  }
+}
+
+/** 502 - an upstream/third-party service returned an error. */
+export class BadGatewayError extends AppError {
+  constructor(message = "Upstream service error", details?: Record<string, unknown>) {
+    super(message, 502, "BAD_GATEWAY", details)
+  }
+}
+
+/** 503 - a required feature/dependency is not configured or unavailable. */
+export class ServiceUnavailableError extends AppError {
+  constructor(message = "Service unavailable", details?: Record<string, unknown>) {
+    super(message, 503, "SERVICE_UNAVAILABLE", details)
+  }
+}
+
+/** 500 - unexpected/uncategorized failure. */
+export class InternalError extends AppError {
+  constructor(message = "Internal server error", details?: Record<string, unknown>) {
+    super(message, 500, "INTERNAL_ERROR", details)
+  }
+}
+
+export function isAppError(error: unknown): error is AppError {
+  return error instanceof AppError
+}

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -1,0 +1,3 @@
+export * from "./errors"
+export * from "./response"
+export * from "./withErrorHandling"

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import { logger } from "@/lib/logger"
+import { AppError, InternalError, isAppError } from "./errors"
+
+export const REQUEST_ID_HEADER = "x-request-id"
+
+export interface ApiErrorBody {
+  error: string
+  code: string
+  details?: Record<string, unknown>
+}
+
+/**
+ * Converts any thrown value into the standard { error, code, details? }
+ * envelope, logs unexpected (non-AppError) failures, and stamps the
+ * response with the request ID for tracing.
+ */
+export function errorResponse(error: unknown, requestId: string): NextResponse<ApiErrorBody> {
+  const appError = toAppError(error)
+
+  if (!isAppError(error)) {
+    logger.error(`[${requestId}] Unhandled API error:`, error)
+  } else if (appError.statusCode >= 500) {
+    logger.error(`[${requestId}] ${appError.code}: ${appError.message}`, appError.details ?? "")
+  }
+
+  const body: ApiErrorBody = { error: appError.message, code: appError.code }
+  if (appError.details) {
+    body.details = appError.details
+  }
+
+  return NextResponse.json(body, {
+    status: appError.statusCode,
+    headers: { [REQUEST_ID_HEADER]: requestId },
+  })
+}
+
+function toAppError(error: unknown): AppError {
+  if (isAppError(error)) return error
+
+  // Don't leak raw internal error messages (stack traces, DB errors, etc.)
+  // to clients in production; keep them in non-production for DX.
+  const message =
+    process.env.NODE_ENV === "production"
+      ? "Internal server error"
+      : error instanceof Error
+        ? error.message
+        : "Internal server error"
+
+  return new InternalError(message)
+}

--- a/lib/api/withErrorHandling.ts
+++ b/lib/api/withErrorHandling.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+import { errorResponse, REQUEST_ID_HEADER } from "./response"
+
+type RouteHandler<Context> = (req: Request, context: Context) => Promise<NextResponse> | NextResponse
+
+function generateRequestId(): string {
+  return globalThis.crypto.randomUUID()
+}
+
+/**
+ * Wraps a Next.js route handler so that:
+ *  - any thrown error (AppError or otherwise) is caught and turned into
+ *    the standard { error, code, details? } JSON response
+ *  - every response (success or error) carries an `x-request-id` header,
+ *    reusing an inbound `x-request-id` header when the caller provided one
+ *
+ * Usage:
+ *   export const GET = withErrorHandling(async (req) => { ... })
+ *   export const GET = withErrorHandling<{ params: Promise<{ id: string }> }>(
+ *     async (req, { params }) => { ... }
+ *   )
+ */
+export function withErrorHandling<Context = unknown>(
+  handler: RouteHandler<Context>,
+): RouteHandler<Context> {
+  return async (req: Request, context: Context): Promise<NextResponse> => {
+    // `req` may be omitted by callers/tests that don't need it (e.g. static
+    // GET handlers with no dynamic input), so avoid assuming it exists.
+    const requestId = req?.headers?.get(REQUEST_ID_HEADER) ?? generateRequestId()
+
+    try {
+      const response = await handler(req, context)
+      if (!response.headers.has(REQUEST_ID_HEADER)) {
+        response.headers.set(REQUEST_ID_HEADER, requestId)
+      }
+      return response
+    } catch (error) {
+      return errorResponse(error, requestId)
+    }
+  }
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -59,8 +59,8 @@ export function getIP(req: Request): string {
  */
 export function rateLimitResponse(reset: number) {
   return NextResponse.json(
-    { error: "Too many requests. Please try again later." },
-    { 
+    { error: "Too many requests. Please try again later.", code: "RATE_LIMITED" },
+    {
       status: 429,
       headers: {
         "X-RateLimit-Reset": Math.ceil(reset / 1000).toString(),

--- a/tests/api_routes.test.ts
+++ b/tests/api_routes.test.ts
@@ -1,77 +1,96 @@
-import { describe, it, expect } from 'vitest';
-import request from 'supertest';
+import { describe, it, expect } from "vitest";
+import { GET as getHunts } from "../app/api/v1/hunts/route";
+import { GET as getHuntById } from "../app/api/v1/hunts/[id]/route";
+import { GET as getHuntLeaderboard } from "../app/api/v1/hunts/[id]/leaderboard/route";
+import { GET as getFeatured } from "../app/api/admin/featured/route";
+import { POST as postAnswers } from "../app/api/v1/answers/route";
 
-// Import handlers from the app directory.
-import { GET as getHunts } from '../../app/api/v1/hunts/route';
-import { GET as getLeaderboard } from '../../app/api/v1/hunts/[id]/leaderboard/route';
-import { GET as getFeatured } from '../../app/api/admin/featured/route';
-import { GET as getIpfs } from '../../app/api/ipfs/route';
-import { GET as getAnalytics } from '../../app/api/analytics/route';
-
-function handlerToExpress(handler) {
-  return async (req, res) => {
-    const result = await handler(req);
-    if (result?.json) {
-      const data = await result.json();
-      res.status(result.status || 200).json(data);
-    } else {
-      res.status(200).send(result);
-    }
-  };
-}
-
-describe('API Integration Tests', () => {
-  it('GET /api/v1/hunts should return paginated hunts', async () => {
-    const app = request(handlerToExpress(getHunts));
-    const response = await app.get('/api/v1/hunts?limit=5');
-    expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('data');
-    expect(response.body).toHaveProperty('pagination');
+describe("API route error handling", () => {
+  it("GET /api/v1/hunts returns paginated hunts with a request id header", async () => {
+    const res = await getHunts(new Request("http://localhost/api/v1/hunts?limit=5"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+    const body = await res.json();
+    expect(body).toHaveProperty("data");
+    expect(body).toHaveProperty("pagination");
   });
 
-  it('GET /api/v1/hunts/:id/leaderboard returns leaderboard data', async () => {
-    const app = request(handlerToExpress(getLeaderboard));
-    const response = await app.get('/api/v1/hunts/123/leaderboard');
-    expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('leaderboard');
+  it("GET /api/admin/featured returns the featured hunt id with a request id header", async () => {
+    const res = await getFeatured(new Request("http://localhost/api/admin/featured"), undefined);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+    const body = await res.json();
+    expect(body).toHaveProperty("featuredHuntId");
   });
 
-  it('GET /api/admin/featured returns featured items', async () => {
-    const app = request(handlerToExpress(getFeatured));
-    const response = await app.get('/api/admin/featured');
-    expect(response.status).toBe(200);
-    expect(Array.isArray(response.body)).toBe(true);
+  it("GET /api/v1/hunts/[id] with a non-numeric id returns a consistent { error, code, details } response", async () => {
+    const res = await getHuntById(new Request("http://localhost/api/v1/hunts/not-a-number"), {
+      params: Promise.resolve({ id: "not-a-number" }),
+    });
+    expect(res.status).toBe(400);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "Invalid hunt ID",
+      code: "VALIDATION_ERROR",
+      details: { id: "not-a-number" },
+    });
   });
 
-  it('GET /api/ipfs returns IPFS info', async () => {
-    const app = request(handlerToExpress(getIpfs));
-    const response = await app.get('/api/ipfs');
-    expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('cid');
+  it("GET /api/v1/hunts/[id] for an unknown hunt returns a 404 NOT_FOUND", async () => {
+    const res = await getHuntById(new Request("http://localhost/api/v1/hunts/999999"), {
+      params: Promise.resolve({ id: "999999" }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("NOT_FOUND");
+    expect(body).toHaveProperty("error");
   });
 
-  it('GET /api/analytics returns analytics data', async () => {
-    const app = request(handlerToExpress(getAnalytics));
-    const response = await app.get('/api/analytics');
-    expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('metrics');
+  it("GET /api/v1/hunts/[id]/leaderboard with an invalid id returns a 400 validation error", async () => {
+    const res = await getHuntLeaderboard(new Request("http://localhost/api/v1/hunts/abc/leaderboard"), {
+      params: Promise.resolve({ id: "abc" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body).toHaveProperty("error");
   });
 
-  it('Unauthorized access returns 401 when applicable', async () => {
-    const app = request(handlerToExpress(getHunts));
-    const response = await app.get('/api/v1/hunts');
-    if (response.status === 401) {
-      expect(response.body).toHaveProperty('error');
-    } else {
-      expect([200, 403]).toContain(response.status);
-    }
+  it("POST /api/v1/answers with a missing field returns a 400 validation error naming the field", async () => {
+    const res = await postAnswers(
+      new Request("http://localhost/api/v1/answers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ huntId: 1, clueId: 1, answer: "test" }), // wallet omitted
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "wallet is required",
+      code: "VALIDATION_ERROR",
+      details: { field: "wallet" },
+    });
   });
 
-  it('Error response follows format', async () => {
-    const errorHandler = async () => { throw new Error('Test error'); };
-    const app = request(handlerToExpress(errorHandler));
-    const response = await app.get('/api/error');
-    expect(response.status).toBeGreaterThanOrEqual(400);
-    expect(response.body).toHaveProperty('error');
+  it("POST /api/v1/answers with an invalid JSON body returns a 400 validation error", async () => {
+    const res = await postAnswers(
+      new Request("http://localhost/api/v1/answers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Invalid request body", code: "VALIDATION_ERROR" });
+  });
+
+  it("every error response carries an x-request-id header for tracing", async () => {
+    const res = await getHuntById(new Request("http://localhost/api/v1/hunts/not-a-number"), {
+      params: Promise.resolve({ id: "not-a-number" }),
+    });
+    expect(res.headers.get("x-request-id")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Closes #557.

Every route under `app/api/**` (and `app/.well-known/**`) previously improvised its own error shape (`{ error: string }` with inconsistent status codes), several had no try/catch at all, and there was no request ID for tracing. This PR adds a shared error-handling layer and wires it into every route.

- **`lib/api/errors.ts`** — `AppError` base class plus typed subclasses: `ValidationError` (400), `AuthError` (401), `ForbiddenError` (403), `NotFoundError` (404), `ConflictError` (409), `RateLimitError` (429), `BadGatewayError` (502), `ServiceUnavailableError` (503), `InternalError` (500).
- **`lib/api/response.ts`** — `errorResponse()` converts any thrown value (typed `AppError` or not) into a consistent `{ error, code, details? }` JSON body, logs unexpected errors, and hides raw error messages in production.
- **`lib/api/withErrorHandling.ts`** — wraps a route handler in try/catch, forwards the route context (e.g. dynamic `params`) untouched, and stamps every response — success or error — with an `x-request-id` header (reusing an inbound header if the caller supplied one).
- All 19 `app/api/**` route files plus the 2 `.well-known` handlers now use `withErrorHandling` and throw typed errors instead of building ad-hoc `NextResponse.json({ error }, { status })` calls.
- `lib/rate-limit.ts`'s `rateLimitResponse()` now also includes `code: "RATE_LIMITED"` for consistency with the new envelope.
- Fixed `tests/api_routes.test.ts`, which previously couldn't even load (it imported a nonexistent `app/api/analytics/route` module and bridged the Fetch-API-based route handlers through an incompatible Express/supertest adapter). It's rewritten to invoke the real handlers directly and assert the new error format end-to-end.
- Added `lib/api/errors.test.ts` (21 tests) covering every error class, `errorResponse`, and `withErrorHandling`.

Note: `app/api/v1/hunts/id/route.ts` has a pre-existing, unrelated bug — its folder is a literal `id` segment (not `[id]`), so the handler's `params` destructuring never resolves an actual ID and the route always 400s. I left that behavior untouched since fixing it is out of scope for an error-handling PR; only its error *shape* was updated.

## Acceptance criteria

- [x] Error response helper with standard format
- [x] Error types: `ValidationError`, `NotFoundError`, `AuthError`, `ForbiddenError`, `ConflictError`, `RateLimitError`, `BadGatewayError`, `ServiceUnavailableError`, `InternalError`
- [x] All API routes wrapped with try-catch middleware (`withErrorHandling`)
- [x] Consistent `{ error: string, code: string, details?: object }` format
- [x] `x-request-id` header on all responses for tracing

## Test plan

- [x] `pnpm exec vitest run` — no new failures vs. `main` baseline (26 pre-existing failures in unrelated wallet-hook/component tests are unchanged; this branch additionally fixes 2 previously-broken test files)
- [x] `pnpm exec eslint` on all changed files — clean
- [x] `pnpm exec tsc --noEmit` — no new type errors (one pre-existing syntax error in `components/GameCompleteModal.tsx`, unrelated to this change, confirmed present on `main` too)