### PR TITLE
feat(hints): progressive hint system for hunt clues (#591)

### DIFF
--- a/app/api/analytics/hint-usage/route.ts
+++ b/app/api/analytics/hint-usage/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server"
+import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit"
+import { recordHintUsage, getHintUsageStats } from "@/lib/analytics"
+
+/**
+ * POST /api/analytics/hint-usage
+ * Body: { huntId: number; clueId: number; hintIndex: number; wallet: string }
+ *
+ * Records a hint reveal event. The wallet address is hashed server-side before
+ * storage — raw addresses are never persisted.
+ */
+export async function POST(req: Request) {
+  const ip = getIP(req)
+  const { success, reset } = rateLimit(ip, { limit: 60, windowMs: 60_000 })
+  if (!success) return rateLimitResponse(reset)
+
+  let body: { huntId?: unknown; clueId?: unknown; hintIndex?: unknown; wallet?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+  }
+
+  const { huntId, clueId, hintIndex, wallet } = body
+
+  if (typeof huntId !== "number" || huntId <= 0) {
+    return NextResponse.json({ error: "huntId must be a positive number" }, { status: 400 })
+  }
+  if (typeof clueId !== "number" || clueId <= 0) {
+    return NextResponse.json({ error: "clueId must be a positive number" }, { status: 400 })
+  }
+  if (typeof hintIndex !== "number" || hintIndex < 0 || hintIndex > 2) {
+    return NextResponse.json({ error: "hintIndex must be 0, 1, or 2" }, { status: 400 })
+  }
+  if (typeof wallet !== "string" || wallet.trim().length === 0) {
+    return NextResponse.json({ error: "wallet is required" }, { status: 400 })
+  }
+
+  try {
+    await recordHintUsage(huntId, clueId, hintIndex, wallet.trim())
+    return NextResponse.json({ ok: true }, { status: 200 })
+  } catch (error) {
+    // Analytics errors must never break gameplay
+    console.error("Failed to record hint usage analytics:", error)
+    return NextResponse.json({ ok: true }, { status: 200 })
+  }
+}
+
+/**
+ * GET /api/analytics/hint-usage?huntId=<n>
+ *
+ * Returns aggregated hint reveal counts for a hunt.
+ * Intended for creator dashboards; no auth in this mock implementation.
+ */
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const huntIdParam = searchParams.get("huntId")
+  const huntId = huntIdParam ? Number(huntIdParam) : NaN
+
+  if (!huntId || Number.isNaN(huntId)) {
+    return NextResponse.json({ error: "huntId query param is required" }, { status: 400 })
+  }
+
+  try {
+    const stats = await getHintUsageStats(huntId)
+    return NextResponse.json({ huntId, stats }, { status: 200 })
+  } catch (error) {
+    console.error("Failed to fetch hint usage stats:", error)
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 })
+  }
+}

--- a/app/api/v1/answers/route.ts
+++ b/app/api/v1/answers/route.ts
@@ -11,6 +11,7 @@ import {
   getConfig,
 } from "@/lib/anti-cheat"
 import { getServerClue } from "@/lib/server/seedClues"
+import { recordHintUsage } from "@/lib/analytics"
 
 export async function POST(req: Request) {
   const ip = getIP(req)
@@ -23,14 +24,22 @@ export async function POST(req: Request) {
     return rateLimitResponse(ipReset)
   }
 
-  let body: { huntId?: number; clueId?: number; answer?: string; wallet?: string; clientTimestamp?: number }
+  let body: {
+    huntId?: number
+    clueId?: number
+    answer?: string
+    wallet?: string
+    clientTimestamp?: number
+    /** Number of progressive hints the player revealed before submitting. */
+    hintsUsed?: number
+  }
   try {
     body = await req.json()
   } catch {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
   }
 
-  const { huntId, clueId, answer, wallet, clientTimestamp } = body
+  const { huntId, clueId, answer, wallet, clientTimestamp, hintsUsed } = body
 
   if (!huntId || typeof huntId !== "number") {
     return NextResponse.json({ error: "huntId is required" }, { status: 400 })
@@ -44,6 +53,9 @@ export async function POST(req: Request) {
   if (!wallet || typeof wallet !== "string" || wallet.trim().length === 0) {
     return NextResponse.json({ error: "wallet is required" }, { status: 400 })
   }
+
+  // Clamp hintsUsed to a sane range (0-3) — never trust the client blindly
+  const validatedHintsUsed = Math.min(3, Math.max(0, typeof hintsUsed === "number" ? Math.floor(hintsUsed) : 0))
 
   if (isBanned(wallet, ip)) {
     return NextResponse.json({ error: "Account is banned due to suspicious activity" }, { status: 403 })
@@ -83,6 +95,15 @@ export async function POST(req: Request) {
     anomalyFlags,
   )
 
+  // Record each hint reveal in the analytics store (non-blocking, fire-and-forget)
+  if (correct && validatedHintsUsed > 0) {
+    for (let i = 0; i < validatedHintsUsed; i++) {
+      recordHintUsage(huntId, clueId, i, wallet).catch(() => {
+        // Analytics errors must never break the answer response
+      })
+    }
+  }
+
   if (!correct) {
     return NextResponse.json(
       { correct: false, score: 0, bonusPoints: 0, flags: anomalyFlags },
@@ -98,5 +119,6 @@ export async function POST(req: Request) {
     event: "ClueCompleted",
     serverTimestamp: Date.now(),
     flags: anomalyFlags,
+    hintsUsed: validatedHintsUsed,
   })
 }

--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -1,25 +1,25 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import confetti from "canvas-confetti";
 import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { ArrowRight, CheckCircle2, Loader2, Printer } from "lucide-react";
+import { ArrowRight, CheckCircle2, Clock, Lightbulb, Loader2, Printer } from "lucide-react";
 import picture from "@/public/static-images/image1.png";
 import { HuntCardSkeleton } from "@/components/LoadingSkeletons";
 import { cn } from "@/lib/utils";
 import sanitizeHtml from "@/lib/sanitizeHtml";
 import { submitAnswer, AnswerIncorrectError, pollTransaction } from "@/lib/contracts/hunt";
 import { getClueElapsedSeconds, recordClueAttempt } from "@/lib/huntAttemptHistory";
-import { calculateCluePoints, DEFAULT_SCORING_WEIGHTS } from "@/lib/scoring";
+import { calculateCluePoints } from "@/lib/scoring";
 import { resolveImageSrc, GATEWAY_COUNT } from "@/lib/ipfs";
-import type { HuntCard as Hunt } from "@/lib/types";
+import type { ClueHint, HuntCard as Hunt } from "@/lib/types";
 import { usePlayerCount } from "@/hooks/usePlayerCount";
 
 export type { Hunt };
 
 interface HuntCardsProps {
-  hunts: Hunt[]; // always an array of one item in active/preview mode
+  hunts: Hunt[];
   isActive?: boolean;
   preview?: boolean;
   onUnlock?: () => void;
@@ -36,11 +36,6 @@ interface HuntCardsProps {
   solved?: boolean;
   /** Whether the hunt has ended. */
   huntEnded?: boolean;
-  /**
-   * Pre-fetched player count from the arcade page (via usePlayerCounts).
-   * When omitted, the component fetches its own count via usePlayerCount.
-   * Passing from the parent avoids N individual fetches when many cards render.
-   */
   playerCount?: number;
   playerCountLoading?: boolean;
   playerCountError?: string | null;
@@ -52,10 +47,7 @@ interface HuntCardsProps {
 const DEFAULT_POINTS = 10;
 
 const shakeVariants = {
-  shake: {
-    x: [0, -10, 10, -10, 10, -5, 5, 0],
-    transition: { duration: 0.5 },
-  },
+  shake: { x: [0, -10, 10, -10, 10, -5, 5, 0], transition: { duration: 0.5 } },
   idle: { x: 0 },
 };
 
@@ -64,6 +56,50 @@ const slideVariants = {
   animate: { opacity: 1, y: 0 },
   exit: { opacity: 0, y: -20 },
 };
+
+/**
+ * Resolve the effective hints array for a clue, falling back to the legacy
+ * single-hint fields when the new `hints` array is absent.
+ */
+function resolveHints(hunt: Hunt): ClueHint[] {
+  if (hunt.hints && hunt.hints.length > 0) return hunt.hints;
+  // Legacy fallback: treat hint/hintCost as a single hint with no delay
+  if (hunt.hint) {
+    return [{ text: hunt.hint, penalty: hunt.hintCost ?? 0, delaySeconds: 0 }];
+  }
+  return [];
+}
+
+/**
+ * Hook that drives the per-hint countdown timer.
+ * Returns seconds remaining until the next hint can be revealed (0 = ready).
+ */
+function useHintCountdown(
+  lastRevealedAt: number | null,
+  nextDelaySeconds: number
+): number {
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    if (lastRevealedAt === null || nextDelaySeconds <= 0) {
+      setRemaining(0);
+      return;
+    }
+    const tick = () => {
+      const elapsed = (Date.now() - lastRevealedAt) / 1000;
+      const left = Math.max(0, Math.ceil(nextDelaySeconds - elapsed));
+      setRemaining(left);
+      if (left > 0) {
+        timerRef.current = window.setTimeout(tick, 500);
+      }
+    };
+    const timerRef = { current: 0 };
+    tick();
+    return () => window.clearTimeout(timerRef.current);
+  }, [lastRevealedAt, nextDelaySeconds]);
+
+  return remaining;
+}
 
 export const HuntCards: React.FC<HuntCardsProps> = ({
   hunts,
@@ -85,11 +121,8 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
   playerAddress,
   attemptId,
 }) => {
-  const hunt = hunts && hunts.length > 0 ? hunts[0] : {} as Hunt;
+  const hunt = hunts && hunts.length > 0 ? hunts[0] : ({} as Hunt);
 
-  // If the parent pre-fetched counts (arcade page), use those.
-  // Otherwise fall back to the per-card hook (play flow).
-  // Using String(huntId ?? hunt.id) as the key — both are numeric IDs.
   const fallbackId = String(huntId ?? hunt.id ?? "");
   const ownCount = usePlayerCount(playerCountProp !== undefined ? "" : fallbackId);
 
@@ -97,38 +130,50 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
   const countIsLoading = playerCountProp !== undefined ? (playerCountLoadingProp ?? false) : ownCount.isLoading;
   const countError = playerCountProp !== undefined ? (playerCountErrorProp ?? null) : ownCount.error;
   const trending = playerCountProp !== undefined ? (isTrendingProp ?? false) : ownCount.isTrending;
+
   const [input, setInput] = useState("");
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [isPending, setIsPending] = useState(false);
-  // Ref-based guard to prevent concurrent submissions (avoids double-click race)
   const submittingRef = useRef(false);
   const [imgGatewayIdx, setImgGatewayIdx] = useState(0);
-  const [hintRevealed, setHintRevealed] = useState(false);
-  const [hintsUsed, setHintsUsed] = useState(0);
   const [keyboardInsetHeight, setKeyboardInsetHeight] = useState(0);
   const prefersReducedMotion = useReducedMotion();
   const [shake, setShake] = useState(false);
 
+  // ── Progressive hint state ──────────────────────────────────────────────
+  // Index of the next hint to reveal (0 = none revealed yet, hints.length = all revealed)
+  const [revealedCount, setRevealedCount] = useState(0);
+  // Timestamp (ms) when the last hint was revealed — drives the delay countdown
+  const [lastRevealedAt, setLastRevealedAt] = useState<number | null>(null);
+
+  const hints = resolveHints(hunt);
+  const nextHint: ClueHint | undefined = hints[revealedCount];
+  const nextDelay = nextHint?.delaySeconds ?? 0;
+  const countdownSeconds = useHintCountdown(lastRevealedAt, nextDelay);
+
+  // Total penalty accrued from all revealed hints
+  const totalHintPenalty = hints
+    .slice(0, revealedCount)
+    .reduce((sum, h) => sum + h.penalty, 0);
+
+  const revealNextHint = useCallback(() => {
+    if (revealedCount >= hints.length) return;
+    setRevealedCount((n) => n + 1);
+    setLastRevealedAt(Date.now());
+  }, [revealedCount, hints.length]);
+
+  // ── Keyboard inset (mobile virtual keyboard) ───────────────────────────
   useEffect(() => {
     if (typeof window === "undefined") return;
-
     const updateInset = () => {
       const viewport = window.visualViewport;
-      if (!viewport) {
-        setKeyboardInsetHeight(0);
-        return;
-      }
-
-      const inset = Math.max(0, window.innerHeight - viewport.height);
-      setKeyboardInsetHeight(inset);
+      setKeyboardInsetHeight(viewport ? Math.max(0, window.innerHeight - viewport.height) : 0);
     };
-
     updateInset();
     window.addEventListener("resize", updateInset);
     window.visualViewport?.addEventListener("resize", updateInset);
     window.visualViewport?.addEventListener("scroll", updateInset);
-
     return () => {
       window.removeEventListener("resize", updateInset);
       window.visualViewport?.removeEventListener("resize", updateInset);
@@ -152,145 +197,90 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
 
   const handleUnlock = async () => {
     if (!isActive || preview) return;
-    // Immediate ref-guard to avoid race from double-clicks or rapid presses
     if (submittingRef.current) return;
-
     submittingRef.current = true;
     setIsPending(true);
     setError("");
 
     try {
       if (huntId != null) {
-        // Contract path: submit_answer → ClueCompleted | AnswerIncorrect
         const result = await submitAnswer(huntId, Number(hunt.id), input);
-        // Poll for transaction inclusion
-        if (result && result.txHash) {
-          await pollTransaction(result.txHash);
-        }
+        if (result?.txHash) await pollTransaction(result.txHash);
 
-        // ClueCompleted event received
         setSuccess(true);
-
-        const actualPoints = Math.max(
-          0,
-          (points ?? DEFAULT_POINTS) - (hintRevealed ? (hunt.hintCost || 0) : 0)
-        );
 
         let updatedActualPoints = 0;
         if (playerAddress && attemptId) {
           const updatedAttempt = recordClueAttempt(
-            playerAddress, 
-            attemptId, 
+            playerAddress,
+            attemptId,
             {
               clueId: Number(hunt.id),
               clueIndex: currentIndex - 1,
-              question: hunt.title,
+              question: hunt.title ?? "",
               answerGiven: input.trim(),
               timeTakenSeconds: getClueElapsedSeconds(huntId, Number(hunt.id)),
-              pointsEarned: 0, // This will be replaced by the scoring function
+              pointsEarned: 0,
               answeredAt: new Date().toISOString(),
-              hintsUsed: 0, // This will be replaced too
+              hintsUsed: revealedCount,
             },
             points ?? DEFAULT_POINTS,
             hunt.difficulty || "Medium",
-            hintsUsed
+            revealedCount,
+            totalHintPenalty,
           );
           if (updatedAttempt) {
-            // Find the clue we just added to get the points
-            const updatedClue = updatedAttempt.clues.find(
-              (c) => c.clueId === Number(hunt.id)
-            );
-            updatedActualPoints = updatedClue?.pointsEarned || 0;
+            const updatedClue = updatedAttempt.clues.find((c) => c.clueId === Number(hunt.id));
+            updatedActualPoints = updatedClue?.pointsEarned ?? 0;
           }
         } else {
-          // Fallback if no address/attempt ID
-          updatedActualPoints = Math.max(0, (points ?? DEFAULT_POINTS) - (hintRevealed ? (hunt.hintCost || 0) : 0));
+          updatedActualPoints = Math.max(0, (points ?? DEFAULT_POINTS) - totalHintPenalty);
         }
-        
-        // Celebratory confetti (Requirement #146)
+
         const isLastClue = currentIndex === totalHunts;
         const isDifficultClue = (points ?? DEFAULT_POINTS) >= 20;
-
         if (!prefersReducedMotion) {
           if (isLastClue) {
-            confetti({
-              particleCount: 150,
-              spread: 100,
-              origin: { y: 0.6 },
-              colors: ["#3737A4", "#E3225C", "#39A437", "#FFD43E"],
-            });
+            confetti({ particleCount: 150, spread: 100, origin: { y: 0.6 }, colors: ["#3737A4", "#E3225C", "#39A437", "#FFD43E"] });
           } else if (isDifficultClue) {
-            confetti({
-              particleCount: 80,
-              spread: 60,
-              origin: { y: 0.7 },
-            });
+            confetti({ particleCount: 80, spread: 60, origin: { y: 0.7 } });
           }
         }
 
         setInput("");
         onScoreUpdate?.(updatedActualPoints);
-        setTimeout(() => {
-          setSuccess(false);
-          onUnlock?.();
-        }, 1200);
+        setTimeout(() => { setSuccess(false); onUnlock?.(); }, 1200);
       } else {
-        // Local fallback (test / preview mode — no wallet required)
+        // Local / preview fallback
         if (input.trim().toLowerCase() === (hunt.code || "").trim().toLowerCase()) {
           setSuccess(true);
-          
-          // Calculate points for local mode too!
           const { breakdown } = calculateCluePoints(
             points ?? DEFAULT_POINTS,
             hunt.difficulty || "Medium",
-            0, // For local mode, time is 0 for simplicity
-            hintsUsed,
-            0 // Streak 0 for local mode
+            0,
+            revealedCount,
+            0,
           );
-          
-          // Celebratory confetti for local/preview mode (Requirement #146)
           const isLastClue = currentIndex === totalHunts;
           const isDifficultClue = (points ?? DEFAULT_POINTS) >= 20;
-
           if (!prefersReducedMotion) {
-            if (isLastClue) {
-              confetti({
-                particleCount: 150,
-                spread: 100,
-                origin: { y: 0.6 },
-              });
-            } else if (isDifficultClue) {
-              confetti({
-                particleCount: 80,
-                spread: 60,
-                origin: { y: 0.7 },
-              });
-            }
+            if (isLastClue) confetti({ particleCount: 150, spread: 100, origin: { y: 0.6 } });
+            else if (isDifficultClue) confetti({ particleCount: 80, spread: 60, origin: { y: 0.7 } });
           }
-
           setError("");
           setInput("");
           onScoreUpdate?.(breakdown.totalPoints);
-          setTimeout(() => {
-            setSuccess(false);
-            onUnlock?.();
-          }, 1200);
+          setTimeout(() => { setSuccess(false); onUnlock?.(); }, 1200);
         } else {
           setError("Try Again");
           setSuccess(false);
-          if (!prefersReducedMotion) {
-            setShake(true);
-            setTimeout(() => setShake(false), 500);
-          }
+          if (!prefersReducedMotion) { setShake(true); setTimeout(() => setShake(false), 500); }
         }
       }
     } catch (err) {
       if (err instanceof AnswerIncorrectError) {
         setError("Try Again");
-        if (!prefersReducedMotion) {
-          setShake(true);
-          setTimeout(() => setShake(false), 500);
-        }
+        if (!prefersReducedMotion) { setShake(true); setTimeout(() => setShake(false), 500); }
       } else {
         setError(err instanceof Error ? err.message : "Submission failed. Try again.");
       }
@@ -301,7 +291,6 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
     }
   };
 
-  // Allow Enter key to submit
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") handleUnlock();
   };
@@ -314,25 +303,39 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           isActive ? "sm:scale-105 border-2 border-blue-400" : preview ? "opacity-70" : "opacity-90"
         )}
       />
-    )
+    );
   }
 
   const isLocked = !isActive || preview || isPending || solved || huntEnded;
 
+  // ── Derived hint-button state ──────────────────────────────────────────
+  const allHintsRevealed = revealedCount >= hints.length;
+  const hasHints = hints.length > 0;
+  // Can reveal when: not all revealed, not solved, not locked, and delay elapsed
+  const canRevealNextHint = hasHints && !allHintsRevealed && !solved && !isLocked && countdownSeconds === 0;
+
   return (
-    <div tabIndex={0} onKeyDown={handleKeyDown} className={cn(
-      "rounded-xl sm:rounded-2xl shadow-lg w-full max-w-[400px] transition-all duration-300 relative print:shadow-none print:border-none print:max-w-none print:scale-100 print:m-0 print:opacity-100 bg-white dark:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500",
-      isActive ? "sm:scale-105 border-2 border-blue-400 dark:border-blue-500" : preview ? "opacity-70" : "opacity-90"
-    )}>
+    <div
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "rounded-xl sm:rounded-2xl shadow-lg w-full max-w-[400px] transition-all duration-300 relative print:shadow-none print:border-none print:max-w-none print:scale-100 print:m-0 print:opacity-100 bg-white dark:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500",
+        isActive ? "sm:scale-105 border-2 border-blue-400 dark:border-blue-500" : preview ? "opacity-70" : "opacity-90"
+      )}
+    >
       {solved && (
         <div className="absolute inset-0 bg-green-500/10 rounded-xl sm:rounded-2xl z-20 flex items-center justify-center pointer-events-none print:hidden">
           <CheckCircle2 className="w-12 sm:w-16 h-12 sm:h-16 text-green-500 opacity-60" />
         </div>
       )}
+
+      {/* ── Header band ─────────────────────────────────────────────── */}
       <div className="rounded-t-xl sm:rounded-t-2xl px-4 sm:px-6 pt-6 sm:pt-8 pb-4 sm:pb-6 text-white bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] print:bg-none print:text-black print:p-8">
         <div className="flex justify-between items-center text-xs sm:text-sm mb-3 sm:mb-4">
           {points != null && (
-            <span className="bg-white/20 px-2 py-0.5 rounded-full text-xs font-semibold print:bg-transparent print:border print:border-gray-300 print:text-black">{points} pts</span>
+            <span className="bg-white/20 px-2 py-0.5 rounded-full text-xs font-semibold print:bg-transparent print:border print:border-gray-300 print:text-black">
+              {points} pts
+            </span>
           )}
           <div className="ml-auto flex items-center gap-2">
             {trending && (
@@ -357,7 +360,7 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           )}
           <span className="text-[#B3B3E5] ml-auto print:text-black text-xs sm:text-sm">{currentIndex}/{totalHunts}</span>
         </div>
-        {/* Player count — shown below the title row, above description */}
+
         <span
           className="player-count block text-xs text-white/60 mb-2 print:hidden"
           aria-label={countIsLoading ? "Loading player count" : countError ? undefined : `${count} player${count !== 1 ? "s" : ""} registered`}
@@ -368,10 +371,14 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
             `${count} player${count !== 1 ? "s" : ""} registered`
           )}
         </span>
+
         <h3 className="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2 print:text-3xl print:mb-4">
           {hunt.title || "Untitled Hunt"}
         </h3>
-        <p className="text-xs sm:text-sm opacity-90 mb-4 sm:mb-6 line-clamp-3 print:text-lg print:opacity-100 print:mb-8" dangerouslySetInnerHTML={{ __html: sanitizeHtml(hunt.description || "No description provided.") }} />
+        <p
+          className="text-xs sm:text-sm opacity-90 mb-4 sm:mb-6 line-clamp-3 print:text-lg print:opacity-100 print:mb-8"
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(hunt.description || "No description provided.") }}
+        />
         <div className="flex justify-center">
           {hunt.link || hunt.image ? (
             <Image
@@ -381,11 +388,7 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
               height={180}
               loading="lazy"
               sizes="180px"
-              onError={() => {
-                if (imgGatewayIdx < GATEWAY_COUNT - 1) {
-                  setImgGatewayIdx((i) => i + 1)
-                }
-              }}
+              onError={() => { if (imgGatewayIdx < GATEWAY_COUNT - 1) setImgGatewayIdx((i) => i + 1); }}
               unoptimized
               className="w-[140px] h-[140px] sm:w-[180px] sm:h-[180px] object-contain print:w-64 print:h-auto print:rounded-xl"
             />
@@ -403,31 +406,83 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
         </div>
       </div>
 
-      {hunt.hint && !solved && (
-        <div className="bg-white dark:bg-slate-900 px-4 sm:px-6 py-2 border-b border-gray-100 dark:border-white/5 print:hidden">
-          {!hintRevealed ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full text-xs sm:text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 border-blue-200 dark:border-blue-900/50 py-2 sm:py-2.5"
-              onClick={() => {
-                setHintRevealed(true);
-                setHintsUsed((prev) => prev + 1);
-              }}
-              disabled={isLocked}
-            >
-              Reveal Hint (-{hunt.hintCost || 0} pts)
-            </Button>
-              ) : (
-            <div className="bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300 p-2 sm:p-3 rounded-lg sm:rounded-xl text-xs sm:text-sm border border-blue-100 dark:border-blue-900/30">
-              <span className="font-semibold text-blue-900 dark:text-blue-200 mr-2">Hint:</span>
-              <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(hunt.hint || "") }} />
+      {/* ── Progressive hints panel ─────────────────────────────────── */}
+      {hasHints && !solved && (
+        <div className="bg-white dark:bg-slate-900 px-4 sm:px-6 py-2 border-b border-gray-100 dark:border-white/5 print:hidden space-y-2">
+
+          {/* Already-revealed hints */}
+          {revealedCount > 0 && (
+            <div className="space-y-1.5" aria-live="polite" aria-label="Revealed hints">
+              {hints.slice(0, revealedCount).map((h, i) => (
+                <div
+                  key={i}
+                  className="flex items-start gap-2 bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300 p-2 sm:p-2.5 rounded-lg text-xs sm:text-sm border border-blue-100 dark:border-blue-900/30"
+                >
+                  <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-blue-500 dark:text-blue-400" aria-hidden="true" />
+                  <div className="min-w-0">
+                    <span className="font-semibold text-blue-900 dark:text-blue-200 mr-1.5">
+                      Hint {i + 1}
+                      {h.penalty > 0 && (
+                        <span className="ml-1 text-[10px] font-normal text-blue-500 dark:text-blue-400">
+                          (-{h.penalty} pts)
+                        </span>
+                      )}:
+                    </span>
+                    <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(h.text) }} />
+                  </div>
+                </div>
+              ))}
             </div>
+          )}
+
+          {/* Next-hint button or countdown */}
+          {!allHintsRevealed && (
+            <div>
+              {countdownSeconds > 0 ? (
+                /* Countdown: next hint not yet available */
+                <div
+                  className="flex items-center justify-center gap-2 text-xs sm:text-sm text-slate-500 dark:text-slate-400 py-1.5"
+                  aria-live="polite"
+                  aria-label={`Hint ${revealedCount + 1} available in ${countdownSeconds} seconds`}
+                >
+                  <Clock className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                  <span>
+                    Hint {revealedCount + 1} available in{" "}
+                    <span className="font-semibold tabular-nums">{countdownSeconds}s</span>
+                  </span>
+                </div>
+              ) : (
+                /* Reveal button */
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full text-xs sm:text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 border-blue-200 dark:border-blue-900/50 py-2 sm:py-2.5"
+                  onClick={revealNextHint}
+                  disabled={!canRevealNextHint}
+                  aria-label={`Reveal hint ${revealedCount + 1}${nextHint?.penalty ? ` (costs ${nextHint.penalty} points)` : ""}`}
+                >
+                  <Lightbulb className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" />
+                  Reveal Hint {revealedCount + 1} of {hints.length}
+                  {nextHint?.penalty ? (
+                    <span className="ml-1.5 text-blue-500 dark:text-blue-400">
+                      (-{nextHint.penalty} pts)
+                    </span>
+                  ) : null}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {/* All hints revealed */}
+          {allHintsRevealed && (
+            <p className="text-xs text-center text-slate-400 dark:text-slate-500 py-0.5">
+              All hints revealed
+            </p>
           )}
         </div>
       )}
 
-      {/* Print button */}
+      {/* ── Print button ─────────────────────────────────────────────── */}
       <div className="bg-white dark:bg-slate-900 px-4 sm:px-6 pt-2 sm:pt-3 print:hidden">
         <Button
           variant="outline"
@@ -440,7 +495,7 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
         </Button>
       </div>
 
-      {/* Input and button only for active, non-preview cards */}
+      {/* ── Answer input row ─────────────────────────────────────────── */}
       <div
         data-testid="answer-row"
         className="sticky bottom-0 left-0 z-20 bg-white dark:bg-slate-900 flex gap-2 p-4 sm:p-6 rounded-b-xl sm:rounded-b-2xl items-center print:hidden"
@@ -449,23 +504,19 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           backdropFilter: "saturate(180%) blur(18px)",
         }}
       >
-        <motion.div
-          animate={shake ? "shake" : "idle"}
-          variants={shakeVariants}
-          className="flex-1"
-        >
+        <motion.div animate={shake ? "shake" : "idle"} variants={shakeVariants} className="flex-1">
           <Input
-          placeholder={isActive && !preview ? "Enter answer" : "Locked"}
-          className={cn(
-            "flex-1 px-3 sm:px-4 py-2 sm:py-2.5 rounded-lg sm:rounded-full text-sm transition-colors",
-            isLocked ? "bg-gray-100 dark:bg-slate-800 cursor-not-allowed" : "dark:bg-slate-950 dark:border-white/10"
-          )}
-          value={input}
-          onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
-          onFocus={handleInputFocus}
-          disabled={isLocked}
-        />
+            placeholder={isActive && !preview ? "Enter answer" : "Locked"}
+            className={cn(
+              "flex-1 px-3 sm:px-4 py-2 sm:py-2.5 rounded-lg sm:rounded-full text-sm transition-colors",
+              isLocked ? "bg-gray-100 dark:bg-slate-800 cursor-not-allowed" : "dark:bg-slate-950 dark:border-white/10"
+            )}
+            value={input}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            onFocus={handleInputFocus}
+            disabled={isLocked}
+          />
         </motion.div>
         <Button
           className={cn(
@@ -475,60 +526,30 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           onClick={handleUnlock}
           disabled={isLocked}
         >
-          {isPending ? (
-            <Loader2 className="w-4 h-4 animate-spin" />
-          ) : (
-            <ArrowRight className="w-4 h-4" />
-          )}
+          {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowRight className="w-4 h-4" />}
         </Button>
       </div>
 
-      {/* Feedback */}
+      {/* ── Feedback strip ───────────────────────────────────────────── */}
       <div className="bg-white dark:bg-slate-900 rounded-b-xl sm:rounded-b-2xl -mt-4 pb-4 px-4 sm:px-6 min-h-[36px] print:hidden">
         <AnimatePresence mode="wait">
           {huntEnded && (
-            <motion.div
-              key="ended"
-              initial={prefersReducedMotion ? false : { opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={prefersReducedMotion ? {} : { opacity: 0 }}
-              className="flex items-center justify-center gap-2 text-red-600 dark:text-red-400 font-bold text-sm sm:text-base"
-            >
-              <span>🏁</span>
-              Hunt Ended
+            <motion.div key="ended" initial={prefersReducedMotion ? false : { opacity: 0 }} animate={{ opacity: 1 }} exit={prefersReducedMotion ? {} : { opacity: 0 }} className="flex items-center justify-center gap-2 text-red-600 dark:text-red-400 font-bold text-sm sm:text-base">
+              <span>🏁</span> Hunt Ended
             </motion.div>
           )}
           {!huntEnded && success && (
-            <motion.div
-              key="success"
-              initial={prefersReducedMotion ? false : slideVariants.initial}
-              animate={prefersReducedMotion ? {} : slideVariants.animate}
-              exit={prefersReducedMotion ? {} : slideVariants.exit}
-              className="flex items-center justify-center gap-2 text-green-600 dark:text-green-400 font-bold text-sm sm:text-base"
-            >
-              <CheckCircle2 className="w-4 h-4 sm:w-5 sm:h-5" />
-              Solved!
+            <motion.div key="success" initial={prefersReducedMotion ? false : slideVariants.initial} animate={prefersReducedMotion ? {} : slideVariants.animate} exit={prefersReducedMotion ? {} : slideVariants.exit} className="flex items-center justify-center gap-2 text-green-600 dark:text-green-400 font-bold text-sm sm:text-base">
+              <CheckCircle2 className="w-4 h-4 sm:w-5 sm:h-5" /> Solved!
             </motion.div>
           )}
           {!huntEnded && !success && isPending && (
-            <motion.p
-              key="pending"
-              initial={prefersReducedMotion ? false : { opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={prefersReducedMotion ? {} : { opacity: 0 }}
-              className="text-center text-slate-400 dark:text-slate-400 text-xs sm:text-sm"
-            >
+            <motion.p key="pending" initial={prefersReducedMotion ? false : { opacity: 0 }} animate={{ opacity: 1 }} exit={prefersReducedMotion ? {} : { opacity: 0 }} className="text-center text-slate-400 dark:text-slate-400 text-xs sm:text-sm">
               Submitting...
             </motion.p>
           )}
           {!huntEnded && !success && !isPending && error && (
-            <motion.p
-              key="error"
-              initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={prefersReducedMotion ? {} : { opacity: 0, scale: 0.95 }}
-              className="text-center text-red-500 dark:text-red-400 font-semibold text-xs sm:text-sm"
-            >
+            <motion.p key="error" initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={prefersReducedMotion ? {} : { opacity: 0, scale: 0.95 }} className="text-center text-red-500 dark:text-red-400 font-semibold text-xs sm:text-sm">
               {error}
             </motion.p>
           )}

--- a/components/HuntForm.tsx
+++ b/components/HuntForm.tsx
@@ -4,7 +4,7 @@ import React, { ChangeEvent, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import ToggleSwitch from "./ToggleButton"
-import { Minus, Plus, Trash2, Eye, EyeOff } from "lucide-react"
+import { ChevronDown, ChevronUp, Minus, Plus, Trash2, Eye, EyeOff } from "lucide-react"
 import { Controller, useFieldArray, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
@@ -16,7 +16,7 @@ import { COVER_IMAGE_UPLOAD_ERROR_MESSAGE, uploadToIPFS } from "@/lib/ipfs"
 import { logger } from "@/lib/logger"
 import { toast } from "sonner"
 import { HuntCards } from "./HuntCards"
-import type { CoverImageUploadState, HuntDraft } from "@/lib/types"
+import type { ClueHint, CoverImageUploadState, HuntDraft } from "@/lib/types"
 
 interface HuntFormProps {
   hunt: HuntDraft
@@ -27,12 +27,20 @@ interface HuntFormProps {
   onImageUploadStateChange?: (state: CoverImageUploadState) => void
 }
 
+/** Maximum number of progressive hints per clue. */
+const MAX_HINTS = 3
+
+const hintSchema = z.object({
+  text: z.string().min(1, "Hint text is required"),
+  penalty: z.number().min(0, "Penalty must be 0 or more"),
+  delaySeconds: z.number().min(0, "Delay must be 0 or more"),
+})
+
 const clueSchema = z.object({
   question: z.string().min(1, "Question is required"),
   answer: z.string().min(1, "Answer is required"),
   points: z.number().min(1, "Points must be at least 1"),
-  hint: z.string(),
-  hintCost: z.number().min(0),
+  hints: z.array(hintSchema).max(MAX_HINTS),
   difficulty: z.enum(["Easy", "Medium", "Hard"]).optional(),
 })
 
@@ -42,6 +50,150 @@ const cluesFormSchema = z.object({
 
 type CluesFormData = z.infer<typeof cluesFormSchema>
 
+const DEFAULT_CLUE = {
+  question: "",
+  answer: "",
+  points: 10,
+  hints: [] as z.infer<typeof hintSchema>[],
+  difficulty: undefined as "Easy" | "Medium" | "Hard" | undefined,
+}
+
+/** Sub-component that renders the hints array for one clue row. */
+function ClueHintsEditor({
+  clueIndex,
+  control,
+  errors,
+}: {
+  clueIndex: number
+  control: ReturnType<typeof useForm<CluesFormData>>["control"]
+  errors: ReturnType<typeof useForm<CluesFormData>>["formState"]["errors"]
+}) {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `clues.${clueIndex}.hints`,
+  })
+
+  const canAddHint = fields.length < MAX_HINTS
+
+  return (
+    <div className="flex flex-col gap-2 pl-6">
+      {fields.map((hintField, hIdx) => {
+        const hintErrors = errors.clues?.[clueIndex]?.hints?.[hIdx]
+        return (
+          <div
+            key={hintField.id}
+            className="flex flex-col gap-1 p-2 rounded-lg border border-blue-100 dark:border-blue-900/30 bg-blue-50/50 dark:bg-blue-900/10"
+          >
+            <div className="flex items-center gap-1 mb-0.5">
+              <span className="text-xs font-semibold text-blue-700 dark:text-blue-400 shrink-0">
+                Hint {hIdx + 1}
+              </span>
+              <span className="text-xs text-slate-400 dark:text-slate-500 flex-1">
+                {hIdx === 0 ? "— revealed first" : hIdx === 1 ? "— revealed second" : "— revealed last"}
+              </span>
+              <button
+                type="button"
+                onClick={() => remove(hIdx)}
+                className="text-red-400 hover:text-red-600 p-0.5 rounded"
+                aria-label={`Remove hint ${hIdx + 1} from clue ${clueIndex + 1}`}
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+
+            {/* Hint text */}
+            <Controller
+              control={control}
+              name={`clues.${clueIndex}.hints.${hIdx}.text`}
+              render={({ field: f }) => (
+                <Input
+                  placeholder={`Hint ${hIdx + 1} text…`}
+                  aria-label={`Clue ${clueIndex + 1} hint ${hIdx + 1} text`}
+                  {...f}
+                  className="pl-3 py-1.5 text-xs"
+                />
+              )}
+            />
+            {hintErrors?.text && (
+              <span role="alert" className="text-red-500 text-xs">
+                {hintErrors.text.message}
+              </span>
+            )}
+
+            {/* Penalty + delay on one row */}
+            <div className="flex gap-2">
+              <div className="flex-1 flex flex-col">
+                <Controller
+                  control={control}
+                  name={`clues.${clueIndex}.hints.${hIdx}.penalty`}
+                  render={({ field: f }) => (
+                    <Input
+                      type="number"
+                      placeholder="Penalty pts"
+                      aria-label={`Clue ${clueIndex + 1} hint ${hIdx + 1} score penalty`}
+                      min={0}
+                      value={f.value}
+                      onChange={(e) => f.onChange(parseInt(e.target.value, 10) || 0)}
+                      onBlur={f.onBlur}
+                      name={f.name}
+                      ref={f.ref}
+                      className="pl-3 py-1.5 text-xs"
+                    />
+                  )}
+                />
+                <span className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5">pts deducted</span>
+              </div>
+              <div className="flex-1 flex flex-col">
+                <Controller
+                  control={control}
+                  name={`clues.${clueIndex}.hints.${hIdx}.delaySeconds`}
+                  render={({ field: f }) => (
+                    <Input
+                      type="number"
+                      placeholder="Delay (s)"
+                      aria-label={`Clue ${clueIndex + 1} hint ${hIdx + 1} reveal delay in seconds`}
+                      min={0}
+                      value={f.value}
+                      onChange={(e) => f.onChange(parseInt(e.target.value, 10) || 0)}
+                      onBlur={f.onBlur}
+                      name={f.name}
+                      ref={f.ref}
+                      className="pl-3 py-1.5 text-xs"
+                    />
+                  )}
+                />
+                <span className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5">
+                  {hIdx === 0 ? "wait before hint 1" : `wait after hint ${hIdx}`}
+                </span>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+
+      {canAddHint && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => append({ text: "", penalty: 0, delaySeconds: 30 })}
+          className="self-start text-xs text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-900/50 hover:bg-blue-50 dark:hover:bg-blue-900/20 gap-1"
+          aria-label={`Add hint to clue ${clueIndex + 1}`}
+        >
+          <Plus className="w-3 h-3" />
+          Add Hint {fields.length > 0 ? `(${fields.length}/${MAX_HINTS})` : ""}
+        </Button>
+      )}
+
+      {fields.length === MAX_HINTS && (
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          Maximum of {MAX_HINTS} hints reached.
+        </p>
+      )}
+    </div>
+  )
+}
+
 export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onImageUploadStateChange }: HuntFormProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [isUploading, setIsUploading] = useState(false)
@@ -49,6 +201,8 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
   const [showPreview, setShowPreview] = useState(false)
   const [linkEnabled, setLinkEnabled] = useState(false)
   const [imageUploadState, setImageUploadState] = useState<CoverImageUploadState>("idle")
+  // Track which clue rows have their hints section expanded
+  const [expandedHints, setExpandedHints] = useState<Record<number, boolean>>({})
 
   const {
     control,
@@ -58,7 +212,7 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
   } = useForm<CluesFormData>({
     resolver: zodResolver(cluesFormSchema),
     defaultValues: {
-      clues: [{ question: "", answer: "", points: 10, hint: "", hintCost: 0 }],
+      clues: [{ ...DEFAULT_CLUE }],
     },
   })
 
@@ -66,6 +220,10 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
     control,
     name: "clues",
   })
+
+  const toggleHints = (index: number) => {
+    setExpandedHints((prev) => ({ ...prev, [index]: !prev[index] }))
+  }
 
   const updateImageUploadState = (state: CoverImageUploadState) => {
     setImageUploadState(state)
@@ -98,7 +256,6 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
   const handleClearImage = () => {
     onUpdate("image", "")
     updateImageUploadState("idle")
-
     if (fileInputRef.current) {
       fileInputRef.current.value = ""
     }
@@ -109,7 +266,7 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
   }
 
   const addClueRow = () => {
-    append({ question: "", answer: "", points: 10, hint: "", hintCost: 0 })
+    append({ ...DEFAULT_CLUE })
   }
 
   const removeClueRow = (index: number) => {
@@ -127,14 +284,24 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
     try {
       for (const row of valid) {
         const normalizedAnswer = row.answer.trim().toLowerCase()
+
+        // Build the ClueHint array (only include hints with text)
+        const hints: ClueHint[] = (row.hints ?? [])
+          .filter((h) => h.text.trim().length > 0)
+          .slice(0, MAX_HINTS)
+          .map((h) => ({
+            text: h.text.trim(),
+            penalty: h.penalty,
+            delaySeconds: h.delaySeconds,
+          }))
+
         // Persist locally first to obtain a stable clue id for salting
         const newId = saveClueLocally({
           huntId,
           question: row.question.trim(),
           answer: normalizedAnswer,
           points: row.points,
-          hint: row.hint?.trim() || undefined,
-          hintCost: row.hintCost,
+          hints: hints.length > 0 ? hints : undefined,
           difficulty: row.difficulty,
         })
 
@@ -144,8 +311,14 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
         await withTransactionToast(
           async (setStage) => {
             setStage("approving")
-            // Submit the hashed answer to the contract (expected scheme: sha256(answer + salt))
-            return addClue(huntId, row.question.trim(), hashed, row.points, row.hint?.trim() || undefined, row.hintCost, row.difficulty)
+            return addClue(
+              huntId,
+              row.question.trim(),
+              hashed,
+              row.points,
+              hints,
+              row.difficulty,
+            )
           },
           {
             pending:   "Pending — preparing clue…",
@@ -158,12 +331,12 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
         try {
           updateClueAnswer(huntId, newId, hashed)
         } catch (e) {
-          // non-fatal
           logger.warn("Failed to update local clue answer with hash", e)
         }
       }
       onCluesSaved?.(valid.length)
-      reset({ clues: [{ question: "", answer: "", points: 10, hint: "", hintCost: 0 }] })
+      reset({ clues: [{ ...DEFAULT_CLUE }] })
+      setExpandedHints({})
     } finally {
       setIsSavingClues(false)
     }
@@ -233,135 +406,137 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
             onChange={(e: ChangeEvent<HTMLInputElement>) => onUpdate("description", e.target.value)}
             className="w-full pl-6 py-3"
           />
-        <div className="relative">
-          <Button
-            type="button"
-            size="icon"
-            onClick={triggerFileInput}
-            disabled={isUploading}
-            aria-label="Upload hunt cover image"
-            className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] hover:bg-slate-700 rounded-[12px] text-white cursor-pointer disabled:opacity-50"
-          >
-            {isUploading ? (
-              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-            ) : (
-              <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M18.02 3H16V0.98C16 0.44 15.56 0 15.02 0H14.99C14.44 0 14 0.44 14 0.98V3H11.99C11.45 3 11.01 3.44 11 3.98V4.01C11 4.56 11.44 5 11.99 5H14V7.01C14 7.55 14.44 8 14.99 7.99H15.02C15.56 7.99 16 7.55 16 7.01V5H18.02C18.56 5 19 4.56 19 4.02V3.98C19 3.44 18.56 3 18.02 3ZM13 7.01V6H11.99C11.46 6 10.96 5.79 10.58 5.42C10.21 5.04 10 4.54 10 3.98C10 3.62 10.1 3.29 10.27 3H2C0.9 3 0 3.9 0 5V17C0 18.1 0.9 19 2 19H14C15.1 19 16 18.1 16 17V8.72C15.7 8.89 15.36 9 14.98 9C13.89 8.99 13 8.1 13 7.01ZM12.96 17H3C2.59 17 2.35 16.53 2.6 16.2L4.58 13.57C4.79 13.29 5.2 13.31 5.4 13.59L7 16L9.61 12.52C9.81 12.26 10.2 12.25 10.4 12.51L13.35 16.19C13.61 16.52 13.38 17 12.96 17Z" fill="#FAFAFA"/>
-              </svg>
-            )}
-          </Button>
-          <input
-            type="file"
-            ref={fileInputRef}
-            onChange={handleImageUpload}
-            accept="image/*"
-            aria-label="Upload cover image"
-            className="hidden"
-          />
-          {hunt.image && (
-            <div className="absolute -right-2 -top-2 w-5 h-5 bg-green-500 rounded-full flex items-center justify-center">
-              <div className="w-3 h-3 bg-white rounded-full" />
-            </div>
-          )}
-        </div>
-      </div>
-      {(hunt.image || imageUploadState === "failed") && (
-        <div className="flex items-center justify-between gap-3 text-sm">
-          <span className={imageUploadState === "failed" ? "text-red-500" : "text-slate-500 dark:text-slate-400"}>
-            {imageUploadState === "failed" ? "Cover image upload failed." : "Cover image attached."}
-          </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleClearImage}
-            className="h-auto px-0 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
-          >
-            {hunt.image ? "Remove cover image" : "Skip cover image"}
-          </Button>
-        </div>
-      )}
-
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <span className="text-xl font-semibold dark:text-slate-200">Add Link</span>
-          <div className="flex gap-2">
-            <ToggleSwitch
-              isActive={linkEnabled}
-              onClick={() => setLinkEnabled(!linkEnabled)}
+          <div className="relative">
+            <Button
+              type="button"
+              size="icon"
+              onClick={triggerFileInput}
+              disabled={isUploading}
+              aria-label="Upload hunt cover image"
+              className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] hover:bg-slate-700 rounded-[12px] text-white cursor-pointer disabled:opacity-50"
+            >
+              {isUploading ? (
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M18.02 3H16V0.98C16 0.44 15.56 0 15.02 0H14.99C14.44 0 14 0.44 14 0.98V3H11.99C11.45 3 11.01 3.44 11 3.98V4.01C11 4.56 11.44 5 11.99 5H14V7.01C14 7.55 14.44 8 14.99 7.99H15.02C15.56 7.99 16 7.55 16 7.01V5H18.02C18.56 5 19 4.56 19 4.02V3.98C19 3.44 18.56 3 18.02 3ZM13 7.01V6H11.99C11.46 6 10.96 5.79 10.58 5.42C10.21 5.04 10 4.54 10 3.98C10 3.62 10.1 3.29 10.27 3H2C0.9 3 0 3.9 0 5V17C0 18.1 0.9 19 2 19H14C15.1 19 16 18.1 16 17V8.72C15.7 8.89 15.36 9 14.98 9C13.89 8.99 13 8.1 13 7.01ZM12.96 17H3C2.59 17 2.35 16.53 2.6 16.2L4.58 13.57C4.79 13.29 5.2 13.31 5.4 13.59L7 16L9.61 12.52C9.81 12.26 10.2 12.25 10.4 12.51L13.35 16.19C13.61 16.52 13.38 17 12.96 17Z" fill="#FAFAFA"/>
+                </svg>
+              )}
+            </Button>
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handleImageUpload}
+              accept="image/*"
+              aria-label="Upload cover image"
+              className="hidden"
             />
+            {hunt.image && (
+              <div className="absolute -right-2 -top-2 w-5 h-5 bg-green-500 rounded-full flex items-center justify-center">
+                <div className="w-3 h-3 bg-white rounded-full" />
+              </div>
+            )}
           </div>
         </div>
-        <Input
-          placeholder="Enter Code to Unlock next challenge"
-          aria-label="Unlock Code"
-          value={hunt.code}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => onUpdate("code", e.target.value)}
-          className="w-full pl-6 py-3"
-        />
-      </div>
+        {(hunt.image || imageUploadState === "failed") && (
+          <div className="flex items-center justify-between gap-3 text-sm">
+            <span className={imageUploadState === "failed" ? "text-red-500" : "text-slate-500 dark:text-slate-400"}>
+              {imageUploadState === "failed" ? "Cover image upload failed." : "Cover image attached."}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleClearImage}
+              className="h-auto px-0 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+            >
+              {hunt.image ? "Remove cover image" : "Skip cover image"}
+            </Button>
+          </div>
+        )}
 
-      {/* Clues section */}
-      <div className="space-y-3 pt-4 border-t border-slate-200 dark:border-white/10">
-        <div className="flex items-center justify-between">
-          <span className="text-xl font-semibold bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-transparent bg-clip-text">
-            Clues
-          </span>
-          <Button
-            type="button"
-            onClick={addClueRow}
-            size="sm"
-            className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white flex items-center gap-1 rounded-xl"
-          >
-            <Plus className="w-4 h-4" />
-            Add Clue
-          </Button>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-xl font-semibold dark:text-slate-200">Add Link</span>
+            <div className="flex gap-2">
+              <ToggleSwitch
+                isActive={linkEnabled}
+                onClick={() => setLinkEnabled(!linkEnabled)}
+              />
+            </div>
+          </div>
+          <Input
+            placeholder="Enter Code to Unlock next challenge"
+            aria-label="Unlock Code"
+            value={hunt.code}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onUpdate("code", e.target.value)}
+            className="w-full pl-6 py-3"
+          />
         </div>
 
-        <div className="space-y-2">
-          {fields.map((field, index) => (
-            <div key={field.id} className="flex flex-col gap-2 p-2 border border-slate-100 dark:border-white/5 rounded-lg bg-white/50 dark:bg-slate-900/50">
-              <div className="flex gap-2 items-center">
-                <span className="text-xs text-slate-400 dark:text-slate-500 w-4 shrink-0">{index + 1}.</span>
-                <div className="flex-1 flex flex-col">
-                  <Controller
-                    control={control}
-                    name={`clues.${index}.question`}
-                    render={({ field: f }) => (
-                      <Input
-                        placeholder="Riddle / Question"
-                        aria-label={`Clue ${index + 1} Question`}
-                        aria-describedby={errors.clues?.[index]?.question ? `clue-${index}-question-error` : undefined}
-                        {...f}
-                        className="pl-3 py-2 text-sm"
-                      />
-                    )}
-                  />
-                  {errors.clues?.[index]?.question && (
-                    <span
-                      role="alert"
-                      aria-live="assertive"
-                      id={`clue-${index}-question-error`}
-                      className="text-red-500 text-xs mt-0.5"
-                    >
-                      {errors.clues[index].question.message}
-                    </span>
-                  )}
-                </div>
-                <div className="w-32 flex flex-col">
+        {/* Clues section */}
+        <div className="space-y-3 pt-4 border-t border-slate-200 dark:border-white/10">
+          <div className="flex items-center justify-between">
+            <span className="text-xl font-semibold bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-transparent bg-clip-text">
+              Clues
+            </span>
+            <Button
+              type="button"
+              onClick={addClueRow}
+              size="sm"
+              className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white flex items-center gap-1 rounded-xl"
+            >
+              <Plus className="w-4 h-4" />
+              Add Clue
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            {fields.map((field, index) => (
+              <div key={field.id} className="flex flex-col gap-2 p-2 border border-slate-100 dark:border-white/5 rounded-lg bg-white/50 dark:bg-slate-900/50">
+
+                {/* ── Row 1: question / answer / points / delete ── */}
+                <div className="flex gap-2 items-center">
+                  <span className="text-xs text-slate-400 dark:text-slate-500 w-4 shrink-0">{index + 1}.</span>
+                  <div className="flex-1 flex flex-col">
                     <Controller
-                    control={control}
-                    name={`clues.${index}.answer`}
-                    render={({ field: f }) => (
-                      <Input
-                        placeholder="Answer (use | for multiple)"
+                      control={control}
+                      name={`clues.${index}.question`}
+                      render={({ field: f }) => (
+                        <Input
+                          placeholder="Riddle / Question"
+                          aria-label={`Clue ${index + 1} Question`}
+                          aria-describedby={errors.clues?.[index]?.question ? `clue-${index}-question-error` : undefined}
+                          {...f}
+                          className="pl-3 py-2 text-sm"
+                        />
+                      )}
+                    />
+                    {errors.clues?.[index]?.question && (
+                      <span
+                        role="alert"
+                        aria-live="assertive"
+                        id={`clue-${index}-question-error`}
+                        className="text-red-500 text-xs mt-0.5"
+                      >
+                        {errors.clues[index].question.message}
+                      </span>
+                    )}
+                  </div>
+                  <div className="w-32 flex flex-col">
+                    <Controller
+                      control={control}
+                      name={`clues.${index}.answer`}
+                      render={({ field: f }) => (
+                        <Input
+                          placeholder="Answer (use | for multiple)"
                           aria-label={`Clue ${index + 1} Answer`}
                           aria-describedby={errors.clues?.[index]?.answer ? `clue-${index}-answer-error` : undefined}
                           {...f}
-                        className="pl-3 py-2 text-sm"
-                      />
-                    )}
-                  />
+                          className="pl-3 py-2 text-sm"
+                        />
+                      )}
+                    />
                     {errors.clues?.[index]?.answer && (
                       <span
                         role="alert"
@@ -372,102 +547,109 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
                         {errors.clues[index].answer.message}
                       </span>
                     )}
+                  </div>
+                  <div className="w-16 flex flex-col">
+                    <Controller
+                      control={control}
+                      name={`clues.${index}.points`}
+                      render={({ field: f }) => (
+                        <Input
+                          type="number"
+                          placeholder="Pts"
+                          aria-label={`Clue ${index + 1} Points`}
+                          min={1}
+                          value={f.value}
+                          onChange={(e) => f.onChange(parseInt(e.target.value, 10) || 0)}
+                          onBlur={f.onBlur}
+                          name={f.name}
+                          ref={f.ref}
+                          className="pl-3 py-2 text-sm"
+                        />
+                      )}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => removeClueRow(index)}
+                    disabled={fields.length === 1}
+                    className="text-red-400 hover:text-red-600 shrink-0 disabled:opacity-30"
+                    aria-label={`Remove clue ${index + 1}`}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
                 </div>
-                <div className="w-16 flex flex-col">
+
+                {/* ── Row 2: difficulty + hints toggle ── */}
+                <div className="flex gap-2 items-center pl-6">
                   <Controller
                     control={control}
-                    name={`clues.${index}.points`}
+                    name={`clues.${index}.difficulty`}
                     render={({ field: f }) => (
-                      <Input
-                        type="number"
-                        placeholder="Pts"
-                        aria-label={`Clue ${index + 1} Points`}
-                        min={1}
-                        value={f.value}
-                        onChange={(e) => f.onChange(parseInt(e.target.value, 10) || 0)}
-                        onBlur={f.onBlur}
-                        name={f.name}
-                        ref={f.ref}
-                        className="pl-3 py-2 text-sm"
-                      />
+                      <select
+                        aria-label={`Clue ${index + 1} Difficulty`}
+                        value={f.value ?? ""}
+                        onChange={(e) => f.onChange(e.target.value || undefined)}
+                        className="w-28 pl-3 py-2 text-sm rounded-md border border-input bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value="">Difficulty</option>
+                        <option value="Easy">Easy</option>
+                        <option value="Medium">Medium</option>
+                        <option value="Hard">Hard</option>
+                      </select>
                     )}
                   />
-                </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => removeClueRow(index)}
-                  disabled={fields.length === 1}
-                  className="text-red-400 hover:text-red-600 shrink-0 disabled:opacity-30"
-                >
-                  <Trash2 className="w-4 h-4" />
-                </Button>
-              </div>
-              <div className="flex gap-2 items-center pl-6">
-                <Controller
-                  control={control}
-                  name={`clues.${index}.hint`}
-                  render={({ field: f }) => (
-                    <Input
-                      placeholder="Optional Hint Text"
-                      {...f}
-                      className="flex-1 pl-3 py-2 text-sm"
-                    />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name={`clues.${index}.hintCost`}
-                  render={({ field: f }) => (
-                    <Input
-                      type="number"
-                      placeholder="Hint Cost"
-                      min={0}
-                      value={f.value}
-                      onChange={(e) => f.onChange(parseInt(e.target.value, 10) || 0)}
-                      onBlur={f.onBlur}
-                      name={f.name}
-                      ref={f.ref}
-                      className="w-24 pl-3 py-2 text-sm"
-                    />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name={`clues.${index}.difficulty`}
-                  render={({ field: f }) => (
-                    <select
-                      aria-label={`Clue ${index + 1} Difficulty`}
-                      value={f.value ?? ""}
-                      onChange={(e) => f.onChange(e.target.value || undefined)}
-                      className="w-28 pl-3 py-2 text-sm rounded-md border border-input bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                    >
-                      <option value="">Difficulty</option>
-                      <option value="Easy">Easy</option>
-                      <option value="Medium">Medium</option>
-                      <option value="Hard">Hard</option>
-                    </select>
-                  )}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
 
-        {huntId && (
-          <div className="flex justify-end pt-1">
-            <Button
-              type="button"
-              onClick={handleSubmit(onSaveClues)}
-              disabled={isSavingClues}
-              className="bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 text-white px-5 py-2 rounded-xl disabled:opacity-50"
-            >
-              {isSavingClues ? "Saving..." : "Save Clues"}
-            </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => toggleHints(index)}
+                    className="ml-auto text-xs text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-900/50 hover:bg-blue-50 dark:hover:bg-blue-900/20 gap-1"
+                    aria-expanded={!!expandedHints[index]}
+                    aria-controls={`hints-panel-${index}`}
+                  >
+                    {expandedHints[index] ? (
+                      <ChevronUp className="w-3 h-3" />
+                    ) : (
+                      <ChevronDown className="w-3 h-3" />
+                    )}
+                    Hints
+                  </Button>
+                </div>
+
+                {/* ── Hints panel (collapsible) ── */}
+                {expandedHints[index] && (
+                  <div id={`hints-panel-${index}`} className="pt-1">
+                    <p className="pl-6 text-xs text-slate-500 dark:text-slate-400 mb-2">
+                      Add up to {MAX_HINTS} progressive hints. Players must wait the specified delay before
+                      revealing the next hint, and each hint deducts points from their score.
+                    </p>
+                    <ClueHintsEditor
+                      clueIndex={index}
+                      control={control}
+                      errors={errors}
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
-        )}
-      </div>
+
+          {huntId && (
+            <div className="flex justify-end pt-1">
+              <Button
+                type="button"
+                onClick={handleSubmit(onSaveClues)}
+                disabled={isSavingClues}
+                className="bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 text-white px-5 py-2 rounded-xl disabled:opacity-50"
+              >
+                {isSavingClues ? "Saving..." : "Save Clues"}
+              </Button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -92,3 +92,119 @@ export async function getAllHuntViewCounts(): Promise<HuntViewStats[]> {
     views: entry.views,
   }))
 }
+
+// ─── Hint Usage Analytics ─────────────────────────────────────────────────────
+
+export type HintUsageEvent = {
+  huntId: number
+  clueId: number
+  hintIndex: number  // 0-based index of the hint revealed
+  wallet: string
+  timestamp: string
+}
+
+export type HintUsageStats = {
+  huntId: number
+  clueId: number
+  hintIndex: number
+  totalReveals: number
+}
+
+const HINT_ANALYTICS_STORE_PATH = path.join(process.cwd(), "data", "hint-usage.json")
+
+async function ensureHintStoreFile(): Promise<void> {
+  const dir = path.dirname(HINT_ANALYTICS_STORE_PATH)
+  await fs.mkdir(dir, { recursive: true })
+  try {
+    await fs.access(HINT_ANALYTICS_STORE_PATH)
+  } catch {
+    await fs.writeFile(HINT_ANALYTICS_STORE_PATH, JSON.stringify([], null, 2), "utf8")
+  }
+}
+
+async function readHintStore(): Promise<HintUsageEvent[]> {
+  await ensureHintStoreFile()
+  const raw = await fs.readFile(HINT_ANALYTICS_STORE_PATH, "utf8")
+  try {
+    const data = JSON.parse(raw)
+    return Array.isArray(data) ? data : []
+  } catch {
+    return []
+  }
+}
+
+async function writeHintStore(events: HintUsageEvent[]): Promise<void> {
+  await ensureHintStoreFile()
+  await fs.writeFile(HINT_ANALYTICS_STORE_PATH, JSON.stringify(events, null, 2), "utf8")
+}
+
+/**
+ * Record a single hint reveal event.
+ * The wallet address is hashed before storage so raw addresses are never persisted.
+ */
+export async function recordHintUsage(
+  huntId: number,
+  clueId: number,
+  hintIndex: number,
+  wallet: string,
+): Promise<void> {
+  const events = await readHintStore()
+  const secret = process.env.HUNT_VIEW_ANALYTICS_SECRET || "hunty-analytics-secret"
+  const walletHash = crypto.createHmac("sha256", secret).update(wallet).digest("hex")
+
+  events.push({
+    huntId,
+    clueId,
+    hintIndex,
+    wallet: walletHash,
+    timestamp: new Date().toISOString(),
+  })
+
+  await writeHintStore(events)
+
+  // Optional: forward to external analytics endpoint
+  if (process.env.HUNT_VIEW_ANALYTICS_ENDPOINT) {
+    const payload = {
+      event: "hint_used",
+      huntIdHash: hashHuntId(huntId),
+      clueId,
+      hintIndex,
+      timestamp: new Date().toISOString(),
+    }
+    try {
+      await fetch(process.env.HUNT_VIEW_ANALYTICS_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(process.env.HUNT_VIEW_ANALYTICS_KEY
+            ? { Authorization: `Bearer ${process.env.HUNT_VIEW_ANALYTICS_KEY}` }
+            : {}),
+        },
+        body: JSON.stringify(payload),
+      })
+    } catch (error) {
+      logger.warn("Failed to forward hint usage analytics", error)
+    }
+  }
+}
+
+/**
+ * Return aggregated hint usage counts grouped by hunt + clue + hintIndex.
+ */
+export async function getHintUsageStats(huntId: number): Promise<HintUsageStats[]> {
+  const events = await readHintStore()
+  const filtered = events.filter((e) => e.huntId === huntId)
+
+  const map = new Map<string, HintUsageStats>()
+  for (const e of filtered) {
+    const key = `${e.huntId}:${e.clueId}:${e.hintIndex}`
+    const existing = map.get(key)
+    if (existing) {
+      existing.totalReveals += 1
+    } else {
+      map.set(key, { huntId: e.huntId, clueId: e.clueId, hintIndex: e.hintIndex, totalReveals: 1 })
+    }
+  }
+
+  return Array.from(map.values())
+}

--- a/lib/contracts/hunt.ts
+++ b/lib/contracts/hunt.ts
@@ -164,8 +164,7 @@ export async function addClue(
   question: string,
   answer: string,
   points: number,
-  hint?: string,
-  hintCost?: number,
+  hints?: import("@/lib/types").ClueHint[],
   difficulty?: import("@/lib/types").ClueDifficulty,
 ): Promise<AddClueResult> {
   if (typeof window === "undefined")
@@ -175,10 +174,6 @@ export async function addClue(
   const wallet = getActiveWalletAdapter();
   const publicKey = await wallet.getPublicKey();
 
-  // Expect `answer` to be the pre-hashed value (SHA-256 hex) computed
-  // client-side using the scheme: sha256(lowercase(answer) + `${huntId}_${clueId}`)
-  // For backwards compatibility, if a plain-text answer is provided it will be
-  // stored as-is (legacy behaviour).
   const normalizedAnswer = answer;
 
   const account = (await withSorobanRpcRetry(() =>
@@ -190,8 +185,7 @@ export async function addClue(
     question,
     answer: normalizedAnswer,
     points,
-    ...(hint ? { hint } : {}),
-    ...(hintCost ? { hint_cost: hintCost } : {}),
+    ...(hints && hints.length > 0 ? { hints } : {}),
     ...(difficulty ? { difficulty } : {}),
   });
   const key = `add_clue:${Date.now()}`;
@@ -460,6 +454,7 @@ export async function get_clue_info(
       id: clue.id,
       question: clue.question,
       points: clue.points,
+      hints: clue.hints,
       hint: clue.hint,
       hintCost: clue.hintCost,
       difficulty: clue.difficulty,

--- a/lib/huntAttemptHistory.ts
+++ b/lib/huntAttemptHistory.ts
@@ -149,7 +149,13 @@ export function recordClueAttempt(
   clueRecord: ClueAttemptRecord,
   basePoints: number,
   difficulty: ClueDifficulty,
-  hintsUsed: number = 0
+  hintsUsed: number = 0,
+  /**
+   * Exact penalty in points accrued from revealed progressive hints.
+   * When provided, this is used instead of the weight-based hint penalty
+   * calculation so that per-hint `penalty` values are honoured precisely.
+   */
+  exactHintPenalty?: number,
 ): HuntAttemptRecord | null {
   return updateAttempt(playerAddress, attemptId, (attempt) => {
     // Calculate scoring for this clue
@@ -159,7 +165,8 @@ export function recordClueAttempt(
       clueRecord.timeTakenSeconds,
       hintsUsed,
       attempt.currentStreak,
-      attempt.scoringWeights
+      attempt.scoringWeights,
+      exactHintPenalty,
     )
 
     // Create the updated clue record with scoring details

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -66,7 +66,8 @@ export function calculateTimeBonus(
 }
 
 /**
- * Calculate the hint penalty for a clue
+ * Calculate the hint penalty for a clue using the legacy weight-based approach.
+ * Used when per-hint `penalty` values are not available (backwards compatibility).
  * @param basePoints Base points for the clue
  * @param hintsUsed Number of hints used
  * @param weight Hint penalty weight from config
@@ -77,6 +78,17 @@ export function calculateHintPenalty(
   weight: number = DEFAULT_SCORING_WEIGHTS.hintPenalty
 ): number {
   return Math.round(basePoints * weight * hintsUsed)
+}
+
+/**
+ * Calculate the exact hint penalty from a progressive hints array.
+ * Each hint carries its own absolute `penalty` in points, so we simply sum them.
+ * This supersedes the weight-based `calculateHintPenalty` when hints data is present.
+ *
+ * @param revealedHintPenalties Array of `penalty` values for every hint the player revealed.
+ */
+export function calculateProgressiveHintPenalty(revealedHintPenalties: number[]): number {
+  return revealedHintPenalties.reduce((sum, p) => sum + p, 0)
 }
 
 /**
@@ -104,7 +116,11 @@ export function calculateDifficultyMultiplier(
 }
 
 /**
- * Calculate the total points for a single clue
+ * Calculate the total points for a single clue.
+ *
+ * @param exactHintPenalty When provided (progressive hints mode), this value is
+ *   used directly as the hint penalty instead of computing it from `hintsUsed`
+ *   and the weight multiplier. Pass the sum of all revealed hint `penalty` fields.
  */
 export function calculateCluePoints(
   basePoints: number,
@@ -112,11 +128,15 @@ export function calculateCluePoints(
   timeTakenSeconds: number,
   hintsUsed: number,
   currentStreak: number,
-  weights: ScoringWeights = DEFAULT_SCORING_WEIGHTS
+  weights: ScoringWeights = DEFAULT_SCORING_WEIGHTS,
+  exactHintPenalty?: number,
 ): { breakdown: ClueScoringBreakdown; newStreak: number } {
   const difficultyMultiplier = calculateDifficultyMultiplier(difficulty, weights.difficultyMultiplier)
   const timeBonus = calculateTimeBonus(basePoints, timeTakenSeconds, 60, weights.timeBonus)
-  const hintPenalty = calculateHintPenalty(basePoints, hintsUsed, weights.hintPenalty)
+  // Prefer exact per-hint penalty sum when available; fall back to weight-based calc.
+  const hintPenalty = exactHintPenalty !== undefined
+    ? exactHintPenalty
+    : calculateHintPenalty(basePoints, hintsUsed, weights.hintPenalty)
   const streakBonus = calculateStreakBonus(currentStreak, weights.streakBonus)
 
   const totalPoints = Math.max(0, Math.round(

--- a/lib/server/seedClues.ts
+++ b/lib/server/seedClues.ts
@@ -1,13 +1,47 @@
 import type { Clue } from "@/lib/types"
 
 export const SEED_CLUES: Clue[] = [
-  { id: 1, huntId: 1, question: "What landmark is at the town center?", answer: "fountain", points: 10 },
-  { id: 2, huntId: 1, question: "Find the historic clock tower", answer: "clock tower", points: 15 },
+  {
+    id: 1, huntId: 1,
+    question: "What landmark is at the town center?",
+    answer: "fountain", points: 10,
+    hints: [
+      { text: "It's a water feature.", penalty: 2, delaySeconds: 0 },
+      { text: "People toss coins into it.", penalty: 3, delaySeconds: 30 },
+      { text: "It is made of stone and sprays water upward.", penalty: 5, delaySeconds: 60 },
+    ],
+  },
+  {
+    id: 2, huntId: 1,
+    question: "Find the historic clock tower",
+    answer: "clock tower", points: 15,
+    hints: [
+      { text: "It's a tall structure you can hear on the hour.", penalty: 3, delaySeconds: 0 },
+      { text: "Look north of the main square.", penalty: 4, delaySeconds: 45 },
+    ],
+  },
   { id: 3, huntId: 1, question: "What color is the old town hall door?", answer: "green", points: 10 },
-  { id: 4, huntId: 1, question: "Locate the hidden mural on Main Street", answer: "phoenix", points: 20 },
+  {
+    id: 4, huntId: 1,
+    question: "Locate the hidden mural on Main Street",
+    answer: "phoenix", points: 20,
+    hints: [
+      { text: "The mural depicts a mythical bird.", penalty: 4, delaySeconds: 0 },
+      { text: "It is painted on the east-facing wall of a café.", penalty: 6, delaySeconds: 60 },
+    ],
+  },
   { id: 5, huntId: 1, question: "Count the arches on the bridge", answer: "3", points: 15 },
   { id: 6, huntId: 2, question: "What is the library's mascot?", answer: "owl", points: 10 },
-  { id: 7, huntId: 2, question: "Find the oldest tree on campus", answer: "oak", points: 15 },
+  {
+    id: 7, huntId: 2,
+    question: "Find the oldest tree on campus",
+    answer: "oak", points: 15,
+    hints: [
+      { text: "It is a deciduous hardwood.", penalty: 3, delaySeconds: 0 },
+      { text: "You'll find it near the science building.", penalty: 4, delaySeconds: 30 },
+      { text: "Its trunk is over 1 metre in diameter.", penalty: 5, delaySeconds: 60 },
+    ],
+  },
   { id: 8, huntId: 2, question: "What year was the science hall built?", answer: "1965", points: 20 },
   { id: 9, huntId: 2, question: "Decode the message at the student center", answer: "carpe diem", points: 25 },
   { id: 10, huntId: 2, question: "Name the statue near the fountain", answer: "pioneer", points: 15 },
@@ -16,7 +50,14 @@ export const SEED_CLUES: Clue[] = [
   { id: 13, huntId: 3, question: "The desk where I work hides a clue", answer: "monitor", points: 10 },
   { id: 14, huntId: 3, question: "Look for the sticky note on the whiteboard", answer: "synergy", points: 15 },
   { id: 15, huntId: 3, question: "What is the coffee blend in the break room?", answer: "colombian", points: 10 },
-  { id: 16, huntId: 3, question: "Find the secret message in the server room", answer: "42", points: 20 },
+  {
+    id: 16, huntId: 3,
+    question: "Find the secret message in the server room",
+    answer: "42", points: 20,
+    hints: [
+      { text: "The answer is also the answer to life, the universe, and everything.", penalty: 5, delaySeconds: 0 },
+    ],
+  },
   { id: 17, huntId: 4, question: "Treasure is buried beneath the old pine", answer: "pine", points: 15 },
   { id: 18, huntId: 4, question: "Follow the stone path to the answer", answer: "gazebo", points: 20 },
   { id: 19, huntId: 4, question: "What is carved into the park bench?", answer: "wanderlust", points: 10 },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,13 +61,35 @@ export type HuntInfo = {
 
 export type ClueDifficulty = "Easy" | "Medium" | "Hard"
 
+/**
+ * A single progressive hint entry. Creators can define up to 3 hints per clue.
+ * Each hint is revealed in order and may carry an optional score penalty and
+ * a minimum delay (in seconds) that must elapse after the previous hint before
+ * this one can be revealed.
+ */
+export interface ClueHint {
+  /** The hint text shown to the player. */
+  text: string
+  /** Points deducted from the clue score when this hint is revealed. */
+  penalty: number
+  /** Seconds the player must wait after the previous hint before revealing this one. */
+  delaySeconds: number
+}
+
 export interface Clue {
   id: number
   huntId: number
   question: string
   answer: string
   points: number
+  /**
+   * Progressive hints array (up to 3). Takes precedence over the legacy
+   * `hint` / `hintCost` fields when present.
+   */
+  hints?: ClueHint[]
+  /** @deprecated Use `hints[0]` instead. Kept for backwards compatibility. */
   hint?: string
+  /** @deprecated Use `hints[0].penalty` instead. Kept for backwards compatibility. */
   hintCost?: number
   /** Optional difficulty tag set by the creator. */
   difficulty?: ClueDifficulty
@@ -83,7 +105,11 @@ export type ClueInfo = {
   id: number
   question: string
   points: number
+  /** Progressive hints (up to 3). Supersedes the legacy `hint`/`hintCost` fields. */
+  hints?: ClueHint[]
+  /** @deprecated Use `hints[0]` instead. */
   hint?: string
+  /** @deprecated Use `hints[0].penalty` instead. */
   hintCost?: number
   difficulty?: ClueDifficulty
 }
@@ -93,7 +119,10 @@ export interface ClueRow {
   question: string
   answer: string
   points: number
+  hints?: ClueHint[]
+  /** @deprecated */
   hint?: string
+  /** @deprecated */
   hintCost?: number
   difficulty?: ClueDifficulty
 }
@@ -314,7 +343,11 @@ export interface HuntCard {
   link?: string
   code?: string
   image?: string
+  /** Progressive hints (up to 3). Supersedes `hint`/`hintCost` when present. */
+  hints?: ClueHint[]
+  /** @deprecated Use `hints[0]` instead. */
   hint?: string
+  /** @deprecated Use `hints[0].penalty` instead. */
   hintCost?: number
   points?: number
   difficulty?: ClueDifficulty


### PR DESCRIPTION
- Add ClueHint interface (text, penalty, delaySeconds) to Clue/ClueInfo/ClueRow/HuntCard
- HuntForm: collapsible per-clue hints editor (up to 3 hints, each with text, penalty, delay)
- HuntCards: progressive reveal UI with countdown timer and per-hint penalty display
- Scoring: calculateProgressiveHintPenalty(); exactHintPenalty override in calculateCluePoints
- huntAttemptHistory: exactHintPenalty threaded through recordClueAttempt
- seedClues: sample progressive hints on 7 seed clues for testing
- contracts/hunt: addClue accepts hints[]; get_clue_info returns hints array
- analytics: hint usage tracking with file store + optional external endpoint
- POST /api/analytics/hint-usage + GET /api/analytics/hint-usage routes added
- answers route: accepts hintsUsed, records analytics fire-and-forget on correct answer

Backwards compatible: legacy hint/hintCost fields kept with @deprecated tags.

Closes #591