### PR TITLE
[#596] Build player profile page

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -285,8 +285,13 @@ export default function UserProfilePage() {
 
   const completedHunts = hunts.filter((h) => h.status === "Completed")
   const inProgressHunts = hunts.filter((h) => h.status === "In-Progress")
+  const totalXlmEarned = rewardHistory.reduce(
+    (sum, entry) => sum + (entry.type === "XLM" ? (entry.amount ?? 0) : 0),
+    0,
+  )
 
   const displayAddress = publicKey ? shortenAddress(publicKey) : "Not connected"
+  const avatarLabel = publicKey ? publicKey.slice(1, 3).toUpperCase() : "HP"
 
   return (
     <div className="min-h-screen bg-linear-to-tr from-blue-100 bg-purple-100 to-[#f9f9ff] pb-20">
@@ -303,9 +308,14 @@ export default function UserProfilePage() {
             </p>
           </div>
 
-          <Card className="border border-slate-200 bg-white/70 shadow-sm px-4 py-3 flex flex-col gap-1 max-w-sm">
-            <div className="text-xs uppercase tracking-wide text-slate-500">Connected Wallet</div>
-            <div className="font-mono text-sm text-slate-800 break-all">{displayAddress}</div>
+          <Card className="border border-slate-200 bg-white/70 shadow-sm px-4 py-3 flex items-center gap-3 max-w-sm">
+            <div className="h-11 w-11 rounded-full bg-gradient-to-br from-[#3737A4] to-[#0C0C4F] text-white grid place-items-center font-semibold text-sm">
+              {avatarLabel}
+            </div>
+            <div className="flex flex-col gap-1">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Connected Wallet</div>
+              <div className="font-mono text-sm text-slate-800 break-all">{displayAddress}</div>
+            </div>
           </Card>
         </div>
 
@@ -372,6 +382,13 @@ export default function UserProfilePage() {
                     <StatPill label="NFT Rewards" value={summary.totalNftRewards ?? 0} />
                     <StatPill label="NFTs Claimed" value={summary.claimedNftRewards ?? 0} />
                     <StatPill label="NFTs Unclaimed" value={summary.unclaimedNftRewards ?? 0} />
+                  </div>
+                  <div className="mt-4">
+                    <StatPill
+                      label="Total XLM Earned"
+                      value={Number(totalXlmEarned.toFixed(2))}
+                      valueClassName="text-emerald-600"
+                    />
                   </div>
                   <div className="mt-4 text-sm text-slate-600">
                     Completion rate:{" "}


### PR DESCRIPTION
## Summary
- add a wallet avatar badge to the profile header for a stronger player identity surface
- keep wallet address visible while improving hierarchy and readability
- add a "Total XLM Earned" stat sourced from reward history entries

## Validation
- Updated profile file diagnostics pass
- Full repository build/tests currently blocked by existing upstream issues unrelated to this profile patch

Closes #596
