### PR TITLE
feat: build hunt preview mode (#581)

### DIFF
--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react"
 import dynamic from "next/dynamic"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { ArrowLeft, Pencil, BarChart3, HelpCircle } from "lucide-react"
+import { ArrowLeft, Pencil, BarChart3, HelpCircle, Eye } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardDescription, CardTitle } from "@/components/ui/card"
 
@@ -185,10 +185,22 @@ export default function CreatorPage() {
                           {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
                         </span>
                         {isDraft && (
-                          <span className="flex items-center gap-1 text-xs text-amber-700">
-                            <Pencil className="h-3 w-3" />
-                            Edit
-                          </span>
+                          <div className="flex items-center gap-2">
+                            <span className="flex items-center gap-1 text-xs text-amber-700">
+                              <Pencil className="h-3 w-3" />
+                              Edit
+                            </span>
+                            {hunt.cluesCount > 0 && (
+                              <Link
+                                href={`/hunt/${hunt.id}/preview`}
+                                onClick={(e) => e.stopPropagation()}
+                                className="flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-medium"
+                              >
+                                <Eye className="h-3 w-3" />
+                                Preview
+                              </Link>
+                            )}
+                          </div>
                         )}
                         {isActive && (
                           <span className="flex items-center gap-1 text-xs text-emerald-700">

--- a/app/hunt/[id]/preview/page.tsx
+++ b/app/hunt/[id]/preview/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * Preview route: /hunt/[id]/preview
+ *
+ * Allows creators to preview their hunt exactly as players will see it,
+ * with local answer validation and no on-chain writes (#581).
+ */
+
+import type { Metadata } from "next"
+import { PreviewPageClient } from "@/components/PreviewPageClient"
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  return {
+    title: `Preview Hunt #${id} | Hunty`,
+    description: "Creator preview — answers are validated locally and nothing is saved.",
+    robots: { index: false, follow: false },
+  }
+}
+
+export default async function PreviewPage({ params }: PageProps) {
+  const { id } = await params
+  const huntId = parseInt(id, 10)
+
+  return <PreviewPageClient huntId={huntId} />
+}

--- a/app/hunty/page.tsx
+++ b/app/hunty/page.tsx
@@ -45,6 +45,7 @@ const EMPTY_HUNT_DRAFT: HuntDraft = {
 
 function CreateGameContent() {  
   const searchParams = useSearchParams()
+  const editHuntId = searchParams.get("edit") ? parseInt(searchParams.get("edit")!, 10) : undefined
   const [activeTab, setActiveTab] = useState<"create" | "rewards" | "publish" | "leaderboard">("create")
   const [hunts, setHunts] = useLocalStorage<HuntDraft[]>("draft-hunts", [EMPTY_HUNT_DRAFT])
   const [rewards, setRewards] = useLocalStorage<Reward[]>("draft-rewards", []);
@@ -845,7 +846,7 @@ function CreateGameContent() {
             </div>
             {/* Right Panel - Live Preview */}
               <div ref={previewContainerRef} className="hidden lg:block">
-                <GamePreview hunts={hunts} />
+                <GamePreview hunts={hunts} huntId={editHuntId} />
               </div>
             </div>
           </div>

--- a/components/GamePreview.tsx
+++ b/components/GamePreview.tsx
@@ -1,27 +1,54 @@
 "use client"
 
+import Link from "next/link"
+import { Eye } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Eye} from "lucide-react"
 import PlayCircle from "@/components/icons/PlayCircle"
 import { HuntCards } from "./HuntCards"
 import type { HuntCard } from "@/lib/types"
 
 interface GamePreviewProps {
   hunts: HuntCard[]
+  /** Hunt ID to link to the full-page preview. When provided, "Preview" opens /hunt/:id/preview */
+  huntId?: number
 }
 
-export function GamePreview({ hunts }: GamePreviewProps) {
+export function GamePreview({ hunts, huntId }: GamePreviewProps) {
   return (
-    <div className="bg-slate-100 backdrop-blur-md rounded-2xl p-6 border border-white/20 print:bg-transparent print:border-none print:p-0 print:shadow-none" style={{boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.1), inset 0 0 20px rgba(0, 0, 0, 0.15), 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)'}}>
+    <div
+      className="bg-slate-100 backdrop-blur-md rounded-2xl p-6 border border-white/20 print:bg-transparent print:border-none print:p-0 print:shadow-none"
+      style={{
+        boxShadow:
+          "inset 0 1px 0 0 rgba(255, 255, 255, 0.1), inset 0 0 20px rgba(0, 0, 0, 0.15), 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
+      }}
+    >
       <div className="flex items-center justify-between mb-4 print:hidden">
         <span className="text-[16px] font-normal text-slate-800">Live Preview</span>
         <div className="flex gap-2">
-          <Button size="sm" className="bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 text-white px-3 py-[6px] rounded-xl text-sm font-semibold">
-          <Eye /> Reveal
+          <Button
+            size="sm"
+            className="bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 text-white px-3 py-[6px] rounded-xl text-sm font-semibold"
+          >
+            <Eye /> Reveal
           </Button>
-          <Button size="sm" className="bg-gradient-to-br from-[#2F2FFF] to-[#E87785] hover:bg-purple-700 text-white px-3 py-[6px] rounded-xl text-sm font-semibold">
-            <PlayCircle /> Test
-          </Button>
+          {huntId ? (
+            <Button
+              size="sm"
+              asChild
+              className="bg-gradient-to-br from-[#2F2FFF] to-[#E87785] hover:bg-purple-700 text-white px-3 py-[6px] rounded-xl text-sm font-semibold"
+            >
+              <Link href={`/hunt/${huntId}/preview`} target="_blank" rel="noopener noreferrer">
+                <PlayCircle /> Preview
+              </Link>
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              className="bg-gradient-to-br from-[#2F2FFF] to-[#E87785] hover:bg-purple-700 text-white px-3 py-[6px] rounded-xl text-sm font-semibold"
+            >
+              <PlayCircle /> Test
+            </Button>
+          )}
         </div>
       </div>
 

--- a/components/HuntDashboard.tsx
+++ b/components/HuntDashboard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useState, type MouseEvent as ReactMouseEvent } from "react"
-import { Plus, Trash2, Trophy, Copy, X, BarChart3, List } from "lucide-react"
+import { Plus, Trash2, Trophy, Copy, X, BarChart3, List, Eye } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -463,15 +463,31 @@ export function HuntDashboard({
                           Duplicate
                         </Button>
                         {isDraft && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => openClueModal(hunt)}
-                            className="border-[#3737A4] text-[#3737A4] hover:bg-[#3737A4] hover:text-white"
-                          >
-                            <Plus className="mr-1 h-3 w-3" />
-                            Add Clues
-                          </Button>
+                          <>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => openClueModal(hunt)}
+                              className="border-[#3737A4] text-[#3737A4] hover:bg-[#3737A4] hover:text-white"
+                            >
+                              <Plus className="mr-1 h-3 w-3" />
+                              Add Clues
+                            </Button>
+                            {hasClues && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                asChild
+                                className="border-amber-400 text-amber-700 hover:bg-amber-50 dark:border-amber-600 dark:text-amber-400 dark:hover:bg-amber-900/20"
+                                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                              >
+                                <Link href={`/hunt/${hunt.id}/preview`}>
+                                  <Eye className="mr-1 h-3 w-3" />
+                                  Preview
+                                </Link>
+                              </Button>
+                            )}
+                          </>
                         )}
                         {(isActive || isCompleted) && (
                           <Button

--- a/components/PreviewClueCard.tsx
+++ b/components/PreviewClueCard.tsx
@@ -1,0 +1,285 @@
+"use client"
+
+/**
+ * PreviewClueCard (#581)
+ *
+ * A creator-only clue card that validates answers locally without any
+ * Soroban contract calls or score persistence.  Mirrors the visual layout
+ * of HuntCards so the preview is an accurate representation of the live
+ * player experience.
+ */
+
+import React, { useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { CheckCircle2, Eye, EyeOff, Lightbulb, RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+import { isValidClueAnswer } from "@/lib/clueAnswerValidation"
+import { matchesClueAnswer } from "@/lib/clueAnswerVerification"
+import type { Clue } from "@/lib/types"
+
+interface PreviewClueCardProps {
+  clue: Clue
+  huntId: number
+  clueIndex: number
+  totalClues: number
+  isSolved: boolean
+  /** Called when a correct answer is confirmed. */
+  onSolve: (answer: string) => void
+  /** Called when a wrong answer is submitted (for shake animation coordination). */
+  onWrongAnswer?: (answer: string) => void
+  /** Called when the creator clicks "Reset" to undo their solved state. */
+  onReset?: () => void
+}
+
+const shakeVariants = {
+  shake: {
+    x: [0, -10, 10, -10, 10, -5, 5, 0],
+    transition: { duration: 0.5 },
+  },
+  idle: { x: 0 },
+}
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  Easy: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  Medium: "bg-amber-100 text-amber-700 border-amber-200",
+  Hard: "bg-red-100 text-red-700 border-red-200",
+}
+
+export function PreviewClueCard({
+  clue,
+  huntId,
+  clueIndex,
+  totalClues,
+  isSolved,
+  onSolve,
+  onWrongAnswer,
+  onReset,
+}: PreviewClueCardProps) {
+  const [input, setInput] = useState("")
+  const [shake, setShake] = useState(false)
+  const [isChecking, setIsChecking] = useState(false)
+  const [showHint, setShowHint] = useState(false)
+  const [showAnswer, setShowAnswer] = useState(false)
+  const [feedback, setFeedback] = useState<"correct" | "wrong" | null>(null)
+
+  const handleSubmit = async () => {
+    const trimmed = input.trim()
+    if (!isValidClueAnswer(trimmed)) return
+
+    setIsChecking(true)
+    setFeedback(null)
+
+    try {
+      const correct = await matchesClueAnswer(trimmed, clue, huntId)
+      if (correct) {
+        setFeedback("correct")
+        // Brief visual delay so the creator sees the success state
+        setTimeout(() => {
+          onSolve(trimmed)
+          setInput("")
+          setFeedback(null)
+        }, 700)
+      } else {
+        setFeedback("wrong")
+        setShake(true)
+        setTimeout(() => setShake(false), 600)
+        onWrongAnswer?.(trimmed)
+      }
+    } finally {
+      setIsChecking(false)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") handleSubmit()
+  }
+
+  return (
+    <div
+      className={cn(
+        "rounded-3xl border bg-white shadow-lg transition-all duration-300 w-full max-w-sm mx-auto",
+        isSolved
+          ? "border-emerald-300 bg-emerald-50/50 shadow-emerald-100"
+          : "border-slate-200",
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 pt-6 pb-3">
+        <span className="text-xs font-semibold text-slate-400 uppercase tracking-widest">
+          Clue {clueIndex + 1} / {totalClues}
+        </span>
+        <div className="flex items-center gap-2">
+          {clue.difficulty && (
+            <span
+              className={cn(
+                "text-xs font-medium px-2 py-0.5 rounded-full border",
+                DIFFICULTY_COLORS[clue.difficulty] ?? "bg-slate-100 text-slate-600 border-slate-200",
+              )}
+            >
+              {clue.difficulty}
+            </span>
+          )}
+          {clue.points != null && (
+            <span className="text-xs font-semibold text-indigo-600 bg-indigo-50 border border-indigo-100 px-2 py-0.5 rounded-full">
+              {clue.points} pts
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Question */}
+      <div className="px-6 pb-4">
+        <p className="text-slate-800 text-base font-medium leading-relaxed">
+          {clue.question}
+        </p>
+      </div>
+
+      {/* Solved overlay */}
+      <AnimatePresence>
+        {isSolved && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            className="mx-6 mb-4 flex items-center gap-3 rounded-2xl bg-emerald-100 border border-emerald-200 px-4 py-3"
+          >
+            <CheckCircle2 className="w-5 h-5 text-emerald-600 shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-emerald-700">
+                Correct! +{clue.points ?? 0} pts
+              </p>
+              <p className="text-xs text-emerald-600/80">
+                Preview only — no data saved
+              </p>
+            </div>
+            {onReset && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onReset}
+                className="ml-auto text-emerald-600 hover:text-emerald-800 hover:bg-emerald-200 shrink-0"
+                aria-label="Reset this clue"
+              >
+                <RotateCcw className="w-4 h-4" />
+              </Button>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Answer input */}
+      {!isSolved && (
+        <div className="px-6 pb-4 space-y-3">
+          <motion.div
+            animate={shake ? "shake" : "idle"}
+            variants={shakeVariants}
+          >
+            <Input
+              value={input}
+              onChange={(e) => {
+                setInput(e.target.value)
+                setFeedback(null)
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Type your answer…"
+              disabled={isChecking}
+              className={cn(
+                "rounded-xl border-slate-200 focus-visible:ring-indigo-400",
+                feedback === "wrong" && "border-red-400 focus-visible:ring-red-300",
+                feedback === "correct" && "border-emerald-400",
+              )}
+              aria-label="Answer input"
+            />
+          </motion.div>
+
+          {feedback === "wrong" && (
+            <p className="text-xs text-red-500 font-medium" role="alert">
+              That&apos;s not quite right — try again!
+            </p>
+          )}
+
+          <Button
+            onClick={handleSubmit}
+            disabled={isChecking || !isValidClueAnswer(input)}
+            className="w-full bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white rounded-xl disabled:opacity-50"
+          >
+            {isChecking ? "Checking…" : "Submit Answer"}
+          </Button>
+        </div>
+      )}
+
+      {/* Hint & reveal-answer helpers (creator perks) */}
+      <div className="px-6 pb-6 flex flex-wrap gap-2">
+        {clue.hint && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowHint((v) => !v)}
+            className="text-xs gap-1.5 text-amber-700 border-amber-200 hover:bg-amber-50"
+          >
+            <Lightbulb className="w-3.5 h-3.5" />
+            {showHint ? "Hide Hint" : "Show Hint"}
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowAnswer((v) => !v)}
+          className="text-xs gap-1.5 text-slate-600 border-slate-200 hover:bg-slate-50"
+        >
+          {showAnswer ? (
+            <EyeOff className="w-3.5 h-3.5" />
+          ) : (
+            <Eye className="w-3.5 h-3.5" />
+          )}
+          {showAnswer ? "Hide Answer" : "Reveal Answer"}
+        </Button>
+      </div>
+
+      {/* Hint panel */}
+      <AnimatePresence>
+        {showHint && clue.hint && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="overflow-hidden"
+          >
+            <div className="mx-6 mb-4 rounded-2xl bg-amber-50 border border-amber-200 px-4 py-3">
+              <p className="text-xs font-semibold text-amber-700 mb-1">Hint</p>
+              <p className="text-sm text-amber-900">{clue.hint}</p>
+              {clue.hintCost != null && (
+                <p className="text-xs text-amber-600 mt-1">
+                  Hint cost for players: {clue.hintCost} pts
+                </p>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Reveal answer panel */}
+      <AnimatePresence>
+        {showAnswer && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="overflow-hidden"
+          >
+            <div className="mx-6 mb-6 rounded-2xl bg-indigo-50 border border-indigo-200 px-4 py-3">
+              <p className="text-xs font-semibold text-indigo-700 mb-1">
+                Answer (creator only)
+              </p>
+              <p className="text-sm font-mono text-indigo-900 break-all">
+                {clue.answer}
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/components/PreviewPageClient.tsx
+++ b/components/PreviewPageClient.tsx
@@ -1,0 +1,629 @@
+"use client"
+
+/**
+ * PreviewPageClient (#581)
+ *
+ * Full-featured hunt preview page for creators.
+ *
+ * Features:
+ * - Landing overview mirroring the player-facing hunt detail page
+ * - Step-through clue experience with dry-run answer validation
+ * - Responsive viewport simulator (mobile / tablet / desktop)
+ * - Share preview link with collaborators
+ * - Reset session at any time
+ */
+
+import React, { useCallback, useEffect, useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import {
+  ArrowLeft,
+  Check,
+  CheckCircle2,
+  ExternalLink,
+  Info,
+  Monitor,
+  RotateCcw,
+  Share2,
+  Smartphone,
+  Tablet,
+  Trophy,
+} from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { PreviewClueCard } from "@/components/PreviewClueCard"
+import { formatTimestamp } from "@/lib/dateUtils"
+import {
+  advancePreviewSession,
+  buildPreviewUrl,
+  copyPreviewUrlToClipboard,
+  createPreviewSession,
+  recordWrongAttempt,
+  resetPreviewSession,
+  type PreviewSession,
+  type PreviewViewport,
+  VIEWPORT_LABELS,
+  VIEWPORT_WIDTHS,
+} from "@/lib/previewStore"
+
+// ─── Viewport icons ───────────────────────────────────────────────────────────
+
+const VIEWPORT_ICONS: Record<PreviewViewport, React.ReactNode> = {
+  mobile: <Smartphone className="w-4 h-4" />,
+  tablet: <Tablet className="w-4 h-4" />,
+  desktop: <Monitor className="w-4 h-4" />,
+}
+
+const VIEWPORTS: PreviewViewport[] = ["mobile", "tablet", "desktop"]
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function PreviewBanner({ huntId }: { huntId: number }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleShare = async () => {
+    const ok = await copyPreviewUrlToClipboard(huntId)
+    if (ok) {
+      setCopied(true)
+      toast.success("Preview link copied to clipboard!")
+      setTimeout(() => setCopied(false), 2000)
+    } else {
+      // Fallback: show the URL in a toast
+      toast.info(`Preview URL: ${buildPreviewUrl(huntId)}`, { duration: 5000 })
+    }
+  }
+
+  return (
+    <div
+      className="sticky top-0 z-30 flex items-center justify-between gap-3 px-4 py-2.5 bg-amber-50 border-b border-amber-200 text-amber-900"
+      role="banner"
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <Info className="w-4 h-4 shrink-0 text-amber-600" />
+        <p className="text-xs sm:text-sm font-medium truncate">
+          <span className="font-semibold">Preview Mode</span>
+          <span className="hidden sm:inline"> — answers are validated locally, nothing is saved.</span>
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleShare}
+        className="shrink-0 border-amber-300 text-amber-800 hover:bg-amber-100 gap-1.5 text-xs"
+        aria-label="Copy preview link"
+      >
+        {copied ? (
+          <>
+            <Check className="w-3.5 h-3.5" />
+            Copied!
+          </>
+        ) : (
+          <>
+            <Share2 className="w-3.5 h-3.5" />
+            Share Preview
+          </>
+        )}
+      </Button>
+    </div>
+  )
+}
+
+function ViewportSelector({
+  current,
+  onChange,
+}: {
+  current: PreviewViewport
+  onChange: (v: PreviewViewport) => void
+}) {
+  return (
+    <div
+      className="flex items-center gap-1 bg-slate-100 rounded-xl p-1"
+      role="group"
+      aria-label="Preview viewport"
+    >
+      {VIEWPORTS.map((v) => (
+        <button
+          key={v}
+          onClick={() => onChange(v)}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+            current === v
+              ? "bg-white text-slate-900 shadow-sm"
+              : "text-slate-500 hover:text-slate-700"
+          }`}
+          aria-pressed={current === v}
+          title={VIEWPORT_LABELS[v]}
+        >
+          {VIEWPORT_ICONS[v]}
+          <span className="hidden sm:inline capitalize">{v}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function ViewportWrapper({
+  viewport,
+  children,
+}: {
+  viewport: PreviewViewport
+  children: React.ReactNode
+}) {
+  const width = VIEWPORT_WIDTHS[viewport]
+
+  if (width === null) {
+    // Desktop — full width, no artificial constraint
+    return <div className="w-full">{children}</div>
+  }
+
+  return (
+    <div className="flex justify-center w-full">
+      <div
+        style={{ width, maxWidth: "100%" }}
+        className="transition-all duration-300 border-2 border-dashed border-slate-300 rounded-2xl overflow-hidden"
+        aria-label={`${VIEWPORT_LABELS[viewport]} viewport`}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// ─── Hunt landing overview (mirrors app/hunt/[id]/page.tsx appearance) ────────
+
+function HuntLandingOverview({
+  session,
+  onStartPreview,
+}: {
+  session: PreviewSession
+  onStartPreview: () => void
+}) {
+  const { hunt } = session
+  const totalPoints = session.clues.reduce((s, cs) => s + (cs.clue.points ?? 0), 0)
+
+  const statusStyles: Record<string, { label: string; classes: string }> = {
+    Active: {
+      label: "Active",
+      classes: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30",
+    },
+    Draft: {
+      label: "Draft",
+      classes: "bg-amber-500/10 text-amber-400 border border-amber-500/30",
+    },
+    Completed: {
+      label: "Completed",
+      classes: "bg-zinc-500/10 text-zinc-400 border border-zinc-500/30",
+    },
+    Cancelled: {
+      label: "Cancelled",
+      classes: "bg-red-500/10 text-red-400 border border-red-500/30",
+    },
+  }
+
+  const statusStyle = statusStyles[hunt.status] ?? statusStyles.Draft
+
+  return (
+    <div className="min-h-screen bg-[#0b0c10] text-white pb-16">
+      {/* Background glows */}
+      <div className="fixed inset-0 pointer-events-none">
+        <div className="absolute top-0 left-1/3 w-[600px] h-[400px] bg-violet-700/20 rounded-full blur-[120px]" />
+        <div className="absolute bottom-0 right-1/4 w-[400px] h-[300px] bg-indigo-600/15 rounded-full blur-[100px]" />
+      </div>
+
+      <div className="relative max-w-3xl mx-auto px-6 pt-16">
+        {/* Status badge */}
+        <div className="mb-6">
+          <span
+            className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold tracking-widest uppercase ${statusStyle.classes}`}
+          >
+            {hunt.status === "Active" && (
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+            )}
+            {statusStyle.label}
+          </span>
+        </div>
+
+        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight text-white leading-tight mb-4">
+          {hunt.title}
+        </h1>
+
+        <p className="text-zinc-400 text-lg leading-relaxed mb-10">
+          {hunt.description}
+        </p>
+
+        {/* Metadata cards */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-12">
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-5">
+            <p className="text-xs text-slate-400 uppercase tracking-widest mb-1">Hunt ID</p>
+            <p className="text-white font-semibold text-lg">#{hunt.id}</p>
+          </div>
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-5">
+            <p className="text-xs text-slate-400 uppercase tracking-widest mb-1">Clues</p>
+            <p className="text-white font-semibold text-lg">{session.clues.length}</p>
+          </div>
+          <div className="col-span-2 sm:col-span-1 bg-white/5 border border-white/10 rounded-2xl p-5">
+            <p className="text-xs text-slate-400 uppercase tracking-widest mb-1">Total Points</p>
+            <p className="text-white font-semibold text-lg">{totalPoints}</p>
+          </div>
+          {hunt.rewardType && (
+            <div className="bg-white/5 border border-white/10 rounded-2xl p-5">
+              <p className="text-xs text-slate-400 uppercase tracking-widest mb-1">Reward</p>
+              <p className="text-white font-semibold text-lg">{hunt.rewardType}</p>
+            </div>
+          )}
+          {hunt.startTime && (
+            <div className="bg-white/5 border border-white/10 rounded-2xl p-5">
+              <p className="text-xs text-slate-400 uppercase tracking-widest mb-1">Starts</p>
+              <p className="text-white font-semibold text-sm">{formatTimestamp(hunt.startTime)}</p>
+            </div>
+          )}
+          {hunt.endTime && (
+            <div className="bg-white/5 border border-white/10 rounded-2xl p-5">
+              <p className="text-xs text-slate-400 uppercase tracking-widest mb-1">Ends</p>
+              <p className="text-white font-semibold text-sm">{formatTimestamp(hunt.endTime)}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Start preview CTA */}
+        {session.clues.length > 0 ? (
+          <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+            <Button
+              onClick={onStartPreview}
+              className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] hover:opacity-90 text-white px-8 py-3 rounded-full text-lg font-semibold shadow-lg shadow-indigo-500/20"
+            >
+              Start Preview
+            </Button>
+            <p className="text-xs text-zinc-500">Validates answers locally · Nothing is saved</p>
+          </div>
+        ) : (
+          <div className="rounded-2xl bg-amber-900/30 border border-amber-500/20 px-6 py-4">
+            <p className="text-amber-400 font-medium">No clues added yet.</p>
+            <p className="text-amber-400/70 text-sm mt-1">
+              Add clues in the{" "}
+              <Link
+                href="/hunty"
+                className="underline underline-offset-2 hover:text-amber-300"
+              >
+                hunt editor
+              </Link>{" "}
+              to preview the full experience.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Clue step-through ────────────────────────────────────────────────────────
+
+function ClueStepThrough({
+  session,
+  onSolve,
+  onWrongAnswer,
+  onResetClue,
+  onGoToClue,
+}: {
+  session: PreviewSession
+  onSolve: (clueIndex: number, answer: string) => void
+  onWrongAnswer: (clueIndex: number, answer: string) => void
+  onResetClue: (clueIndex: number) => void
+  onGoToClue: (index: number) => void
+}) {
+  const { currentClueIndex, clues } = session
+  const currentState = clues[currentClueIndex]
+
+  if (!currentState) return null
+
+  const solvedCount = clues.filter((cs) => cs.solved).length
+
+  return (
+    <div className="min-h-screen bg-gradient-to-tr from-blue-100 via-purple-100 to-[#f9f9ff] pb-12">
+      {/* Top progress bar */}
+      <div className="w-full bg-slate-200 h-1">
+        <div
+          className="bg-gradient-to-r from-[#3737A4] to-[#0C0C4F] h-1 transition-all duration-500"
+          style={{ width: `${(solvedCount / clues.length) * 100}%` }}
+          role="progressbar"
+          aria-valuenow={solvedCount}
+          aria-valuemax={clues.length}
+          aria-label={`${solvedCount} of ${clues.length} clues solved`}
+        />
+      </div>
+
+      {/* Header */}
+      <div className="max-w-4xl mx-auto px-4 pt-8 pb-4">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h2 className="text-xl font-bold bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-transparent">
+              {session.hunt.title}
+            </h2>
+            <p className="text-sm text-slate-500 mt-0.5">
+              {solvedCount} / {clues.length} clues · {session.totalPoints} pts
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-slate-500 bg-slate-100 rounded-full px-3 py-1.5">
+            <Info className="w-3.5 h-3.5" />
+            Preview only
+          </div>
+        </div>
+
+        {/* Clue navigation dots */}
+        <div className="flex items-center gap-1.5 mt-4 flex-wrap" role="tablist" aria-label="Clue navigation">
+          {clues.map((cs, i) => (
+            <button
+              key={cs.clue.id}
+              role="tab"
+              aria-selected={i === currentClueIndex}
+              aria-label={`Clue ${i + 1}${cs.solved ? ", solved" : ""}`}
+              onClick={() => onGoToClue(i)}
+              className={`w-7 h-7 rounded-full text-xs font-semibold transition-all ${
+                i === currentClueIndex
+                  ? "bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white shadow-md scale-110"
+                  : cs.solved
+                  ? "bg-emerald-500 text-white"
+                  : "bg-slate-200 text-slate-600 hover:bg-slate-300"
+              }`}
+            >
+              {cs.solved ? <CheckCircle2 className="w-4 h-4 mx-auto" /> : i + 1}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Active clue card */}
+      <div className="max-w-4xl mx-auto px-4 py-4">
+        <PreviewClueCard
+          clue={currentState.clue}
+          huntId={session.huntId}
+          clueIndex={currentClueIndex}
+          totalClues={clues.length}
+          isSolved={currentState.solved}
+          onSolve={(answer) => onSolve(currentClueIndex, answer)}
+          onWrongAnswer={(answer) => onWrongAnswer(currentClueIndex, answer)}
+          onReset={currentState.solved ? () => onResetClue(currentClueIndex) : undefined}
+        />
+      </div>
+
+      {/* Navigation buttons */}
+      <div className="max-w-4xl mx-auto px-4 pb-8 flex items-center justify-between gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onGoToClue(Math.max(0, currentClueIndex - 1))}
+          disabled={currentClueIndex === 0}
+          className="rounded-full"
+        >
+          ← Previous
+        </Button>
+        {currentClueIndex < clues.length - 1 ? (
+          <Button
+            size="sm"
+            onClick={() => onGoToClue(currentClueIndex + 1)}
+            className="rounded-full bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white"
+          >
+            Next Clue →
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            disabled={!currentState.solved}
+            className="rounded-full bg-gradient-to-b from-[#39A437] to-[#194F0C] text-white disabled:opacity-50"
+          >
+            {currentState.solved ? "Finish Hunt →" : "Solve to finish"}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Completion screen ────────────────────────────────────────────────────────
+
+function PreviewComplete({
+  session,
+  onRestart,
+}: {
+  session: PreviewSession
+  onRestart: () => void
+}) {
+  return (
+    <div className="min-h-screen bg-gradient-to-tr from-blue-100 via-purple-100 to-[#f9f9ff] flex items-center justify-center p-6">
+      <div className="max-w-sm w-full text-center bg-white rounded-3xl shadow-xl border border-slate-100 p-10">
+        <div className="w-16 h-16 bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] rounded-full flex items-center justify-center mx-auto mb-6 shadow-lg">
+          <Trophy className="w-8 h-8 text-white" />
+        </div>
+        <h2 className="text-2xl font-bold text-slate-900 mb-2">Hunt Complete!</h2>
+        <p className="text-slate-500 text-sm mb-6">
+          Preview finished · No data was saved
+        </p>
+        <div className="bg-indigo-50 border border-indigo-100 rounded-2xl px-6 py-4 mb-8">
+          <p className="text-3xl font-bold text-indigo-700">{session.totalPoints}</p>
+          <p className="text-indigo-500 text-sm mt-1">points scored</p>
+        </div>
+        <div className="flex flex-col gap-3">
+          <Button
+            onClick={onRestart}
+            className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white rounded-full gap-2"
+          >
+            <RotateCcw className="w-4 h-4" />
+            Restart Preview
+          </Button>
+          <Button variant="outline" asChild className="rounded-full">
+            <Link href={`/hunty?edit=${session.huntId}`}>
+              <ExternalLink className="w-4 h-4 mr-2" />
+              Back to Editor
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+type PreviewView = "landing" | "clues" | "complete"
+
+interface PreviewPageClientProps {
+  huntId: number
+}
+
+export function PreviewPageClient({ huntId }: PreviewPageClientProps) {
+  const router = useRouter()
+  const [session, setSession] = useState<PreviewSession | null>(null)
+  const [view, setView] = useState<PreviewView>("landing")
+  const [viewport, setViewport] = useState<PreviewViewport>("desktop")
+  const [notFound, setNotFound] = useState(false)
+
+  // Initialize session once on mount
+  useEffect(() => {
+    const s = createPreviewSession(huntId)
+    if (!s) {
+      setNotFound(true)
+    } else {
+      setSession(s)
+    }
+  }, [huntId])
+
+  const handleSolve = useCallback((clueIndex: number, answer: string) => {
+    setSession((prev) => {
+      if (!prev) return prev
+      const next = advancePreviewSession(prev, clueIndex, answer)
+      if (next.isComplete) {
+        // Delay so the user sees the success card before the complete screen
+        setTimeout(() => setView("complete"), 800)
+      }
+      return next
+    })
+  }, [])
+
+  const handleWrongAnswer = useCallback((clueIndex: number, answer: string) => {
+    setSession((prev) => (prev ? recordWrongAttempt(prev, clueIndex, answer) : prev))
+  }, [])
+
+  const handleResetClue = useCallback((clueIndex: number) => {
+    setSession((prev) => {
+      if (!prev) return prev
+      const updatedClues = prev.clues.map((cs, i) =>
+        i === clueIndex ? { ...cs, solved: false, lastAttempt: undefined, lastAttemptCorrect: undefined } : cs,
+      )
+      const totalPoints = updatedClues
+        .filter((cs) => cs.solved)
+        .reduce((s, cs) => s + (cs.clue.points ?? 0), 0)
+      return { ...prev, clues: updatedClues, totalPoints, isComplete: false }
+    })
+  }, [])
+
+  const handleGoToClue = useCallback((index: number) => {
+    setSession((prev) => {
+      if (!prev) return prev
+      return { ...prev, currentClueIndex: index }
+    })
+  }, [])
+
+  const handleRestart = useCallback(() => {
+    setSession((prev) => (prev ? resetPreviewSession(prev) : prev))
+    setView("landing")
+  }, [])
+
+  const handleResetAndGoToClues = useCallback(() => {
+    setSession((prev) => (prev ? resetPreviewSession(prev) : prev))
+    setView("clues")
+  }, [])
+
+  // Not found
+  if (notFound) {
+    return (
+      <div className="min-h-screen bg-[#0b0c10] flex items-center justify-center p-6">
+        <div className="text-center">
+          <p className="text-white text-2xl font-bold mb-3">Hunt not found</p>
+          <p className="text-zinc-400 mb-6">
+            This hunt doesn&apos;t exist in local storage, or it may have been deleted.
+          </p>
+          <Button asChild className="rounded-full bg-[#3737A4] text-white">
+            <Link href="/creator">Go to Creator Dashboard</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  // Loading
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-[#0b0c10] flex items-center justify-center">
+        <div className="text-white text-lg animate-pulse">Loading preview…</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0b0c10]">
+      {/* Preview banner always visible */}
+      <PreviewBanner huntId={huntId} />
+
+      {/* Toolbar */}
+      <div className="bg-[#111318] border-b border-white/10 px-4 py-2 flex items-center justify-between gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.back()}
+          className="text-slate-400 hover:text-white gap-1.5 text-xs"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </Button>
+
+        <div className="flex items-center gap-2">
+          <ViewportSelector current={viewport} onChange={setViewport} />
+
+          {view !== "landing" && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleResetAndGoToClues}
+              className="text-slate-400 hover:text-white gap-1.5 text-xs"
+              title="Reset preview"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">Reset</span>
+            </Button>
+          )}
+
+          {view === "landing" && session.clues.length > 0 && (
+            <Button
+              size="sm"
+              onClick={() => setView("clues")}
+              className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-white text-xs rounded-lg px-3"
+            >
+              Start Preview
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Viewport wrapper */}
+      <ViewportWrapper viewport={viewport}>
+        {view === "landing" && (
+          <HuntLandingOverview
+            session={session}
+            onStartPreview={() => setView("clues")}
+          />
+        )}
+        {view === "clues" && (
+          <ClueStepThrough
+            session={session}
+            onSolve={handleSolve}
+            onWrongAnswer={handleWrongAnswer}
+            onResetClue={handleResetClue}
+            onGoToClue={handleGoToClue}
+          />
+        )}
+        {view === "complete" && (
+          <PreviewComplete session={session} onRestart={handleRestart} />
+        )}
+      </ViewportWrapper>
+    </div>
+  )
+}

--- a/components/__tests__/PreviewClueCard.test.tsx
+++ b/components/__tests__/PreviewClueCard.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for components/PreviewClueCard.tsx (#581)
+ */
+
+import React from "react"
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PreviewClueCard } from "@/components/PreviewClueCard"
+import type { Clue } from "@/lib/types"
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// matchesClueAnswer returns true when the answer matches "4" or "paris"
+vi.mock("@/lib/clueAnswerVerification", () => ({
+  matchesClueAnswer: vi.fn(async (candidate: string) => {
+    const correct = ["4", "paris"]
+    return correct.includes(candidate.trim().toLowerCase())
+  }),
+}))
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const baseClue: Clue = {
+  id: 1,
+  huntId: 42,
+  question: "What is 2 + 2?",
+  answer: "4",
+  points: 10,
+  difficulty: "Easy",
+}
+
+const hintedClue: Clue = {
+  ...baseClue,
+  hint: "It's a single digit",
+  hintCost: 2,
+}
+
+function renderCard(clue: Clue = baseClue, isSolved = false) {
+  const onSolve = vi.fn()
+  const onWrongAnswer = vi.fn()
+  const onReset = vi.fn()
+  const user = userEvent.setup()
+
+  const utils = render(
+    <PreviewClueCard
+      clue={clue}
+      huntId={42}
+      clueIndex={0}
+      totalClues={3}
+      isSolved={isSolved}
+      onSolve={onSolve}
+      onWrongAnswer={onWrongAnswer}
+      onReset={onReset}
+    />
+  )
+
+  return { ...utils, user, onSolve, onWrongAnswer, onReset }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PreviewClueCard — rendering", () => {
+  it("shows the clue question", () => {
+    renderCard()
+    expect(screen.getByText("What is 2 + 2?")).toBeInTheDocument()
+  })
+
+  it("shows clue progress (1 / 3)", () => {
+    renderCard()
+    expect(screen.getByText(/Clue 1 \/ 3/i)).toBeInTheDocument()
+  })
+
+  it("shows difficulty badge", () => {
+    renderCard()
+    expect(screen.getByText("Easy")).toBeInTheDocument()
+  })
+
+  it("shows points badge", () => {
+    renderCard()
+    expect(screen.getByText("10 pts")).toBeInTheDocument()
+  })
+
+  it("renders answer input when not solved", () => {
+    renderCard()
+    expect(screen.getByPlaceholderText(/type your answer/i)).toBeInTheDocument()
+  })
+
+  it("shows solved state and hides input when isSolved=true", () => {
+    renderCard(baseClue, true)
+    expect(screen.getByText(/Correct!/i)).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/type your answer/i)).not.toBeInTheDocument()
+  })
+
+  it("shows reset button when solved", () => {
+    renderCard(baseClue, true)
+    expect(screen.getByLabelText(/reset this clue/i)).toBeInTheDocument()
+  })
+})
+
+describe("PreviewClueCard — answer submission", () => {
+  it("calls onSolve with the correct answer", async () => {
+    const { user, onSolve } = renderCard()
+    await user.type(screen.getByPlaceholderText(/type your answer/i), "4")
+    await user.click(screen.getByRole("button", { name: /submit answer/i }))
+    await waitFor(() => expect(onSolve).toHaveBeenCalledWith("4"))
+  })
+
+  it("calls onWrongAnswer on an incorrect submission", async () => {
+    const { user, onWrongAnswer } = renderCard()
+    await user.type(screen.getByPlaceholderText(/type your answer/i), "wrong")
+    await user.click(screen.getByRole("button", { name: /submit answer/i }))
+    await waitFor(() => expect(onWrongAnswer).toHaveBeenCalledWith("wrong"))
+  })
+
+  it("shows wrong-answer feedback message", async () => {
+    const { user } = renderCard()
+    await user.type(screen.getByPlaceholderText(/type your answer/i), "wrong")
+    await user.click(screen.getByRole("button", { name: /submit answer/i }))
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/not quite right/i)
+    )
+  })
+
+  it("submit button is disabled when input is empty", () => {
+    renderCard()
+    const btn = screen.getByRole("button", { name: /submit answer/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it("submits on Enter key", async () => {
+    const { user, onSolve } = renderCard()
+    const input = screen.getByPlaceholderText(/type your answer/i)
+    await user.type(input, "4")
+    await user.keyboard("{Enter}")
+    await waitFor(() => expect(onSolve).toHaveBeenCalled())
+  })
+})
+
+describe("PreviewClueCard — hint panel", () => {
+  it("does not show hint button when clue has no hint", () => {
+    renderCard(baseClue)
+    expect(screen.queryByRole("button", { name: /show hint/i })).not.toBeInTheDocument()
+  })
+
+  it("shows hint button when clue has a hint", () => {
+    renderCard(hintedClue)
+    expect(screen.getByRole("button", { name: /show hint/i })).toBeInTheDocument()
+  })
+
+  it("toggles hint panel on click", async () => {
+    const { user } = renderCard(hintedClue)
+    const hintBtn = screen.getByRole("button", { name: /show hint/i })
+    await user.click(hintBtn)
+    expect(screen.getByText("It's a single digit")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /hide hint/i }))
+    await waitFor(() =>
+      expect(screen.queryByText("It's a single digit")).not.toBeInTheDocument()
+    )
+  })
+
+  it("shows hint cost info", async () => {
+    const { user } = renderCard(hintedClue)
+    await user.click(screen.getByRole("button", { name: /show hint/i }))
+    expect(screen.getByText(/hint cost for players: 2/i)).toBeInTheDocument()
+  })
+})
+
+describe("PreviewClueCard — reveal answer panel", () => {
+  it("shows Reveal Answer button", () => {
+    renderCard()
+    expect(screen.getByRole("button", { name: /reveal answer/i })).toBeInTheDocument()
+  })
+
+  it("shows the actual answer when toggled", async () => {
+    const { user } = renderCard()
+    await user.click(screen.getByRole("button", { name: /reveal answer/i }))
+    expect(screen.getByText(baseClue.answer)).toBeInTheDocument()
+  })
+
+  it("toggles back to hide", async () => {
+    const { user } = renderCard()
+    await user.click(screen.getByRole("button", { name: /reveal answer/i }))
+    await user.click(screen.getByRole("button", { name: /hide answer/i }))
+    await waitFor(() =>
+      expect(screen.queryByText("Answer (creator only)")).not.toBeInTheDocument()
+    )
+  })
+})
+
+describe("PreviewClueCard — reset button", () => {
+  it("calls onReset when reset is clicked while solved", async () => {
+    const { user, onReset } = renderCard(baseClue, true)
+    await user.click(screen.getByLabelText(/reset this clue/i))
+    expect(onReset).toHaveBeenCalledOnce()
+  })
+})

--- a/lib/__tests__/previewStore.test.ts
+++ b/lib/__tests__/previewStore.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for lib/previewStore.ts (#581)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { StoredHunt, Clue } from "@/lib/types"
+
+// ─── Mock huntStore ───────────────────────────────────────────────────────────
+
+const mockHunt: StoredHunt = {
+  id: 42,
+  title: "Test Hunt",
+  description: "A test hunt for preview",
+  cluesCount: 2,
+  status: "Draft",
+  rewardType: "XLM",
+}
+
+const mockClues: Clue[] = [
+  { id: 1, huntId: 42, question: "What is 2+2?", answer: "4", points: 10 },
+  { id: 2, huntId: 42, question: "Capital of France?", answer: "paris", points: 20 },
+]
+
+vi.mock("@/lib/huntStore", () => ({
+  getHuntById: vi.fn((id: number) => (id === 42 ? mockHunt : undefined)),
+  getHuntClues: vi.fn((huntId: number) => (huntId === 42 ? mockClues : [])),
+}))
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import {
+  createPreviewSession,
+  advancePreviewSession,
+  recordWrongAttempt,
+  resetPreviewSession,
+  buildPreviewUrl,
+  VIEWPORT_LABELS,
+  VIEWPORT_WIDTHS,
+  type PreviewSession,
+} from "@/lib/previewStore"
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSession(): PreviewSession {
+  const s = createPreviewSession(42)
+  if (!s) throw new Error("Session should not be null")
+  return s
+}
+
+// ─── createPreviewSession ─────────────────────────────────────────────────────
+
+describe("createPreviewSession", () => {
+  it("returns null when hunt does not exist", () => {
+    expect(createPreviewSession(999)).toBeNull()
+  })
+
+  it("creates a session with the correct hunt", () => {
+    const session = makeSession()
+    expect(session.huntId).toBe(42)
+    expect(session.hunt.title).toBe("Test Hunt")
+  })
+
+  it("populates clues from huntStore", () => {
+    const session = makeSession()
+    expect(session.clues).toHaveLength(2)
+    expect(session.clues[0].clue.question).toBe("What is 2+2?")
+  })
+
+  it("starts at clue index 0 with 0 points and not complete", () => {
+    const session = makeSession()
+    expect(session.currentClueIndex).toBe(0)
+    expect(session.totalPoints).toBe(0)
+    expect(session.isComplete).toBe(false)
+  })
+
+  it("marks all clues as unsolved initially", () => {
+    const session = makeSession()
+    expect(session.clues.every((cs) => !cs.solved)).toBe(true)
+  })
+
+  it("sets startedAt to an ISO date string", () => {
+    const session = makeSession()
+    expect(() => new Date(session.startedAt)).not.toThrow()
+    expect(new Date(session.startedAt).getFullYear()).toBeGreaterThan(2024)
+  })
+})
+
+// ─── advancePreviewSession ────────────────────────────────────────────────────
+
+describe("advancePreviewSession", () => {
+  it("marks the solved clue and advances the index", () => {
+    const session = makeSession()
+    const next = advancePreviewSession(session, 0, "4")
+    expect(next.clues[0].solved).toBe(true)
+    expect(next.currentClueIndex).toBe(1)
+  })
+
+  it("adds the clue's points to totalPoints", () => {
+    const session = makeSession()
+    const next = advancePreviewSession(session, 0, "4")
+    expect(next.totalPoints).toBe(10)
+  })
+
+  it("sets isComplete when the last clue is solved", () => {
+    const session = makeSession()
+    const after1 = advancePreviewSession(session, 0, "4")
+    const after2 = advancePreviewSession(after1, 1, "paris")
+    expect(after2.isComplete).toBe(true)
+    expect(after2.totalPoints).toBe(30)
+  })
+
+  it("does not advance past the last clue index on completion", () => {
+    const session = makeSession()
+    const after1 = advancePreviewSession(session, 0, "4")
+    const after2 = advancePreviewSession(after1, 1, "paris")
+    // currentClueIndex stays at last clue (not out-of-bounds)
+    expect(after2.currentClueIndex).toBe(1)
+  })
+
+  it("records the answer string", () => {
+    const session = makeSession()
+    const next = advancePreviewSession(session, 0, "four")
+    expect(next.clues[0].lastAttempt).toBe("four")
+    expect(next.clues[0].lastAttemptCorrect).toBe(true)
+  })
+
+  it("does not mutate the original session (immutability)", () => {
+    const session = makeSession()
+    advancePreviewSession(session, 0, "4")
+    expect(session.clues[0].solved).toBe(false)
+  })
+})
+
+// ─── recordWrongAttempt ───────────────────────────────────────────────────────
+
+describe("recordWrongAttempt", () => {
+  it("does not mark the clue as solved", () => {
+    const session = makeSession()
+    const next = recordWrongAttempt(session, 0, "wrong")
+    expect(next.clues[0].solved).toBe(false)
+  })
+
+  it("records the wrong answer", () => {
+    const session = makeSession()
+    const next = recordWrongAttempt(session, 0, "wrong")
+    expect(next.clues[0].lastAttempt).toBe("wrong")
+    expect(next.clues[0].lastAttemptCorrect).toBe(false)
+  })
+
+  it("does not change totalPoints", () => {
+    const session = makeSession()
+    const next = recordWrongAttempt(session, 0, "nope")
+    expect(next.totalPoints).toBe(0)
+  })
+
+  it("does not mutate the original session", () => {
+    const session = makeSession()
+    recordWrongAttempt(session, 0, "wrong")
+    expect(session.clues[0].lastAttempt).toBeUndefined()
+  })
+})
+
+// ─── resetPreviewSession ──────────────────────────────────────────────────────
+
+describe("resetPreviewSession", () => {
+  it("resets all clues to unsolved", () => {
+    const session = makeSession()
+    const advanced = advancePreviewSession(session, 0, "4")
+    const reset = resetPreviewSession(advanced)
+    expect(reset.clues.every((cs) => !cs.solved)).toBe(true)
+  })
+
+  it("resets totalPoints to 0", () => {
+    const session = makeSession()
+    const advanced = advancePreviewSession(session, 0, "4")
+    const reset = resetPreviewSession(advanced)
+    expect(reset.totalPoints).toBe(0)
+  })
+
+  it("resets currentClueIndex to 0", () => {
+    const session = makeSession()
+    const advanced = advancePreviewSession(session, 0, "4")
+    const reset = resetPreviewSession(advanced)
+    expect(reset.currentClueIndex).toBe(0)
+  })
+
+  it("sets isComplete to false", () => {
+    let session = makeSession()
+    session = advancePreviewSession(session, 0, "4")
+    session = advancePreviewSession(session, 1, "paris")
+    expect(session.isComplete).toBe(true)
+    const reset = resetPreviewSession(session)
+    expect(reset.isComplete).toBe(false)
+  })
+
+  it("preserves hunt and huntId", () => {
+    const session = makeSession()
+    const reset = resetPreviewSession(session)
+    expect(reset.huntId).toBe(42)
+    expect(reset.hunt.title).toBe("Test Hunt")
+  })
+})
+
+// ─── buildPreviewUrl ──────────────────────────────────────────────────────────
+
+describe("buildPreviewUrl", () => {
+  it("builds a URL with the hunt ID", () => {
+    const url = buildPreviewUrl(42, "https://hunty.app")
+    expect(url).toBe("https://hunty.app/hunt/42/preview")
+  })
+
+  it("uses window.location.origin when no base is provided", () => {
+    // jsdom sets window.location.origin to "http://localhost:3000" in tests
+    const url = buildPreviewUrl(7)
+    expect(url).toContain("/hunt/7/preview")
+  })
+})
+
+// ─── VIEWPORT_LABELS / VIEWPORT_WIDTHS ───────────────────────────────────────
+
+describe("viewport constants", () => {
+  it("has entries for mobile, tablet, desktop", () => {
+    expect(VIEWPORT_LABELS).toHaveProperty("mobile")
+    expect(VIEWPORT_LABELS).toHaveProperty("tablet")
+    expect(VIEWPORT_LABELS).toHaveProperty("desktop")
+  })
+
+  it("desktop width is null (full width)", () => {
+    expect(VIEWPORT_WIDTHS.desktop).toBeNull()
+  })
+
+  it("mobile width is 375", () => {
+    expect(VIEWPORT_WIDTHS.mobile).toBe(375)
+  })
+
+  it("tablet width is 768", () => {
+    expect(VIEWPORT_WIDTHS.tablet).toBe(768)
+  })
+})

--- a/lib/previewStore.ts
+++ b/lib/previewStore.ts
@@ -1,0 +1,168 @@
+/**
+ * Preview store for hunt preview mode (#581).
+ *
+ * Provides in-memory state for a creator's dry-run preview of a hunt,
+ * using local clues from huntStore rather than Soroban contracts.
+ * No data is persisted — every navigation to the preview page starts fresh.
+ */
+
+import type { Clue, StoredHunt } from "@/lib/types"
+import { getHuntById, getHuntClues } from "@/lib/huntStore"
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface PreviewClueState {
+  clue: Clue
+  /** Whether the creator has solved this clue in the preview session. */
+  solved: boolean
+  /** Most recent answer attempt (for feedback display). */
+  lastAttempt?: string
+  /** Whether the last attempt was correct. */
+  lastAttemptCorrect?: boolean
+}
+
+export interface PreviewSession {
+  huntId: number
+  hunt: StoredHunt
+  clues: PreviewClueState[]
+  /** Index of the currently displayed clue. */
+  currentClueIndex: number
+  /** Total points accumulated during preview. */
+  totalPoints: number
+  /** Whether the preview is complete (all clues solved). */
+  isComplete: boolean
+  /** ISO timestamp when the preview session started. */
+  startedAt: string
+}
+
+export type PreviewViewport = "mobile" | "tablet" | "desktop"
+
+// ─── Session creation ─────────────────────────────────────────────────────────
+
+/**
+ * Creates a new preview session for a hunt.
+ * Returns null when the hunt or its clues are not found in local storage.
+ */
+export function createPreviewSession(huntId: number): PreviewSession | null {
+  const hunt = getHuntById(huntId)
+  if (!hunt) return null
+
+  const clues = getHuntClues(huntId)
+
+  return {
+    huntId,
+    hunt,
+    clues: clues.map((clue) => ({ clue, solved: false })),
+    currentClueIndex: 0,
+    totalPoints: 0,
+    isComplete: false,
+    startedAt: new Date().toISOString(),
+  }
+}
+
+// ─── Session manipulation (pure functions, no side effects) ──────────────────
+
+/** Advance the session to the next clue after a correct answer. */
+export function advancePreviewSession(
+  session: PreviewSession,
+  clueIndex: number,
+  answer: string,
+): PreviewSession {
+  const updatedClues = session.clues.map((cs, i) => {
+    if (i !== clueIndex) return cs
+    const pointsAwarded = cs.clue.points ?? 0
+    return {
+      ...cs,
+      solved: true,
+      lastAttempt: answer,
+      lastAttemptCorrect: true,
+      pointsAwarded,
+    }
+  })
+
+  const pointsAwarded = session.clues[clueIndex]?.clue.points ?? 0
+  const totalPoints = session.totalPoints + pointsAwarded
+
+  const nextIndex = Math.min(clueIndex + 1, session.clues.length - 1)
+  const isComplete = clueIndex >= session.clues.length - 1
+
+  return {
+    ...session,
+    clues: updatedClues,
+    currentClueIndex: isComplete ? clueIndex : nextIndex,
+    totalPoints,
+    isComplete,
+  }
+}
+
+/** Record a wrong answer attempt without advancing. */
+export function recordWrongAttempt(
+  session: PreviewSession,
+  clueIndex: number,
+  answer: string,
+): PreviewSession {
+  const updatedClues = session.clues.map((cs, i) => {
+    if (i !== clueIndex) return cs
+    return {
+      ...cs,
+      lastAttempt: answer,
+      lastAttemptCorrect: false,
+    }
+  })
+
+  return { ...session, clues: updatedClues }
+}
+
+/** Reset the session back to the beginning. */
+export function resetPreviewSession(session: PreviewSession): PreviewSession {
+  return {
+    ...session,
+    clues: session.clues.map((cs) => ({
+      clue: cs.clue,
+      solved: false,
+    })),
+    currentClueIndex: 0,
+    totalPoints: 0,
+    isComplete: false,
+    startedAt: new Date().toISOString(),
+  }
+}
+
+// ─── Share link helpers ───────────────────────────────────────────────────────
+
+/** Builds the absolute preview URL for sharing with collaborators. */
+export function buildPreviewUrl(huntId: number, baseUrl?: string): string {
+  const base =
+    baseUrl ??
+    (typeof window !== "undefined" ? window.location.origin : "https://hunty.app")
+  return `${base}/hunt/${huntId}/preview`
+}
+
+/**
+ * Copies the preview URL to the clipboard and returns true on success.
+ * No-ops on non-browser environments.
+ */
+export async function copyPreviewUrlToClipboard(huntId: number): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) return false
+  try {
+    const url = buildPreviewUrl(huntId)
+    await navigator.clipboard.writeText(url)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// ─── Viewport helpers ─────────────────────────────────────────────────────────
+
+export const VIEWPORT_LABELS: Record<PreviewViewport, string> = {
+  mobile: "Mobile (375px)",
+  tablet: "Tablet (768px)",
+  desktop: "Desktop (full)",
+}
+
+export const VIEWPORT_WIDTHS: Record<PreviewViewport, number | null> = {
+  mobile: 375,
+  tablet: 768,
+  desktop: null,
+}


### PR DESCRIPTION
closes #581 
Allow creators to preview their hunt exactly as players will see it before publishing.

- Add lib/previewStore.ts: pure in-memory session state, dry-run answer validation, viewport helpers, share-link utilities
- Add components/PreviewClueCard.tsx: creator-only clue card with local answer validation (no contract calls, nothing persisted), hint toggle, answer reveal, shake animation on wrong answers
- Add components/PreviewPageClient.tsx: full-page preview UI with hunt landing overview, clue step-through, viewport simulator (mobile/tablet/desktop), share-link banner, and completion screen
- Add app/hunt/[id]/preview/page.tsx: Next.js route at /hunt/:id/preview
- Wire up Preview button in HuntDashboard (draft cards with clues)
- Wire up Preview link in creator page (draft cards)
- Wire up Preview button in GamePreview editor sidebar (?edit=ID)
- Add unit tests: previewStore (24 tests), PreviewClueCard (18 tests)