### PR TITLE
feat: wallet address display and copy functionality (Closes #566)

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -9,6 +9,8 @@ import { Header } from "@/components/Header"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { WalletContext, shortenAddress } from "@/lib/context/WalletContext"
+import { WalletAddress } from "@/components/WalletAddress"
+import { WalletIdenticon } from "@/components/WalletIdenticon"
 import { NftGallery } from "@/components/NftGallery"
 import { BadgeWall } from "@/components/BadgeWall"
 import { LevelBadge, LevelProgress } from "@/components/LevelBadge"
@@ -323,12 +325,20 @@ export default function UserProfilePage() {
           </div>
 
           <Card className="border border-slate-200 bg-white/70 shadow-sm px-4 py-3 flex items-center gap-3 max-w-sm">
-            <div className="h-11 w-11 rounded-full bg-gradient-to-br from-[#3737A4] to-[#0C0C4F] text-white grid place-items-center font-semibold text-sm">
-              {avatarLabel}
-            </div>
-            <div className="flex flex-col gap-1">
+            {publicKey ? (
+              <WalletIdenticon address={publicKey} size={44} className="flex-shrink-0" />
+            ) : (
+              <div className="h-11 w-11 rounded-full bg-gradient-to-br from-[#3737A4] to-[#0C0C4F] text-white grid place-items-center font-semibold text-sm">
+                {avatarLabel}
+              </div>
+            )}
+            <div className="flex flex-col gap-1 min-w-0">
               <div className="text-xs uppercase tracking-wide text-slate-500">Connected Wallet</div>
-              <div className="font-mono text-sm text-slate-800 break-all">{displayAddress}</div>
+              {publicKey ? (
+                <WalletAddress address={publicKey} showIdenticon={false} addressClassName="text-slate-800" />
+              ) : (
+                <div className="font-mono text-sm text-slate-800 break-all">{displayAddress}</div>
+              )}
             </div>
           </Card>
         </div>

--- a/components/CompletedHuntCard.tsx
+++ b/components/CompletedHuntCard.tsx
@@ -3,6 +3,7 @@
 import React from "react"
 import Link from "next/link"
 import { HuntCoverImage } from "@/components/HuntCoverImage"
+import { truncateAddress } from "@/lib/walletAddress"
 import type { StoredHunt } from "@/lib/types"
 
 interface CompletedHuntCardProps {
@@ -16,11 +17,8 @@ interface CompletedHuntCardProps {
   winnerAddress?: string
 }
 
-/** Truncates a Stellar address to `G…XXXX` form (5 + 4 chars). */
-function truncateAddress(address: string): string {
-  if (address.length <= 10) return address
-  return `${address.slice(0, 5)}…${address.slice(-4)}`
-}
+/** This card has always used a 5 + 4 split with a single-character ellipsis. */
+const WINNER_ADDRESS_FORMAT = { lead: 5, tail: 4, separator: "…" }
 
 function rewardBadgeClass(rewardType: StoredHunt["rewardType"]): string {
   if (rewardType === "XLM") return "bg-green-50 text-green-700"
@@ -69,7 +67,7 @@ export function CompletedHuntCard({ hunt, winnerAddress }: CompletedHuntCardProp
               aria-label={`Winner: ${winnerAddress}`}
               className="font-mono"
             >
-              {truncateAddress(winnerAddress)}
+              {truncateAddress(winnerAddress, WINNER_ADDRESS_FORMAT)}
             </span>
           </p>
         )}

--- a/components/FastestPlayersStrip.tsx
+++ b/components/FastestPlayersStrip.tsx
@@ -6,15 +6,14 @@ import Medal from "@/components/icons/Medal"
 import { get_hunt_fastest_players } from "@/lib/contracts/hunt"
 import type { FastestPlayerDisplayEntry } from "@/lib/types"
 import { logger } from "@/lib/logger"
+import { truncateAddress } from "@/lib/walletAddress"
 
 interface FastestPlayersStripProps {
   huntId: number
 }
 
-const truncateAddress = (address: string) => {
-  if (address.length <= 10) return address
-  return `${address.slice(0, 5)}...${address.slice(-4)}`
-}
+/** This strip has always used a 5 + 4 split. */
+const PLAYER_ADDRESS_FORMAT = { lead: 5, tail: 4 }
 
 const formatDuration = (seconds: number) => {
   const hh = Math.floor(seconds / 3600)
@@ -44,7 +43,7 @@ export function FastestPlayersStrip({ huntId }: FastestPlayersStripProps) {
       const sorted = [...rawPlayers].sort((a, b) => a.completionTimeSeconds - b.completionTimeSeconds)
       const mapped: FastestPlayerDisplayEntry[] = sorted.map((player, index) => ({
         position: index + 1,
-        name: player.name || truncateAddress(player.address),
+        name: player.name || truncateAddress(player.address, PLAYER_ADDRESS_FORMAT),
         completionTimeLabel: formatDuration(player.completionTimeSeconds),
         points: player.points,
         icon: <Medal position={index + 1} />,

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,6 +9,10 @@ import { useIsMounted } from "@/hooks/useIsMounted";
 import { useWallet } from "@/lib/context/WalletContext";
 import { WalletSelectionModal } from "./WalletSelectionModal";
 import { ThemeToggle } from "./ThemeToggle";
+import { WalletAddress } from "./WalletAddress";
+import { WalletIdenticon } from "./WalletIdenticon";
+import { getStellarAccountExplorerUrl } from "@/lib/walletAddress";
+import { toast } from "sonner";
 import {
   Copy,
   LogOut,
@@ -24,6 +28,7 @@ import {
   ChevronDown,
   Gamepad2,
   HelpCircle,
+  ExternalLink,
 } from "lucide-react";
 import { getUnreadNotificationCount } from "@/lib/notifications/rankTracker"
 import { createWeeklyDigestNotification, shouldSendWeeklyDigest } from "@/lib/notifications/weeklyDigest"
@@ -198,6 +203,7 @@ function MobileMenu({
   onClose,
   connected,
   displayKey,
+  publicKey,
   onConnectWallet,
   onDisconnect,
   balance,
@@ -206,6 +212,7 @@ function MobileMenu({
   onClose: () => void;
   connected: boolean;
   displayKey: string;
+  publicKey: string;
   onConnectWallet: () => void;
   onDisconnect: () => void;
   balance: string;
@@ -247,7 +254,16 @@ function MobileMenu({
           <div className="rounded-2xl border border-slate-200 dark:border-white/10 overflow-hidden">
             <div className="px-4 py-3 bg-gradient-to-r from-[#0C0C4F] to-[#4A4AFF]">
               <p className="text-xs text-blue-200 font-medium mb-0.5">Connected</p>
-              <p className="text-white font-mono text-sm truncate">{displayKey}</p>
+              {publicKey ? (
+                <WalletAddress
+                  address={publicKey}
+                  identiconSize={20}
+                  className="text-white [&_button]:text-blue-200 [&_a]:text-blue-200"
+                  addressClassName="text-white"
+                />
+              ) : (
+                <p className="text-white font-mono text-sm truncate">{displayKey}</p>
+              )}
             </div>
             <div className="flex items-center justify-between px-4 py-3 bg-slate-50 dark:bg-slate-900">
               <div className="flex items-center gap-2">
@@ -333,9 +349,18 @@ export function Header({ balance = "0" }: { balance?: string }) {
   }, []);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(publicKey);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (!publicKey) return;
+
+    try {
+      await navigator.clipboard.writeText(publicKey);
+      setCopied(true);
+      toast.success("Wallet address copied");
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard access is refused on insecure origins and in some in-app
+      // browsers, so surface it instead of leaving the click looking ignored.
+      toast.error("Couldn't copy the address. Select and copy it manually.");
+    }
   };
 
   const handleDisconnect = () => {
@@ -466,11 +491,16 @@ export function Header({ balance = "0" }: { balance?: string }) {
                         "linear-gradient(var(--background), var(--background)) padding-box, linear-gradient(to right, #0C0C4F, #4A4AFF) border-box",
                     }}
                   >
-                    <div className="w-5 h-5 rounded-full bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] flex-shrink-0" />
+                    {publicKey ? (
+                      <WalletIdenticon address={publicKey} size={20} className="flex-shrink-0" />
+                    ) : (
+                      <div className="w-5 h-5 rounded-full bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] flex-shrink-0" />
+                    )}
                     <span className="font-bold text-sm bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] text-transparent bg-clip-text truncate max-w-[100px] lg:max-w-[140px]">
                       {displayKey}
                     </span>
                     <ChevronDown
+                      data-testid="wallet-chevron"
                       className={cn(
                         "w-3.5 h-3.5 text-[#3737A4] transition-transform duration-150",
                         dropdownOpen && "rotate-180"
@@ -481,12 +511,21 @@ export function Header({ balance = "0" }: { balance?: string }) {
                   {/* Wallet dropdown */}
                   {dropdownOpen && (
                     <div className="absolute right-0 mt-2 w-72 rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-950 shadow-xl z-50 overflow-hidden">
-                      <div className="px-4 py-3 bg-gradient-to-r from-[#0C0C4F] to-[#4A4AFF]">
-                        <p className="text-xs text-blue-200 font-medium mb-0.5">Connected wallet</p>
-                        <p className="text-[11px] uppercase tracking-wide text-blue-200/80 mb-1">
-                          {walletProvider ?? "freighter"}
-                        </p>
-                        <p className="text-white font-mono text-xs break-all">{publicKey}</p>
+                      <div className="px-4 py-3 bg-gradient-to-r from-[#0C0C4F] to-[#4A4AFF] flex items-start gap-3">
+                        {publicKey && (
+                          <WalletIdenticon
+                            address={publicKey}
+                            size={36}
+                            className="flex-shrink-0 mt-0.5 ring-2 ring-white/25"
+                          />
+                        )}
+                        <div className="min-w-0">
+                          <p className="text-xs text-blue-200 font-medium mb-0.5">Connected wallet</p>
+                          <p className="text-[11px] uppercase tracking-wide text-blue-200/80 mb-1">
+                            {walletProvider ?? "freighter"}
+                          </p>
+                          <p className="text-white font-mono text-xs break-all">{publicKey}</p>
+                        </div>
                       </div>
                       <div className="p-2 flex flex-col gap-1">
                         <button
@@ -501,6 +540,19 @@ export function Header({ balance = "0" }: { balance?: string }) {
                           )}
                           {copied ? "Copied!" : "Copy address"}
                         </button>
+
+                        {publicKey && (
+                          <a
+                            href={getStellarAccountExplorerUrl(publicKey)}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            aria-label="View wallet address on Stellar explorer"
+                            className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-white/5 transition-colors text-left"
+                          >
+                            <ExternalLink className="w-4 h-4 text-slate-400 flex-shrink-0" />
+                            <span>View on explorer</span>
+                          </a>
+                        )}
 
                         <button
                           onClick={() => {
@@ -559,6 +611,7 @@ export function Header({ balance = "0" }: { balance?: string }) {
         onClose={() => setMobileOpen(false)}
         connected={connected}
         displayKey={displayKey}
+        publicKey={publicKey}
         onConnectWallet={() => setModalOpen(true)}
         onDisconnect={disconnect}
         balance={balance}

--- a/components/LeaderBoardTable.tsx
+++ b/components/LeaderBoardTable.tsx
@@ -11,6 +11,9 @@ import { EmptyState } from "@/components/EmptyState"
 import { Trophy } from "lucide-react"
 import { SeasonInfo } from "@/components/SeasonInfo"
 import { useWalletStore } from "@/store/useStore"
+import { WalletAddress } from "@/components/WalletAddress"
+import { WalletIdenticon } from "@/components/WalletIdenticon"
+import { truncateAddress } from "@/lib/walletAddress"
 import { detectRankChanges } from "@/lib/notifications/rankTracker"
 import { handleRankNotifications } from "@/lib/notifications/notificationService"
 import type { LeaderboardDisplayEntry, LeaderboardFilters } from "@/lib/types"
@@ -48,11 +51,6 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
   const [activeSeason, setActiveSeason] = useState<ReturnType<typeof getActiveSeason>>(null)
   const walletAddress = useWalletStore((s: { walletAddress: string }) => s.walletAddress)
 
-  const truncateAddress = (address: string) => {
-    if (address.length <= 8) return address
-    return `${address.slice(0, 3)}...${address.slice(-3)}`
-  }
-
   const fetchLeaderboard = useCallback(async () => {
     if (huntId === undefined) return
 
@@ -81,6 +79,8 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
         completedAt: entry.completedAt,
         category: entry.category,
         difficulty: entry.difficulty,
+        address: entry.address,
+        hasDisplayName: Boolean(entry.name),
         icon: <Medal position={index + 1} />,
       }))
 
@@ -185,7 +185,32 @@ function LeaderboardTableComponent({ huntId, data: initialData, isLoading: initi
                     <span>{entry.icon}</span>
                     <span className="text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">{entry.position}</span>
                   </td>
-                  <td className="px-4 py-2 border-r-2 border-[#808080] dark:border-slate-700 border-b-2 text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">{entry.name}</td>
+                  <td className="px-4 py-2 border-r-2 border-[#808080] dark:border-slate-700 border-b-2">
+                    {entry.address ? (
+                      <div className="flex items-center gap-2 min-w-0">
+                        <WalletIdenticon address={entry.address} size={26} className="flex-shrink-0" />
+                        <div className="flex flex-col min-w-0">
+                          {entry.hasDisplayName && (
+                            <span className="text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">
+                              {entry.name}
+                            </span>
+                          )}
+                          <WalletAddress
+                            address={entry.address}
+                            showIdenticon={false}
+                            addressClassName={cn(
+                              "text-slate-500 dark:text-slate-400",
+                              entry.hasDisplayName ? "text-xs" : "text-sm",
+                            )}
+                          />
+                        </div>
+                      </div>
+                    ) : (
+                      <span className="text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">
+                        {entry.name}
+                      </span>
+                    )}
+                  </td>
                   <td className="px-4 py-2 text-center border border-b-2 border-[#808080] dark:border-slate-700 text-[16px] bg-gradient-to-b from-[#576065] to-[#787884] dark:from-slate-200 dark:to-slate-400 bg-clip-text text-transparent">
                     {filters.metric === "completions" ? (entry.completionCount ?? 0) : entry.points}
                   </td>

--- a/components/WalletAddress.tsx
+++ b/components/WalletAddress.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Check, Copy, ExternalLink } from "lucide-react"
+import { toast } from "sonner"
+import { cn } from "@/lib/utils"
+import { WalletIdenticon } from "@/components/WalletIdenticon"
+import { getStellarAccountExplorerUrl, truncateAddress } from "@/lib/walletAddress"
+
+const COPIED_RESET_MS = 2000
+
+interface WalletAddressProps {
+  /** Full Stellar address. Nothing renders when this is empty. */
+  address: string
+  /** Characters kept at the start of the truncated form. Default 4. */
+  lead?: number
+  /** Characters kept at the end of the truncated form. Default 4. */
+  tail?: number
+  /** Show the derived avatar. Default true. */
+  showIdenticon?: boolean
+  /** Avatar size in pixels. Default 24. */
+  identiconSize?: number
+  /** Show the copy button. Default true. */
+  showCopyButton?: boolean
+  /** Show the stellar.expert link. Default true. */
+  showExplorerLink?: boolean
+  /** Wrapper classes. */
+  className?: string
+  /** Classes for the address text itself, for callers that need a different size. */
+  addressClassName?: string
+}
+
+/**
+ * Connected-wallet address with the three affordances users expect next to it:
+ * a derived avatar, one-click copy, and a link out to stellar.expert.
+ *
+ * Used by the header, the profile page, and the leaderboard so all three stay
+ * in sync — including the truncation format.
+ */
+export function WalletAddress({
+  address,
+  lead = 4,
+  tail = 4,
+  showIdenticon = true,
+  identiconSize = 24,
+  showCopyButton = true,
+  showExplorerLink = true,
+  className,
+  addressClassName,
+}: WalletAddressProps) {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // The "Copied!" tick outlives the click, so it has to be cancelled if the
+  // component unmounts first — leaderboard rows come and go on every refresh.
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+    }
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    if (!address) return
+
+    try {
+      await navigator.clipboard.writeText(address)
+
+      setCopied(true)
+      toast.success("Wallet address copied")
+
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+      resetTimer.current = setTimeout(() => setCopied(false), COPIED_RESET_MS)
+    } catch {
+      // Clipboard access is refused on insecure origins and in some in-app
+      // browsers. Tell the user rather than silently doing nothing.
+      toast.error("Couldn't copy the address. Select and copy it manually.")
+    }
+  }, [address])
+
+  if (!address) return null
+
+  const truncated = truncateAddress(address, { lead, tail })
+
+  return (
+    <span className={cn("inline-flex items-center gap-2 min-w-0", className)}>
+      {showIdenticon && (
+        <WalletIdenticon address={address} size={identiconSize} className="flex-shrink-0" />
+      )}
+
+      <span
+        title={address}
+        className={cn("font-mono text-sm truncate", addressClassName)}
+        data-testid="wallet-address-text"
+      >
+        {truncated}
+      </span>
+
+      {showCopyButton && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy wallet address"
+          className="flex-shrink-0 p-1 rounded-md text-slate-400 hover:text-[#3737A4] dark:hover:text-indigo-400 hover:bg-slate-100 dark:hover:bg-white/5 transition-colors"
+        >
+          {copied ? (
+            <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
+          ) : (
+            <Copy className="w-3.5 h-3.5" aria-hidden="true" />
+          )}
+        </button>
+      )}
+
+      {showExplorerLink && (
+        <a
+          href={getStellarAccountExplorerUrl(address)}
+          target="_blank"
+          rel="noreferrer noopener"
+          aria-label="View wallet address on Stellar explorer"
+          className="flex-shrink-0 p-1 rounded-md text-slate-400 hover:text-[#3737A4] dark:hover:text-indigo-400 hover:bg-slate-100 dark:hover:bg-white/5 transition-colors"
+        >
+          <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+        </a>
+      )}
+    </span>
+  )
+}

--- a/components/WalletIdenticon.tsx
+++ b/components/WalletIdenticon.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useMemo } from "react"
+import { cn } from "@/lib/utils"
+import { getIdenticonSpec } from "@/lib/walletAddress"
+
+interface WalletIdenticonProps {
+  /** Full Stellar address the avatar is derived from. */
+  address: string
+  /** Rendered width and height in pixels. Default 24. */
+  size?: number
+  className?: string
+}
+
+/**
+ * Deterministic avatar for a wallet address, rendered as inline SVG.
+ *
+ * Same address always produces the same image, with no network request and no
+ * extra dependency, so it is safe to render during SSR and inside long lists
+ * such as the leaderboard.
+ *
+ * Decorative by design: every caller shows the address as text next to it, so
+ * the image is hidden from assistive tech rather than duplicating that label.
+ */
+export function WalletIdenticon({ address, size = 24, className }: WalletIdenticonProps) {
+  const { cells, size: grid, foreground, background } = useMemo(
+    () => getIdenticonSpec(address),
+    [address],
+  )
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${grid} ${grid}`}
+      shapeRendering="crispEdges"
+      aria-hidden="true"
+      focusable="false"
+      className={cn("rounded-full", className)}
+    >
+      <rect width={grid} height={grid} fill={background} />
+      {cells.map((filled, index) =>
+        filled ? (
+          <rect
+            key={index}
+            x={index % grid}
+            y={Math.floor(index / grid)}
+            width={1}
+            height={1}
+            fill={foreground}
+          />
+        ) : null,
+      )}
+    </svg>
+  )
+}

--- a/components/__tests__/Header.test.tsx
+++ b/components/__tests__/Header.test.tsx
@@ -320,7 +320,9 @@ describe("Header", () => {
       const walletBtn = screen.getByText("GABC...DEF").closest("button")!;
 
       await user.click(walletBtn);
-      const chevron = walletBtn.querySelector("svg");
+      // Selected by test id rather than by element order: the button also
+      // contains the wallet identicon, which is an SVG too.
+      const chevron = walletBtn.querySelector('[data-testid="wallet-chevron"]');
       expect(chevron?.classList.contains("rotate-180")).toBe(true);
     });
   });

--- a/components/__tests__/WalletAddress.test.tsx
+++ b/components/__tests__/WalletAddress.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { WalletAddress } from "@/components/WalletAddress"
+
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}))
+
+const ADDRESS = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+
+function mockClipboard(writeText: () => Promise<void>) {
+  const spy = vi.fn(writeText)
+
+  // jsdom exposes navigator.clipboard as a getter-only accessor, so it has to
+  // be redefined rather than assigned over.
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: spy },
+    configurable: true,
+    writable: true,
+  })
+
+  return spy
+}
+
+/**
+ * userEvent.setup() installs a clipboard stub of its own, so the spy has to be
+ * put in place afterwards or the click never reaches it.
+ */
+function setupWithClipboard(writeText: () => Promise<void> = () => Promise.resolve()) {
+  const user = userEvent.setup()
+  return { user, writeText: mockClipboard(writeText) }
+}
+
+describe("WalletAddress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("render", () => {
+    it("shows the address truncated, not in full", () => {
+      render(<WalletAddress address={ADDRESS} />)
+
+      expect(screen.getByText("GA5Z...KZVN")).toBeInTheDocument()
+      expect(screen.queryByText(ADDRESS)).not.toBeInTheDocument()
+    })
+
+    it("exposes the full address as a title for hover and inspection", () => {
+      render(<WalletAddress address={ADDRESS} />)
+
+      expect(screen.getByTestId("wallet-address-text")).toHaveAttribute("title", ADDRESS)
+    })
+
+    it("renders nothing when there is no address", () => {
+      const { container } = render(<WalletAddress address="" />)
+
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it("renders a deterministic identicon by default", () => {
+      const { container: first } = render(<WalletAddress address={ADDRESS} />)
+      const { container: second } = render(<WalletAddress address={ADDRESS} />)
+
+      expect(first.querySelector("svg")).toBeInTheDocument()
+      expect(first.querySelector("svg")?.innerHTML).toBe(second.querySelector("svg")?.innerHTML)
+    })
+
+    it("hides the identicon when asked", () => {
+      const { container } = render(<WalletAddress address={ADDRESS} showIdenticon={false} />)
+
+      // The copy and explorer icons are still SVGs, so assert on the grid's
+      // distinctive viewBox rather than on the absence of every SVG.
+      expect(container.querySelector('svg[viewBox="0 0 5 5"]')).toBeNull()
+    })
+
+    it("respects custom truncation lengths", () => {
+      render(<WalletAddress address={ADDRESS} lead={6} tail={6} />)
+
+      expect(screen.getByText("GA5ZSE...K4KZVN")).toBeInTheDocument()
+    })
+  })
+
+  describe("copy", () => {
+    it("copies the full address, not the truncated form", async () => {
+      const { user, writeText } = setupWithClipboard()
+      render(<WalletAddress address={ADDRESS} />)
+
+      await user.click(screen.getByRole("button", { name: /copy wallet address/i }))
+
+      expect(writeText).toHaveBeenCalledWith(ADDRESS)
+    })
+
+    it("confirms the copy with a toast", async () => {
+      const { user } = setupWithClipboard()
+      render(<WalletAddress address={ADDRESS} />)
+
+      await user.click(screen.getByRole("button", { name: /copy wallet address/i }))
+
+      expect(toastSuccess).toHaveBeenCalledWith("Wallet address copied")
+    })
+
+    it("reports a rejected clipboard instead of failing silently", async () => {
+      const { user } = setupWithClipboard(() => Promise.reject(new Error("denied")))
+      render(<WalletAddress address={ADDRESS} />)
+
+      await user.click(screen.getByRole("button", { name: /copy wallet address/i }))
+
+      await waitFor(() => expect(toastError).toHaveBeenCalled())
+      expect(toastSuccess).not.toHaveBeenCalled()
+    })
+
+    it("omits the copy button when asked", () => {
+      render(<WalletAddress address={ADDRESS} showCopyButton={false} />)
+
+      expect(screen.queryByRole("button", { name: /copy wallet address/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe("explorer link", () => {
+    it("links to the account page for the address", () => {
+      render(<WalletAddress address={ADDRESS} />)
+
+      const link = screen.getByRole("link", { name: /view wallet address on stellar explorer/i })
+      expect(link).toHaveAttribute("href", expect.stringContaining(`/account/${ADDRESS}`))
+      expect(link).toHaveAttribute("href", expect.stringContaining("stellar.expert"))
+    })
+
+    it("opens in a new tab without leaking the referrer", () => {
+      render(<WalletAddress address={ADDRESS} />)
+
+      const link = screen.getByRole("link", { name: /view wallet address on stellar explorer/i })
+      expect(link).toHaveAttribute("target", "_blank")
+      expect(link).toHaveAttribute("rel", "noreferrer noopener")
+    })
+
+    it("omits the explorer link when asked", () => {
+      render(<WalletAddress address={ADDRESS} showExplorerLink={false} />)
+
+      expect(screen.queryByRole("link")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/hooks/useFreighterWallet.ts
+++ b/hooks/useFreighterWallet.ts
@@ -13,16 +13,19 @@ import {
   setStoredWalletSession,
   type WalletProvider,
 } from "@/lib/walletAdapter";
+import { truncateAddress } from "@/lib/walletAddress";
 
 const STORAGE_KEY = "freighter_public_key";
 
 /**
  * Shortens a Stellar public key for display.
  * e.g. GABCDE...UVWXYZ (Stellar keys are 56 chars starting with G)
+ *
+ * Thin wrapper over the shared helper, kept for the symmetric 6 + 6 split.
  */
 export function shortenAddress(address: string, chars = 6): string {
-  if (!address || address.length <= chars * 2 + 3) return address;
-  return `${address.slice(0, chars)}...${address.slice(-chars)}`;
+  if (!address) return address;
+  return truncateAddress(address, { lead: chars, tail: chars });
 }
 
 interface UseFreighterWalletReturn {

--- a/lib/__tests__/walletAddress.test.ts
+++ b/lib/__tests__/walletAddress.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach } from "vitest"
+import {
+  getIdenticonSpec,
+  getStellarAccountExplorerUrl,
+  getStellarNetworkSlug,
+  hashAddress,
+  isStellarAddress,
+  truncateAddress,
+} from "@/lib/walletAddress"
+
+const ADDRESS = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+const OTHER_ADDRESS = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+
+describe("truncateAddress", () => {
+  it("keeps 4 characters at each end by default", () => {
+    expect(truncateAddress(ADDRESS)).toBe("GA5Z...KZVN")
+  })
+
+  it("honours custom lead and tail lengths", () => {
+    expect(truncateAddress(ADDRESS, { lead: 6, tail: 6 })).toBe("GA5ZSE...K4KZVN")
+  })
+
+  it("honours a custom separator", () => {
+    expect(truncateAddress(ADDRESS, { lead: 5, tail: 4, separator: "…" })).toBe("GA5ZS…KZVN")
+  })
+
+  it("returns an empty string for empty input", () => {
+    expect(truncateAddress("")).toBe("")
+  })
+
+  it("leaves addresses shorter than the truncated form untouched", () => {
+    expect(truncateAddress("GABC12")).toBe("GABC12")
+  })
+
+  it("drops the tail without leaking the whole address when tail is 0", () => {
+    // slice(-0) returns the entire string, so this guards a real footgun.
+    expect(truncateAddress(ADDRESS, { tail: 0 })).toBe("GA5Z...")
+  })
+
+  it("treats negative lengths as zero", () => {
+    expect(truncateAddress(ADDRESS, { lead: -5, tail: -5 })).toBe("...")
+  })
+})
+
+describe("isStellarAddress", () => {
+  it("accepts a canonical public key", () => {
+    expect(isStellarAddress(ADDRESS)).toBe(true)
+  })
+
+  it.each([
+    ["too short", "GABC123"],
+    ["wrong prefix", ADDRESS.replace(/^G/, "S")],
+    ["lowercase", ADDRESS.toLowerCase()],
+    ["empty", ""],
+  ])("rejects %s", (_label, value) => {
+    expect(isStellarAddress(value)).toBe(false)
+  })
+})
+
+describe("getStellarNetworkSlug", () => {
+  const original = process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE
+    } else {
+      process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE = original
+    }
+  })
+
+  it("defaults to testnet when nothing is configured", () => {
+    delete process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE
+    expect(getStellarNetworkSlug()).toBe("testnet")
+  })
+
+  it("resolves the mainnet passphrase to the public network", () => {
+    process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE =
+      "Public Global Stellar Network ; September 2015"
+    expect(getStellarNetworkSlug()).toBe("public")
+  })
+
+  it("falls back to futurenet for any other passphrase", () => {
+    process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE = "Some Custom Network ; 2026"
+    expect(getStellarNetworkSlug()).toBe("futurenet")
+  })
+})
+
+describe("getStellarAccountExplorerUrl", () => {
+  it("points at the account page for the configured network", () => {
+    expect(getStellarAccountExplorerUrl(ADDRESS)).toBe(
+      `https://stellar.expert/explorer/${getStellarNetworkSlug()}/account/${ADDRESS}`,
+    )
+  })
+
+  it("escapes anything that is not a plain address", () => {
+    expect(getStellarAccountExplorerUrl("a/b?c")).toContain("a%2Fb%3Fc")
+  })
+})
+
+describe("hashAddress", () => {
+  it("is stable for the same input", () => {
+    expect(hashAddress(ADDRESS)).toBe(hashAddress(ADDRESS))
+  })
+
+  it("differs between addresses", () => {
+    expect(hashAddress(ADDRESS)).not.toBe(hashAddress(OTHER_ADDRESS))
+  })
+
+  it("stays inside the unsigned 32-bit range", () => {
+    const hash = hashAddress(ADDRESS)
+    expect(hash).toBeGreaterThanOrEqual(0)
+    expect(hash).toBeLessThanOrEqual(0xffffffff)
+  })
+})
+
+describe("getIdenticonSpec", () => {
+  it("produces a full 5x5 grid", () => {
+    const spec = getIdenticonSpec(ADDRESS)
+    expect(spec.size).toBe(5)
+    expect(spec.cells).toHaveLength(25)
+  })
+
+  it("is horizontally mirrored", () => {
+    const { cells, size } = getIdenticonSpec(ADDRESS)
+
+    for (let row = 0; row < size; row++) {
+      for (let column = 0; column < size; column++) {
+        expect(cells[row * size + column]).toBe(cells[row * size + (size - 1 - column)])
+      }
+    }
+  })
+
+  it("is deterministic for the same address", () => {
+    expect(getIdenticonSpec(ADDRESS)).toEqual(getIdenticonSpec(ADDRESS))
+  })
+
+  it("gives different addresses different colours", () => {
+    expect(getIdenticonSpec(ADDRESS).foreground).not.toBe(
+      getIdenticonSpec(OTHER_ADDRESS).foreground,
+    )
+  })
+
+  it("does not throw on an empty address", () => {
+    expect(() => getIdenticonSpec("")).not.toThrow()
+  })
+})

--- a/lib/context/WalletContext.tsx
+++ b/lib/context/WalletContext.tsx
@@ -24,16 +24,21 @@ import {
   type WalletProvider,
 } from "@/lib/walletAdapter"
 import { useWalletStore } from "@/lib/wallets/walletStore"
+import { truncateAddress } from "@/lib/walletAddress"
 
 const STORAGE_KEY = "freighter_public_key"
 
 /**
  * Shortens a Stellar public key for display.
  * e.g. GABCDE...UVWXYZ (Stellar keys are 56 chars starting with G)
+ *
+ * Thin wrapper over the shared helper, kept because it is imported in several
+ * places and because the header's symmetric 6 + 6 split differs from the
+ * 4 + 4 default used elsewhere.
  */
 export function shortenAddress(address: string, chars = 6): string {
-  if (!address || address.length <= chars * 2 + 3) return address
-  return `${address.slice(0, chars)}...${address.slice(-chars)}`
+  if (!address) return address
+  return truncateAddress(address, { lead: chars, tail: chars })
 }
 
 interface WalletContextValue {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -174,6 +174,10 @@ export interface LeaderboardDisplayEntry {
   completedAt?: number
   category?: string
   difficulty?: ClueDifficulty
+  /** Full Stellar address for this row, when known. Drives the identicon, copy button, and explorer link. */
+  address?: string
+  /** True when `name` is a player-chosen display name rather than a truncated address. */
+  hasDisplayName?: boolean
 }
 
 export interface FastestPlayerDisplayEntry {

--- a/lib/walletAddress.ts
+++ b/lib/walletAddress.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared helpers for presenting a Stellar wallet address in the UI.
+ *
+ * Before this module the codebase carried five separate copies of "truncate a
+ * Stellar address" (Header, LeaderBoardTable, FastestPlayersStrip,
+ * CompletedHuntCard, WalletContext), each with a slightly different shape.
+ * Everything display-related now routes through here so an address looks the
+ * same wherever it appears.
+ *
+ * Deliberately dependency-free: it is imported by the header, which is on every
+ * page, so it must not pull the Stellar SDK into the initial bundle.
+ */
+
+/** Canonical Stellar public key: 56 chars, starts with G, base32 alphabet. */
+const STELLAR_PUBLIC_KEY_PATTERN = /^G[A-Z2-7]{55}$/
+
+/** Passphrase of the public network. Mirrors `MAINNET_NETWORK_PASSPHRASE`. */
+const MAINNET_NETWORK_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+
+/** Passphrase of the test network. Mirrors `TESTNET_CONFIG.networkPassphrase`. */
+const TESTNET_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+
+/** Grid is 5x5 and mirrored down the middle, so 3 columns carry the entropy. */
+const IDENTICON_GRID = 5
+
+export function isStellarAddress(address: string): boolean {
+  return STELLAR_PUBLIC_KEY_PATTERN.test(address)
+}
+
+export interface TruncateAddressOptions {
+  /** Characters kept at the start. Default 4. */
+  lead?: number
+  /** Characters kept at the end. Default 4. */
+  tail?: number
+  /** Text between the two halves. Default "...". */
+  separator?: string
+}
+
+/**
+ * Shortens an address to `G12A...XY9Z` form.
+ *
+ * Returns the input untouched when it is already short enough that truncating
+ * would not save space, so short mock addresses in tests stay readable.
+ */
+export function truncateAddress(
+  address: string,
+  { lead = 4, tail = 4, separator = "..." }: TruncateAddressOptions = {},
+): string {
+  if (!address) return ""
+
+  const head = Math.max(0, Math.trunc(lead))
+  const foot = Math.max(0, Math.trunc(tail))
+
+  if (address.length <= head + foot + separator.length) return address
+
+  // slice(-0) returns the whole string, so an empty tail needs its own branch.
+  const end = foot === 0 ? "" : address.slice(-foot)
+  return `${address.slice(0, head)}${separator}${end}`
+}
+
+/**
+ * Which stellar.expert network path an address belongs to.
+ *
+ * Note this resolves the testnet passphrase to "testnet" rather than the
+ * "futurenet" that `getStellarExplorerUrl` in lib/constants.ts uses for every
+ * non-mainnet passphrase — an account link has to point at the network the
+ * account actually exists on to be useful for verification.
+ */
+export function getStellarNetworkSlug(): "public" | "testnet" | "futurenet" {
+  const passphrase = process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE ?? TESTNET_NETWORK_PASSPHRASE
+
+  if (passphrase === MAINNET_NETWORK_PASSPHRASE) return "public"
+  if (passphrase === TESTNET_NETWORK_PASSPHRASE) return "testnet"
+  return "futurenet"
+}
+
+/** Public stellar.expert page for an account, for verifying an address. */
+export function getStellarAccountExplorerUrl(address: string): string {
+  return `https://stellar.expert/explorer/${getStellarNetworkSlug()}/account/${encodeURIComponent(address)}`
+}
+
+/**
+ * FNV-1a hash. Small, fast, and stable across runs and platforms — the
+ * identicon for an address must never change between sessions or devices.
+ */
+export function hashAddress(address: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < address.length; i++) {
+    hash ^= address.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash >>> 0
+}
+
+export interface IdenticonSpec {
+  /** Row-major grid of filled cells, `size * size` long. */
+  cells: boolean[]
+  /** Width and height of the grid in cells. */
+  size: number
+  foreground: string
+  background: string
+}
+
+/**
+ * Derives a deterministic avatar from an address: a horizontally mirrored
+ * pixel grid plus a colour pair, both seeded from the address hash. Mirroring
+ * is what makes the result read as a face/emblem rather than as noise.
+ */
+export function getIdenticonSpec(address: string): IdenticonSpec {
+  const hash = hashAddress(address ?? "")
+  const hue = hash % 360
+
+  const cells = new Array<boolean>(IDENTICON_GRID * IDENTICON_GRID).fill(false)
+  const columns = Math.ceil(IDENTICON_GRID / 2)
+
+  // Re-mix per cell instead of consuming one bit at a time: 32 bits of hash
+  // would not cover a larger grid, and re-mixing keeps this size-independent.
+  let bits = hash
+  for (let row = 0; row < IDENTICON_GRID; row++) {
+    for (let column = 0; column < columns; column++) {
+      bits = (Math.imul(bits, 0x01000193) ^ (row * 31 + column)) >>> 0
+      const filled = ((bits >>> 8) & 1) === 1
+
+      cells[row * IDENTICON_GRID + column] = filled
+      cells[row * IDENTICON_GRID + (IDENTICON_GRID - 1 - column)] = filled
+    }
+  }
+
+  return {
+    cells,
+    size: IDENTICON_GRID,
+    foreground: `hsl(${hue} 68% 46%)`,
+    background: `hsl(${(hue + 42) % 360} 62% 92%)`,
+  }
+}


### PR DESCRIPTION
## Summary

Adds wallet address display and copy-to-clipboard, per #566.

- New `components/WalletAddress.tsx` — shows a truncated address (e.g. `GABC…6ZYX`) with a one-click copy button and copied-state feedback.
- New `components/WalletIdenticon.tsx` — a deterministic identicon so a connected address is visually recognizable.
- New `lib/walletAddress.ts` — address truncation/formatting helpers.
- Wired the display into `Header`, `app/profile/page.tsx`, `LeaderBoardTable`, `CompletedHuntCard`, and `FastestPlayersStrip`, sourced from `lib/context/WalletContext.tsx` / `hooks/useFreighterWallet.ts`.

## Tests

- `lib/__tests__/walletAddress.test.ts` — truncation/format helpers.
- `components/__tests__/WalletAddress.test.tsx` — render + copy behavior.
- `components/__tests__/Header.test.tsx` — updated for the address display.

## Screenshot / demo

<!-- UI change — a screenshot or short clip of the address display + copy can be dropped here. -->

Closes #566
