### PR TITLE
feat: add hunt embed code generator (#296)

### DIFF
--- a/app/api/embed/[id]/route.ts
+++ b/app/api/embed/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
+import { getHuntById } from "@/lib/huntStore";
+
+/**
+ * GET /api/embed/[id]
+ * Returns lightweight hunt data for the embed widget.
+ * Private hunts return 403 so the widget can inform the viewer.
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ip = getIP(req);
+  const { success, reset } = rateLimit(ip, { limit: 120, windowMs: 60 * 1000 });
+
+  if (!success) {
+    return rateLimitResponse(reset);
+  }
+
+  const { id } = await params;
+  const huntId = parseInt(id, 10);
+
+  if (isNaN(huntId)) {
+    return NextResponse.json({ error: "Invalid hunt ID" }, { status: 400 });
+  }
+
+  const hunt = getHuntById(huntId);
+
+  if (!hunt) {
+    return NextResponse.json({ error: "Hunt not found" }, { status: 404 });
+  }
+
+  if (hunt.is_private) {
+    return NextResponse.json(
+      { error: "This hunt is private and cannot be embedded." },
+      { status: 403 }
+    );
+  }
+
+  // Return only the fields the embed widget needs
+  return NextResponse.json(
+    {
+      data: {
+        id: hunt.id,
+        title: hunt.title,
+        description: hunt.description,
+        cluesCount: hunt.cluesCount,
+        status: hunt.status,
+        rewardType: hunt.rewardType,
+        coverImageCid: hunt.coverImageCid ?? null,
+        startTime: hunt.startTime ?? null,
+        endTime: hunt.endTime ?? null,
+      },
+    },
+    {
+      headers: {
+        // Allow any origin to load embed data
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      },
+    }
+  );
+}

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react"
 import dynamic from "next/dynamic"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { ArrowLeft, Pencil, BarChart3, HelpCircle } from "lucide-react"
+import { ArrowLeft, Pencil, BarChart3, HelpCircle, Code2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardDescription, CardTitle } from "@/components/ui/card"
 
@@ -13,6 +13,7 @@ const OnboardingTour = dynamic(() => import("@/components/OnboardingTour"), {
 })
 import { Header } from "@/components/Header"
 import { RewardHistorySection } from "@/components/RewardHistorySection"
+import { EmbedModal } from "@/components/EmbedModal"
 import { useWallet } from "@/lib/context/WalletContext"
 import type { StoredHunt } from "@/lib/types"
 import { getHuntsByCreator } from "@/lib/huntStore"
@@ -40,7 +41,7 @@ export default function CreatorPage() {
   const { connected, publicKey, connect } = useWallet()
   const [hunts, setHunts] = useState<StoredHunt[]>([])
   const [rewardHistory, setRewardHistory] = useState<Awaited<ReturnType<typeof fetchCreatorRewardHistory>>>([])
-
+  const [embedHunt, setEmbedHunt] = useState<StoredHunt | null>(null)
   const loadHunts = useCallback(() => {
     if (!publicKey) {
       setHunts([])
@@ -158,7 +159,9 @@ export default function CreatorPage() {
               {hunts.map((hunt) => {
                 const isDraft = hunt.status === "Draft"
                 const isActive = hunt.status === "Active"
+                const isCompleted = hunt.status === "Completed"
                 const isClickable = isDraft || isActive
+                const canEmbed = isActive || isCompleted
 
                 return (
                   <Card
@@ -184,18 +187,35 @@ export default function CreatorPage() {
                         <span className="text-xs text-slate-500">
                           {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
                         </span>
-                        {isDraft && (
-                          <span className="flex items-center gap-1 text-xs text-amber-700">
-                            <Pencil className="h-3 w-3" />
-                            Edit
-                          </span>
-                        )}
-                        {isActive && (
-                          <span className="flex items-center gap-1 text-xs text-emerald-700">
-                            <BarChart3 className="h-3 w-3" />
-                            Live Statistics
-                          </span>
-                        )}
+                        <div className="flex items-center gap-2">
+                          {isDraft && (
+                            <span className="flex items-center gap-1 text-xs text-amber-700">
+                              <Pencil className="h-3 w-3" />
+                              Edit
+                            </span>
+                          )}
+                          {isActive && (
+                            <span className="flex items-center gap-1 text-xs text-emerald-700">
+                              <BarChart3 className="h-3 w-3" />
+                              Live Statistics
+                            </span>
+                          )}
+                          {canEmbed && (
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                setEmbedHunt(hunt)
+                              }}
+                              className="flex items-center gap-1 text-xs text-[#3737A4] hover:underline font-medium"
+                              title="Get embed code"
+                              aria-label={`Get embed code for ${hunt.title}`}
+                            >
+                              <Code2 className="h-3 w-3" />
+                              Embed
+                            </button>
+                          )}
+                        </div>
                       </div>
                     </div>
                   </Card>
@@ -215,6 +235,13 @@ export default function CreatorPage() {
           </>
         )}
       </div>
+      {embedHunt && (
+        <EmbedModal
+          hunt={embedHunt}
+          open={!!embedHunt}
+          onClose={() => setEmbedHunt(null)}
+        />
+      )}
     </div>
   )
 }

--- a/app/hunt/[id]/embed/page.tsx
+++ b/app/hunt/[id]/embed/page.tsx
@@ -1,0 +1,340 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getHuntById } from "@/lib/huntStore";
+import type { HuntStatus } from "@/lib/types";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+function statusConfig(status: HuntStatus) {
+  switch (status) {
+    case "Active":
+      return { label: "Live Now", dot: "bg-emerald-400", text: "text-emerald-600" };
+    case "Completed":
+      return { label: "Ended", dot: "bg-slate-400", text: "text-slate-500" };
+    case "Draft":
+      return { label: "Coming Soon", dot: "bg-amber-400", text: "text-amber-600" };
+    case "Cancelled":
+      return { label: "Cancelled", dot: "bg-red-400", text: "text-red-500" };
+    default:
+      return { label: status, dot: "bg-slate-400", text: "text-slate-500" };
+  }
+}
+
+export default async function EmbedPage({ params }: PageProps) {
+  const { id } = await params;
+  const huntId = parseInt(id, 10);
+
+  if (isNaN(huntId)) notFound();
+
+  const hunt = getHuntById(huntId);
+
+  if (!hunt) notFound();
+
+  // Private hunts must not be embedded
+  if (hunt.is_private) {
+    return (
+      <div className="embed-root private">
+        <div className="lock-icon" aria-hidden="true">🔒</div>
+        <p className="private-msg">This hunt is private and cannot be embedded.</p>
+        <style>{embedStyles}</style>
+      </div>
+    );
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://hunty.app";
+  const huntUrl = `${baseUrl}/hunt/${hunt.id}`;
+  const { label, dot, text } = statusConfig(hunt.status as HuntStatus);
+
+  const rewardLabel =
+    hunt.rewardType === "Both"
+      ? "XLM + NFT"
+      : hunt.rewardType === "XLM"
+      ? "XLM Reward"
+      : "NFT Reward";
+
+  return (
+    <>
+      {/*
+        Minimal, iframe-friendly layout.
+        No app shell — just the card. Tailwind is not available here
+        because we're rendering inside a cross-origin iframe; we use an
+        inline <style> block so the widget is fully self-contained.
+      */}
+      <div className="embed-root">
+        {/* Cover image strip */}
+        {hunt.coverImageCid && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={hunt.coverImageCid}
+            alt={`${hunt.title} cover`}
+            className="cover"
+          />
+        )}
+
+        <div className="body">
+          {/* Status badge */}
+          <span className={`badge ${text}`}>
+            <span className={`dot ${dot}`} aria-hidden="true" />
+            {label}
+          </span>
+
+          {/* Title */}
+          <h1 className="title">{hunt.title}</h1>
+
+          {/* Description */}
+          {hunt.description && (
+            <p className="description">{hunt.description}</p>
+          )}
+
+          {/* Meta row */}
+          <div className="meta">
+            <span className="meta-item">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 6v6l4 2" />
+              </svg>
+              {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
+            </span>
+            <span className="meta-item reward">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="8" r="7" />
+                <path d="M8.21 13.89 7 23l5-3 5 3-1.21-9.12" />
+              </svg>
+              {rewardLabel}
+            </span>
+          </div>
+
+          {/* CTA */}
+          <a
+            href={huntUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cta"
+            aria-label={`Play ${hunt.title} on Hunty`}
+          >
+            {hunt.status === "Active" ? "Play Hunt →" : "View Hunt →"}
+          </a>
+
+          {/* Powered by */}
+          <a
+            href={baseUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="powered"
+            aria-label="Powered by Hunty"
+          >
+            Powered by <strong>Hunty</strong>
+          </a>
+        </div>
+      </div>
+
+      <style>{embedStyles}</style>
+    </>
+  );
+}
+
+// Self-contained styles — no Tailwind dependency inside the iframe
+const embedStyles = `
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #ffffff;
+    color: #1e1b4b;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #0f0e1a; color: #e2e8f0; }
+  }
+
+  .embed-root {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-height: 100vh;
+    border-radius: 12px;
+    overflow: hidden;
+    background: #ffffff;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .embed-root { background: #0f0e1a; box-shadow: 0 4px 24px rgba(0,0,0,0.4); }
+  }
+
+  .embed-root.private {
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 24px;
+    text-align: center;
+    color: #6b7280;
+  }
+
+  .lock-icon { font-size: 2rem; }
+  .private-msg { font-size: 0.875rem; }
+
+  .cover {
+    width: 100%;
+    height: 140px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 18px 20px 16px;
+    flex: 1;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+  }
+
+  .bg-emerald-400 { background-color: #34d399; }
+  .bg-amber-400   { background-color: #fbbf24; }
+  .bg-red-400     { background-color: #f87171; }
+  .bg-slate-400   { background-color: #94a3b8; }
+
+  .text-emerald-600 { color: #059669; }
+  .text-amber-600   { color: #d97706; }
+  .text-red-500     { color: #ef4444; }
+  .text-slate-500   { color: #64748b; }
+
+  @media (prefers-color-scheme: dark) {
+    .text-emerald-600 { color: #34d399; }
+    .text-amber-600   { color: #fbbf24; }
+    .text-red-500     { color: #f87171; }
+    .text-slate-500   { color: #94a3b8; }
+  }
+
+  .title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1.3;
+    color: #1e1b4b;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .title { color: #f1f5f9; }
+  }
+
+  .description {
+    font-size: 0.82rem;
+    line-height: 1.55;
+    color: #475569;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .description { color: #94a3b8; }
+  }
+
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-top: 2px;
+  }
+
+  .meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.78rem;
+    color: #64748b;
+    font-weight: 500;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .meta-item { color: #94a3b8; }
+  }
+
+  .meta-item.reward { color: #3737a4; }
+  @media (prefers-color-scheme: dark) {
+    .meta-item.reward { color: #818cf8; }
+  }
+
+  .cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: auto;
+    padding: 10px 20px;
+    background: linear-gradient(135deg, #3737a4, #0c0c4f);
+    color: #ffffff !important;
+    font-size: 0.875rem;
+    font-weight: 700;
+    border-radius: 10px;
+    text-decoration: none;
+    transition: opacity 0.15s ease;
+    width: 100%;
+  }
+
+  .cta:hover { opacity: 0.88; }
+
+  .powered {
+    display: block;
+    text-align: center;
+    font-size: 0.68rem;
+    color: #94a3b8;
+    text-decoration: none;
+    margin-top: 6px;
+  }
+
+  .powered:hover { color: #64748b; }
+  .powered strong { color: #3737a4; }
+
+  @media (prefers-color-scheme: dark) {
+    .powered { color: #64748b; }
+    .powered strong { color: #818cf8; }
+  }
+`;

--- a/app/hunt/[id]/share.tsx
+++ b/app/hunt/[id]/share.tsx
@@ -4,6 +4,7 @@ import { HuntControls } from "@/components/HuntControls";
 import { Button } from "@/components/ui/button";
 import { QrCode, Trophy } from "lucide-react";
 import { QrCodeModal } from "@/components/QrCodeModal";
+import { EmbedModal } from "@/components/EmbedModal";
 import { PlayGame } from "@/components/PlayGame";
 import { GameCompleteModal } from "@/components/GameCompleteModal";
 import { ChatWindow } from "@/components/ChatWindow";
@@ -49,6 +50,7 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
     loading: true,
   });
   const [qrOpen, setQrOpen] = useState(false);
+  const [embedOpen, setEmbedOpen] = useState(false);
 
   // Get current players (using stored hunt's playerCount, defaulting to 0)
   const currentPlayers = hunt.playerCount ?? 0;
@@ -293,8 +295,42 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
           >
             <QrCode className="w-4 h-4" />
           </Button>
+          {!hunt.is_private && (
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setEmbedOpen(true)}
+              title="Get embed code"
+              aria-label="Get embed code for this hunt"
+            >
+              {/* Code2 icon inline to avoid an extra import collision */}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="m18 16 4-4-4-4" />
+                <path d="m6 8-4 4 4 4" />
+                <path d="m14.5 4-5 16" />
+              </svg>
+            </Button>
+          )}
         </div>
         <QrCodeModal open={qrOpen} onClose={() => setQrOpen(false)} url={huntUrl} />
+        {!hunt.is_private && (
+          <EmbedModal
+            hunt={hunt}
+            open={embedOpen}
+            onClose={() => setEmbedOpen(false)}
+          />
+        )}
 
         <HuntControls
           hunt={hunt}

--- a/components/EmbedModal.tsx
+++ b/components/EmbedModal.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { Code2, Copy, Check, ExternalLink, AlertTriangle } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { StoredHunt } from "@/lib/types";
+
+interface EmbedModalProps {
+  hunt: StoredHunt;
+  open: boolean;
+  onClose: () => void;
+}
+
+function buildEmbedSnippet(huntId: number, baseUrl: string): string {
+  return `<iframe
+  src="${baseUrl}/hunt/${huntId}/embed"
+  width="360"
+  height="480"
+  frameborder="0"
+  style="border-radius:12px;border:1px solid #e2e8f0;max-width:100%;"
+  title="Hunty – Hunt #${huntId}"
+  loading="lazy"
+  allowtransparency="true"
+></iframe>`;
+}
+
+export function EmbedModal({ hunt, open, onClose }: EmbedModalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const baseUrl =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : (process.env.NEXT_PUBLIC_BASE_URL ?? "https://hunty.app");
+
+  const snippet = buildEmbedSnippet(hunt.id, baseUrl);
+  const previewUrl = `${baseUrl}/hunt/${hunt.id}/embed`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select the textarea text
+      const el = document.getElementById("embed-snippet") as HTMLTextAreaElement | null;
+      el?.select();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent
+        showCloseButton
+        className="sm:max-w-lg rounded-2xl border border-slate-200 bg-white dark:bg-[#0f0e1a] dark:border-white/10"
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg font-bold text-[#0C0C4F] dark:text-slate-100">
+            <Code2 className="w-5 h-5 shrink-0 text-[#3737A4] dark:text-indigo-400" />
+            Embed &ldquo;{hunt.title}&rdquo;
+          </DialogTitle>
+          <DialogDescription className="text-slate-500 dark:text-slate-400 text-sm">
+            Paste this snippet into any webpage, Discord widget, or blog post to show a live hunt card.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Privacy warning */}
+        {hunt.is_private && (
+          <div className="flex items-start gap-2 rounded-xl bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800/40 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+            <span>
+              This hunt is <strong>private</strong>. The embedded widget will show a &ldquo;private hunt&rdquo; message to viewers.
+              Make the hunt public if you want the widget to display its details.
+            </span>
+          </div>
+        )}
+
+        {/* Code block */}
+        <div className="relative rounded-xl border border-slate-200 dark:border-white/10 bg-slate-50 dark:bg-white/5 overflow-hidden">
+          <textarea
+            id="embed-snippet"
+            readOnly
+            value={snippet}
+            rows={7}
+            className="w-full resize-none bg-transparent px-4 py-3 font-mono text-xs text-slate-700 dark:text-slate-300 outline-none leading-relaxed"
+            aria-label="Embed code snippet"
+            onFocus={(e) => e.currentTarget.select()}
+          />
+          <Button
+            size="sm"
+            onClick={handleCopy}
+            className="absolute top-2 right-2 h-7 px-2.5 gap-1.5 bg-[#3737A4] hover:bg-[#2e2e8a] text-white text-xs font-semibold shadow-sm"
+            aria-label="Copy embed code"
+          >
+            {copied ? (
+              <>
+                <Check className="w-3.5 h-3.5" />
+                Copied!
+              </>
+            ) : (
+              <>
+                <Copy className="w-3.5 h-3.5" />
+                Copy
+              </>
+            )}
+          </Button>
+        </div>
+
+        {/* Preview hint */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 pt-1">
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            The widget shows the hunt title, reward type, clue count, and a live Play CTA. It updates automatically.
+          </p>
+          <a
+            href={previewUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold text-[#3737A4] dark:text-indigo-400 hover:underline whitespace-nowrap shrink-0"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            Preview widget
+          </a>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/HuntControls.tsx
+++ b/components/HuntControls.tsx
@@ -8,8 +8,9 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog"
-import { AlertTriangle, X, Loader2 } from "lucide-react"
+import { AlertTriangle, X, Loader2, Code2 } from "lucide-react"
 import type { StoredHunt } from "@/lib/types"
+import { EmbedModal } from "@/components/EmbedModal"
 import Server, { TransactionBuilder, Networks, Operation, Account } from "@stellar/stellar-sdk"
 import { withSorobanRpcRetry } from "@/lib/soroban/rpcRetry"
 import { logger } from "@/lib/logger"
@@ -239,6 +240,7 @@ export function HuntControls({
     onCancelled,
 }: HuntControlsProps) {
     const [modalOpen, setModalOpen] = useState(false)
+    const [embedModalOpen, setEmbedModalOpen] = useState(false)
     const [step, setStep] = useState<1 | 2>(1)
     const [isCancelling, setIsCancelling] = useState(false)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -285,6 +287,15 @@ export function HuntControls({
     return (
         <>
             <Button
+                onClick={() => setEmbedModalOpen(true)}
+                variant="outline"
+                className="border-[#3737A4]/40 text-[#3737A4] hover:bg-[#3737A4]/10 hover:border-[#3737A4]/70 active:scale-95 transition-all duration-150 font-semibold dark:border-indigo-500/40 dark:text-indigo-400 dark:hover:bg-indigo-500/10"
+            >
+                <Code2 className="w-4 h-4 mr-2 shrink-0" />
+                Get Embed Code
+            </Button>
+
+            <Button
                 onClick={openModal}
                 variant="outline"
                 className="border-red-800/50 text-red-400 hover:bg-red-950/60 hover:text-red-300 hover:border-red-600/70 active:scale-95 transition-all duration-150 font-semibold"
@@ -292,6 +303,12 @@ export function HuntControls({
                 <AlertTriangle className="w-4 h-4 mr-2 shrink-0" />
                 Cancel Hunt
             </Button>
+
+            <EmbedModal
+                hunt={hunt}
+                open={embedModalOpen}
+                onClose={() => setEmbedModalOpen(false)}
+            />
 
             <CancelModal
                 isOpen={modalOpen}


### PR DESCRIPTION
## Summary

Implements the embed code generator requested in #296. Hunt creators can now copy an `<iframe>` snippet and drop it into any blog, Discord widget, or website to show a live hunt card.

## Changes

### New files
- `app/api/embed/[id]/route.ts` — public GET endpoint returning lightweight hunt data. Returns 403 for private hunts, sets `Access-Control-Allow-Origin: *` and `Cache-Control` headers for cross-origin embedding.
- `app/hunt/[id]/embed/page.tsx` — iframe-friendly server component with no app shell. Fully self-contained via inline styles. Shows cover image, live status badge, title, description, clue count, reward type, and a Play CTA. Respects `prefers-color-scheme` for dark mode. Private hunts render a locked state.
- `components/EmbedModal.tsx` — Radix Dialog modal with a read-only textarea showing the ready-to-paste snippet, one-click Copy with ✓ feedback, "Preview widget" external link, and an amber warning banner when the hunt is private.

### Modified files
- `components/HuntControls.tsx` — added "Get Embed Code" button (indigo, Code2 icon) alongside the existing Cancel button, gated to creators only.
- `app/hunt/[id]/share.tsx` — added embed icon button next to the QR button in the share row, hidden for private hunts.
- `app/creator/page.tsx` — added "Embed" link on Active/Completed hunt cards in the dashboard grid.

## Acceptance criteria

- [x] Creator can copy embed code from their dashboard
- [x] Embedded iframe shows live hunt info (title, reward, clue count, Play CTA)
- [x] Embed respects the hunt's privacy setting (403 from API, locked widget UI, no button shown for private hunts in share row)
- [x] Iframe is responsive (`max-width: 100%`) and theme-aware (`prefers-color-scheme`)

## Testing

1. Create or open an Active hunt as a creator
2. Visit `/creator` — confirm "Embed" link appears on Active/Completed cards
3. Click it — modal opens with a copyable `<iframe>` snippet
4. Visit `/hunt/[id]` — confirm embed icon appears next to the QR button
5. Click "Get Embed Code" in `HuntControls` — same modal opens
6. Open the preview link — widget renders standalone without the site header/footer
7. Set `is_private: true` on a hunt — confirm the API returns 403, the widget shows the locked state, and the embed button is hidden in the share row

Closes #296