### PR TITLE
feat: expand hunt templates library (#579)

### DIFF
--- a/app/hunty/page.tsx
+++ b/app/hunty/page.tsx
@@ -34,6 +34,7 @@ import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/comp
 import { toast } from "sonner"
 import { downloadElementAsImage } from "@/lib/downloadAsImage"
 import { buildDraftHuntsFromTemplate, getStarterTemplateBySlug } from "@/lib/huntTemplates"
+import { getCommunityTemplateBySlug } from "@/lib/communityTemplates"
 
 const EMPTY_HUNT_DRAFT: HuntDraft = {
   id: 1,
@@ -99,17 +100,33 @@ function CreateGameContent() {
     const templateSlug = searchParams.get("template")
     if (!templateSlug || appliedTemplateRef.current === templateSlug) return
 
-    const template = getStarterTemplateBySlug(templateSlug)
+    const template =
+      getStarterTemplateBySlug(templateSlug) ??
+      getCommunityTemplateBySlug(templateSlug)
     if (!template) return
 
     appliedTemplateRef.current = templateSlug
     setGameName(template.title)
     setHunts(buildDraftHuntsFromTemplate(template))
+
+    // Apply any pre-filled builder settings that shipped with the template.
+    if (template.settings) {
+      if (typeof template.settings.sequential === "boolean") {
+        setSequential(template.settings.sequential)
+      }
+      if (typeof template.settings.timerEnabled === "boolean") {
+        setTimerEnabled(template.settings.timerEnabled)
+      }
+      if (template.settings.rewardType) {
+        setRewardType(template.settings.rewardType)
+      }
+    }
+
     setActiveTab("create")
     setSelectedTemplateTitle(template.title)
     toast.success(`Loaded ${template.title}. You can edit every field before publishing.`)
     router.replace("/hunty")
-  }, [router, searchParams, setGameName, setHunts])
+  }, [router, searchParams, setGameName, setHunts, setRewardType])
 
   const rewardPool = rewards.reduce((sum, r) => sum + r.amount, 0)
 

--- a/app/hunty/templates/page.tsx
+++ b/app/hunty/templates/page.tsx
@@ -4,15 +4,7 @@ import { ArrowLeft, Sparkles } from "lucide-react"
 
 import { Header } from "@/components/Header"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import { STARTER_HUNT_TEMPLATES } from "@/lib/huntTemplates"
+import { HuntTemplatesGallery } from "@/components/HuntTemplatesGallery"
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://hunty.app"
 
@@ -54,65 +46,11 @@ export default function HuntTemplatesPage() {
             Start with a hunt idea, not a blank page
           </h1>
           <p className="text-lg text-slate-600">
-            Pick a starter, load editable sample clues into the builder, and tailor everything before you publish.
+            Pick a starter, filter by category, load editable sample clues into the builder, and tailor everything before you publish.
           </p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-          {STARTER_HUNT_TEMPLATES.map((template) => (
-            <Card
-              key={template.slug}
-              className="overflow-hidden rounded-3xl border border-white/80 bg-white/85 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.35)] backdrop-blur"
-            >
-              <CardHeader className="pb-4">
-                <div className="mb-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  <span className="rounded-full bg-sky-100 px-2.5 py-1 text-sky-700">
-                    {template.category}
-                  </span>
-                  <span>{template.estimatedDuration}</span>
-                </div>
-                <CardTitle className="text-2xl text-slate-900">
-                  {template.title}
-                </CardTitle>
-                <CardDescription className="mt-2 text-sm leading-6 text-slate-600">
-                  {template.description}
-                </CardDescription>
-              </CardHeader>
-
-              <CardContent className="pb-6">
-                <div className="rounded-2xl bg-slate-50 p-4">
-                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                    Sample clues
-                  </p>
-                  <ul className="space-y-2 text-sm text-slate-700">
-                    {template.clues.map((clue, index) => (
-                      <li key={clue.title} className="flex gap-3">
-                        <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white">
-                          {index + 1}
-                        </span>
-                        <span className="leading-6">{clue.title}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </CardContent>
-
-              <CardFooter className="border-t border-slate-100 pt-6">
-                <Button
-                  asChild
-                  className="w-full rounded-2xl bg-[#0C0C4F] py-6 text-base font-semibold text-white hover:bg-slate-800"
-                >
-                  <Link
-                    href={`/hunty?template=${template.slug}`}
-                    aria-label={`Start ${template.title}`}
-                  >
-                    Start from Template
-                  </Link>
-                </Button>
-              </CardFooter>
-            </Card>
-          ))}
-        </div>
+        <HuntTemplatesGallery />
       </div>
     </div>
   )

--- a/components/HuntTemplatesGallery.tsx
+++ b/components/HuntTemplatesGallery.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { Sparkles, Users } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  STARTER_HUNT_TEMPLATES,
+  getTemplateCategories,
+  type HuntTemplate,
+} from "@/lib/huntTemplates"
+import {
+  getCommunityTemplates,
+  type CommunityHuntTemplate,
+} from "@/lib/communityTemplates"
+import { SubmitTemplateDialog } from "@/components/SubmitTemplateDialog"
+
+const ALL_CATEGORIES = "All"
+
+function TemplateCard({
+  template,
+  community = false,
+}: {
+  template: HuntTemplate | CommunityHuntTemplate
+  community?: boolean
+}) {
+  return (
+    <Card className="overflow-hidden rounded-3xl border border-white/80 bg-white/85 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+      <CardHeader className="pb-4">
+        <div className="mb-4 flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-sky-700">
+            {template.category}
+          </span>
+          <span>{template.estimatedDuration}</span>
+          {community && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2.5 py-1 text-orange-700">
+              <Users className="h-3 w-3" />
+              Community
+            </span>
+          )}
+        </div>
+        <CardTitle className="text-2xl text-slate-900">{template.title}</CardTitle>
+        <CardDescription className="mt-2 text-sm leading-6 text-slate-600">
+          {template.description}
+        </CardDescription>
+        {community && "author" in template && (
+          <p className="mt-2 text-xs font-medium text-slate-500">
+            Shared by {template.author}
+          </p>
+        )}
+      </CardHeader>
+
+      <CardContent className="pb-6">
+        <div className="rounded-2xl bg-slate-50 p-4">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Sample clues
+          </p>
+          <ul className="space-y-2 text-sm text-slate-700">
+            {template.clues.map((clue, index) => (
+              <li key={clue.title} className="flex gap-3">
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white">
+                  {index + 1}
+                </span>
+                <span className="leading-6">{clue.title}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </CardContent>
+
+      <CardFooter className="border-t border-slate-100 pt-6">
+        <Button
+          asChild
+          className="w-full rounded-2xl bg-[#0C0C4F] py-6 text-base font-semibold text-white hover:bg-slate-800"
+        >
+          <Link
+            href={`/hunty?template=${template.slug}`}
+            aria-label={`Start ${template.title}`}
+          >
+            Start from Template
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}
+
+export function HuntTemplatesGallery() {
+  const [activeCategory, setActiveCategory] = useState<string>(ALL_CATEGORIES)
+  const [communityTemplates, setCommunityTemplates] = useState<
+    CommunityHuntTemplate[]
+  >([])
+
+  // Community templates live in localStorage, so read them after mount to keep
+  // the server-rendered markup and the first client render in sync.
+  useEffect(() => {
+    setCommunityTemplates(getCommunityTemplates())
+  }, [])
+
+  const refreshCommunityTemplates = () =>
+    setCommunityTemplates(getCommunityTemplates())
+
+  const categories = useMemo(
+    () => [ALL_CATEGORIES, ...getTemplateCategories()],
+    [],
+  )
+
+  const visibleStarters = useMemo(
+    () =>
+      activeCategory === ALL_CATEGORIES
+        ? STARTER_HUNT_TEMPLATES
+        : STARTER_HUNT_TEMPLATES.filter(
+            (template) => template.category === activeCategory,
+          ),
+    [activeCategory],
+  )
+
+  const visibleCommunity = useMemo(
+    () =>
+      activeCategory === ALL_CATEGORIES
+        ? communityTemplates
+        : communityTemplates.filter(
+            (template) => template.category === activeCategory,
+          ),
+    [activeCategory, communityTemplates],
+  )
+
+  return (
+    <>
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div
+          className="flex flex-wrap gap-2"
+          role="tablist"
+          aria-label="Filter templates by category"
+        >
+          {categories.map((category) => {
+            const isActive = category === activeCategory
+            return (
+              <button
+                key={category}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setActiveCategory(category)}
+                className={`rounded-full border px-4 py-2 text-sm font-semibold transition-colors ${
+                  isActive
+                    ? "border-[#0C0C4F] bg-[#0C0C4F] text-white"
+                    : "border-slate-200 bg-white/80 text-slate-600 hover:border-slate-300 hover:text-slate-900"
+                }`}
+              >
+                {category}
+              </button>
+            )
+          })}
+        </div>
+
+        <SubmitTemplateDialog
+          categories={getTemplateCategories()}
+          onSubmitted={refreshCommunityTemplates}
+        />
+      </div>
+
+      {visibleStarters.length === 0 && visibleCommunity.length === 0 ? (
+        <p className="rounded-3xl border border-dashed border-slate-200 bg-white/70 p-10 text-center text-slate-500">
+          No templates in this category yet.
+        </p>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {visibleStarters.map((template) => (
+            <TemplateCard key={template.slug} template={template} />
+          ))}
+        </div>
+      )}
+
+      {visibleCommunity.length > 0 && (
+        <section className="mt-14">
+          <div className="mb-6 flex items-center gap-2 text-slate-900">
+            <Users className="h-5 w-5 text-orange-500" />
+            <h2 className="text-2xl font-bold">Community templates</h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {visibleCommunity.map((template) => (
+              <TemplateCard key={template.slug} template={template} community />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {communityTemplates.length === 0 && (
+        <div className="mt-14 flex flex-col items-center gap-3 rounded-3xl border border-dashed border-orange-200 bg-white/70 p-10 text-center">
+          <Sparkles className="h-6 w-6 text-orange-500" />
+          <p className="max-w-md text-slate-600">
+            Built a hunt you love? Share it as a community template so other
+            creators can start from your idea.
+          </p>
+          <SubmitTemplateDialog
+            categories={getTemplateCategories()}
+            onSubmitted={refreshCommunityTemplates}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/SubmitTemplateDialog.tsx
+++ b/components/SubmitTemplateDialog.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import { useState } from "react"
+import { Plus, Send, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  MIN_TEMPLATE_CLUES,
+  addCommunityTemplate,
+  type CommunityTemplateInput,
+} from "@/lib/communityTemplates"
+import type { HuntTemplateClue } from "@/lib/huntTemplates"
+
+interface SubmitTemplateDialogProps {
+  /** Existing categories offered as quick suggestions. */
+  categories: string[]
+  /** Called after a template is successfully saved. */
+  onSubmitted?: () => void
+}
+
+const emptyClue = (): HuntTemplateClue => ({
+  title: "",
+  description: "",
+  code: "",
+})
+
+function createEmptyClues(): HuntTemplateClue[] {
+  return Array.from({ length: MIN_TEMPLATE_CLUES }, emptyClue)
+}
+
+export function SubmitTemplateDialog({
+  categories,
+  onSubmitted,
+}: SubmitTemplateDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [category, setCategory] = useState("")
+  const [estimatedDuration, setEstimatedDuration] = useState("")
+  const [author, setAuthor] = useState("")
+  const [clues, setClues] = useState<HuntTemplateClue[]>(createEmptyClues)
+
+  const resetForm = () => {
+    setTitle("")
+    setDescription("")
+    setCategory("")
+    setEstimatedDuration("")
+    setAuthor("")
+    setClues(createEmptyClues())
+  }
+
+  const updateClue = (index: number, field: keyof HuntTemplateClue, value: string) => {
+    setClues((current) =>
+      current.map((clue, i) => (i === index ? { ...clue, [field]: value } : clue)),
+    )
+  }
+
+  const addClue = () => setClues((current) => [...current, emptyClue()])
+
+  const removeClue = (index: number) => {
+    setClues((current) =>
+      current.length > MIN_TEMPLATE_CLUES
+        ? current.filter((_, i) => i !== index)
+        : current,
+    )
+  }
+
+  const handleSubmit = () => {
+    const input: CommunityTemplateInput = {
+      title,
+      description,
+      category,
+      estimatedDuration,
+      author,
+      clues,
+    }
+
+    try {
+      const saved = addCommunityTemplate(input)
+      toast.success(`"${saved.title}" shared with the community. Thank you!`)
+      resetForm()
+      setOpen(false)
+      onSubmitted?.()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not submit template.",
+      )
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) resetForm()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button className="rounded-2xl bg-[#0C0C4F] px-5 py-6 text-sm font-semibold text-white hover:bg-slate-800">
+          <Send className="mr-2 h-4 w-4" />
+          Submit a template
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent
+        showCloseButton
+        className="max-h-[85vh] overflow-y-auto sm:max-w-2xl"
+      >
+        <DialogHeader>
+          <DialogTitle>Share a community template</DialogTitle>
+          <DialogDescription>
+            Publish your hunt idea so other creators can start from it. It stays
+            editable after they load it into the builder.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              Title
+              <Input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Riverside Photo Quest"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              Your name
+              <Input
+                value={author}
+                onChange={(e) => setAuthor(e.target.value)}
+                placeholder="Ada L."
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+            Description
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What makes this hunt fun and where does it take place?"
+            />
+          </label>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              Category
+              <Input
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                list="template-categories"
+                placeholder="Outdoor"
+              />
+              <datalist id="template-categories">
+                {categories.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </datalist>
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              Estimated duration
+              <Input
+                value={estimatedDuration}
+                onChange={(e) => setEstimatedDuration(e.target.value)}
+                placeholder="30-45 min"
+              />
+            </label>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold text-slate-800">
+                Clues
+                <span className="ml-1 font-normal text-slate-500">
+                  (at least {MIN_TEMPLATE_CLUES})
+                </span>
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addClue}
+                className="rounded-xl"
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                Add clue
+              </Button>
+            </div>
+
+            {clues.map((clue, index) => (
+              <div
+                key={index}
+                className="space-y-2 rounded-2xl border border-slate-200 bg-slate-50 p-4"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Clue {index + 1}
+                  </span>
+                  {clues.length > MIN_TEMPLATE_CLUES && (
+                    <button
+                      type="button"
+                      onClick={() => removeClue(index)}
+                      aria-label={`Remove clue ${index + 1}`}
+                      className="text-slate-400 hover:text-red-500"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+                <Input
+                  value={clue.title}
+                  onChange={(e) => updateClue(index, "title", e.target.value)}
+                  placeholder="Clue title"
+                  className="bg-white"
+                />
+                <Textarea
+                  value={clue.description}
+                  onChange={(e) =>
+                    updateClue(index, "description", e.target.value)
+                  }
+                  placeholder="What should the player look for?"
+                  className="bg-white"
+                />
+                <Input
+                  value={clue.code}
+                  onChange={(e) => updateClue(index, "code", e.target.value)}
+                  placeholder="Answer / code"
+                  className="bg-white"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            className="rounded-2xl bg-[#0C0C4F] text-white hover:bg-slate-800"
+          >
+            <Send className="mr-2 h-4 w-4" />
+            Share template
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/__tests__/communityTemplates.test.ts
+++ b/lib/__tests__/communityTemplates.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  COMMUNITY_TEMPLATES_STORAGE_KEY,
+  MIN_TEMPLATE_CLUES,
+  addCommunityTemplate,
+  getCommunityTemplateBySlug,
+  getCommunityTemplates,
+  slugify,
+  validateCommunityTemplateInput,
+  type CommunityTemplateInput,
+} from "@/lib/communityTemplates"
+
+function validInput(
+  overrides: Partial<CommunityTemplateInput> = {},
+): CommunityTemplateInput {
+  return {
+    title: "Riverside Photo Quest",
+    description: "A relaxed photo hunt along the river path.",
+    category: "Outdoor",
+    estimatedDuration: "30-45 min",
+    author: "Ada",
+    clues: Array.from({ length: MIN_TEMPLATE_CLUES }, (_, i) => ({
+      title: `Clue ${i + 1}`,
+      description: `Find landmark number ${i + 1}.`,
+      code: `code${i + 1}`,
+    })),
+    ...overrides,
+  }
+}
+
+describe("community templates", () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(COMMUNITY_TEMPLATES_STORAGE_KEY)
+  })
+
+  it("slugifies titles into URL-safe slugs", () => {
+    expect(slugify("Riverside Photo Quest!")).toBe("riverside-photo-quest")
+    expect(slugify("  Multiple   Spaces  ")).toBe("multiple-spaces")
+  })
+
+  it("persists a valid submission and reads it back", () => {
+    const saved = addCommunityTemplate(validInput())
+
+    expect(saved.isCommunity).toBe(true)
+    expect(saved.slug).toBe("riverside-photo-quest")
+    expect(getCommunityTemplates()).toHaveLength(1)
+    expect(getCommunityTemplateBySlug(saved.slug)?.title).toBe(
+      "Riverside Photo Quest",
+    )
+  })
+
+  it("assigns unique slugs when titles collide", () => {
+    const first = addCommunityTemplate(validInput())
+    const second = addCommunityTemplate(validInput())
+
+    expect(first.slug).toBe("riverside-photo-quest")
+    expect(second.slug).toBe("riverside-photo-quest-2")
+  })
+
+  it("returns newest templates first", () => {
+    addCommunityTemplate(validInput({ title: "First Hunt" }))
+    addCommunityTemplate(validInput({ title: "Second Hunt" }))
+
+    const [newest] = getCommunityTemplates()
+    expect(newest.title).toBe("Second Hunt")
+  })
+
+  it("rejects submissions with too few complete clues", () => {
+    const input = validInput({
+      clues: [{ title: "Only one", description: "Just one clue here", code: "x" }],
+    })
+
+    expect(validateCommunityTemplateInput(input)).toMatch(/at least/i)
+    expect(() => addCommunityTemplate(input)).toThrow()
+    expect(getCommunityTemplates()).toHaveLength(0)
+  })
+
+  it("rejects submissions with a missing author or short title", () => {
+    expect(validateCommunityTemplateInput(validInput({ author: "" }))).toMatch(
+      /name/i,
+    )
+    expect(validateCommunityTemplateInput(validInput({ title: "Hi" }))).toMatch(
+      /title/i,
+    )
+  })
+
+  it("ignores clues that are only partially filled", () => {
+    const input = validInput({
+      clues: [
+        ...Array.from({ length: MIN_TEMPLATE_CLUES }, (_, i) => ({
+          title: `Clue ${i + 1}`,
+          description: `Find landmark ${i + 1}.`,
+          code: `code${i + 1}`,
+        })),
+        { title: "Half done", description: "", code: "" },
+      ],
+    })
+
+    const saved = addCommunityTemplate(input)
+    expect(saved.clues).toHaveLength(MIN_TEMPLATE_CLUES)
+  })
+})

--- a/lib/__tests__/huntTemplates.test.ts
+++ b/lib/__tests__/huntTemplates.test.ts
@@ -4,6 +4,7 @@ import {
   STARTER_HUNT_TEMPLATES,
   buildDraftHuntsFromTemplate,
   getStarterTemplateBySlug,
+  getTemplateCategories,
 } from "@/lib/huntTemplates"
 
 describe("hunt templates", () => {
@@ -14,6 +15,26 @@ describe("hunt templates", () => {
   it("ensures every starter template includes at least three sample clues", () => {
     for (const template of STARTER_HUNT_TEMPLATES) {
       expect(template.clues.length).toBeGreaterThanOrEqual(3)
+    }
+  })
+
+  it("includes a Nature Walk starter template", () => {
+    const template = getStarterTemplateBySlug("nature-walk")
+
+    expect(template).toBeDefined()
+    expect(template?.title).toBe("Nature Walk")
+    expect(template?.clues.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it("exposes unique, sorted categories for the filter", () => {
+    const categories = getTemplateCategories()
+
+    expect(categories.length).toBeGreaterThan(0)
+    expect(new Set(categories).size).toBe(categories.length)
+    expect([...categories].sort((a, b) => a.localeCompare(b))).toEqual(categories)
+
+    for (const template of STARTER_HUNT_TEMPLATES) {
+      expect(categories).toContain(template.category)
     }
   })
 

--- a/lib/communityTemplates.ts
+++ b/lib/communityTemplates.ts
@@ -1,0 +1,187 @@
+import { logger } from "@/lib/logger"
+import type { HuntTemplate, HuntTemplateClue } from "@/lib/huntTemplates"
+
+/**
+ * A hunt template contributed by a community member. Community templates are
+ * persisted in the browser's localStorage so creators can share and reuse
+ * their own starters alongside the built-in {@link HuntTemplate} library.
+ */
+export interface CommunityHuntTemplate extends HuntTemplate {
+  /** Marks the template as community-submitted for UI badging and lookups. */
+  isCommunity: true
+  /** Display name of the contributor. */
+  author: string
+  /** Unix timestamp (ms) when the template was submitted. */
+  submittedAt: number
+}
+
+/** Input shape accepted by {@link addCommunityTemplate}. */
+export interface CommunityTemplateInput {
+  title: string
+  description: string
+  category: string
+  estimatedDuration: string
+  author: string
+  clues: HuntTemplateClue[]
+}
+
+export const COMMUNITY_TEMPLATES_STORAGE_KEY = "hunty:community-templates"
+
+/** Minimum number of sample clues a template must include. */
+export const MIN_TEMPLATE_CLUES = 3
+
+/** Converts a free-form title into a URL-safe slug. */
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined"
+}
+
+function isValidClue(clue: unknown): clue is HuntTemplateClue {
+  if (!clue || typeof clue !== "object") return false
+  const candidate = clue as Record<string, unknown>
+  return (
+    typeof candidate.title === "string" &&
+    typeof candidate.description === "string" &&
+    typeof candidate.code === "string"
+  )
+}
+
+function isValidCommunityTemplate(value: unknown): value is CommunityHuntTemplate {
+  if (!value || typeof value !== "object") return false
+  const candidate = value as Record<string, unknown>
+  return (
+    candidate.isCommunity === true &&
+    typeof candidate.slug === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.description === "string" &&
+    typeof candidate.category === "string" &&
+    typeof candidate.estimatedDuration === "string" &&
+    typeof candidate.author === "string" &&
+    typeof candidate.submittedAt === "number" &&
+    Array.isArray(candidate.clues) &&
+    candidate.clues.every(isValidClue)
+  )
+}
+
+/** Reads all persisted community templates, newest first. */
+export function getCommunityTemplates(): CommunityHuntTemplate[] {
+  if (!isBrowser()) return []
+
+  try {
+    const raw = window.localStorage.getItem(COMMUNITY_TEMPLATES_STORAGE_KEY)
+    if (!raw) return []
+
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+
+    return parsed
+      .filter(isValidCommunityTemplate)
+      .sort((a, b) => b.submittedAt - a.submittedAt)
+  } catch (error) {
+    logger.warn("Failed to read community templates from localStorage:", error)
+    return []
+  }
+}
+
+export function getCommunityTemplateBySlug(
+  slug: string,
+): CommunityHuntTemplate | undefined {
+  return getCommunityTemplates().find((template) => template.slug === slug)
+}
+
+/**
+ * Validates a community submission, returning a human-readable error string
+ * when the input is not publishable, or `null` when it is valid.
+ */
+export function validateCommunityTemplateInput(
+  input: CommunityTemplateInput,
+): string | null {
+  if (input.title.trim().length < 4) {
+    return "Template title must be at least 4 characters."
+  }
+  if (input.description.trim().length < 8) {
+    return "Template description must be at least 8 characters."
+  }
+  if (input.category.trim().length === 0) {
+    return "Please choose a category."
+  }
+  if (input.author.trim().length < 2) {
+    return "Please add your name so others can credit you."
+  }
+
+  const filledClues = input.clues.filter(
+    (clue) => clue.title.trim() && clue.description.trim() && clue.code.trim(),
+  )
+  if (filledClues.length < MIN_TEMPLATE_CLUES) {
+    return `Add at least ${MIN_TEMPLATE_CLUES} complete clues (title, description, and answer).`
+  }
+
+  return null
+}
+
+/**
+ * Persists a validated community template. Returns the saved template, or
+ * throws with a validation message when the input is invalid.
+ */
+export function addCommunityTemplate(
+  input: CommunityTemplateInput,
+): CommunityHuntTemplate {
+  const validationError = validateCommunityTemplateInput(input)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+
+  const existing = getCommunityTemplates()
+  const baseSlug = slugify(input.title) || "community-template"
+
+  // Guarantee a unique slug even when titles collide.
+  let slug = baseSlug
+  let suffix = 2
+  const taken = new Set(existing.map((template) => template.slug))
+  while (taken.has(slug)) {
+    slug = `${baseSlug}-${suffix}`
+    suffix += 1
+  }
+
+  const template: CommunityHuntTemplate = {
+    slug,
+    title: input.title.trim(),
+    description: input.description.trim(),
+    category: input.category.trim(),
+    estimatedDuration: input.estimatedDuration.trim() || "30-45 min",
+    author: input.author.trim(),
+    isCommunity: true,
+    submittedAt: Date.now(),
+    clues: input.clues
+      .filter(
+        (clue) => clue.title.trim() && clue.description.trim() && clue.code.trim(),
+      )
+      .map((clue) => ({
+        title: clue.title.trim(),
+        description: clue.description.trim(),
+        code: clue.code.trim(),
+        ...(clue.link?.trim() ? { link: clue.link.trim() } : {}),
+      })),
+  }
+
+  if (isBrowser()) {
+    try {
+      window.localStorage.setItem(
+        COMMUNITY_TEMPLATES_STORAGE_KEY,
+        JSON.stringify([template, ...existing]),
+      )
+    } catch (error) {
+      logger.warn("Failed to persist community template:", error)
+      throw new Error("Could not save your template. Please try again.")
+    }
+  }
+
+  return template
+}

--- a/lib/huntTemplates.ts
+++ b/lib/huntTemplates.ts
@@ -7,6 +7,19 @@ export interface HuntTemplateClue {
   link?: string
 }
 
+/**
+ * Pre-filled builder settings that ship with a template so creators start with
+ * sensible defaults instead of a blank configuration.
+ */
+export interface HuntTemplateSettings {
+  /** Players must solve clues in order. */
+  sequential?: boolean
+  /** Enable the countdown timer for a time-pressured experience. */
+  timerEnabled?: boolean
+  /** Default reward payout type. */
+  rewardType?: "XLM" | "NFT" | "Both"
+}
+
 export interface HuntTemplate {
   slug: string
   title: string
@@ -14,6 +27,8 @@ export interface HuntTemplate {
   category: string
   estimatedDuration: string
   clues: HuntTemplateClue[]
+  /** Optional builder settings pre-filled when the template is loaded. */
+  settings?: HuntTemplateSettings
 }
 
 export const STARTER_HUNT_TEMPLATES: HuntTemplate[] = [
@@ -23,6 +38,11 @@ export const STARTER_HUNT_TEMPLATES: HuntTemplate[] = [
     description: "Guide players through murals, landmarks, and hidden corners in a downtown walking loop.",
     category: "Outdoor",
     estimatedDuration: "45-60 min",
+    settings: {
+      sequential: true,
+      timerEnabled: false,
+      rewardType: "XLM",
+    },
     clues: [
       {
         title: "Mural at Sunrise Alley",
@@ -47,6 +67,11 @@ export const STARTER_HUNT_TEMPLATES: HuntTemplate[] = [
     description: "Help new teammates learn key spaces, people, and culture rituals around the office.",
     category: "Onboarding",
     estimatedDuration: "20-30 min",
+    settings: {
+      sequential: false,
+      timerEnabled: true,
+      rewardType: "XLM",
+    },
     clues: [
       {
         title: "Welcome Wall",
@@ -119,6 +144,11 @@ export const STARTER_HUNT_TEMPLATES: HuntTemplate[] = [
     description: "Turn a gallery visit into a playful puzzle trail across artifacts, portraits, and exhibit labels.",
     category: "Indoor",
     estimatedDuration: "35-50 min",
+    settings: {
+      sequential: true,
+      timerEnabled: false,
+      rewardType: "NFT",
+    },
     clues: [
       {
         title: "Portrait Puzzle",
@@ -161,10 +191,51 @@ export const STARTER_HUNT_TEMPLATES: HuntTemplate[] = [
       },
     ],
   },
+  {
+    slug: "nature-walk",
+    title: "Nature Walk",
+    description: "Lead players along a trail to spot trees, wildlife markers, and scenic lookouts at their own pace.",
+    category: "Outdoor",
+    estimatedDuration: "30-45 min",
+    settings: {
+      sequential: false,
+      timerEnabled: false,
+      rewardType: "XLM",
+    },
+    clues: [
+      {
+        title: "Trailhead Marker",
+        description: "Start at the trailhead sign and enter the trail's total length shown in kilometers.",
+        code: "5",
+      },
+      {
+        title: "Ancient Oak",
+        description: "Find the oldest oak along the path and enter the word carved into its interpretive plaque.",
+        code: "guardian",
+      },
+      {
+        title: "Lookout Point",
+        description: "Reach the scenic overlook and enter the name of the river visible in the valley below.",
+        code: "silverbrook",
+      },
+    ],
+  },
 ]
 
 export function getStarterTemplateBySlug(slug: string): HuntTemplate | undefined {
   return STARTER_HUNT_TEMPLATES.find((template) => template.slug === slug)
+}
+
+/**
+ * Unique, alphabetically sorted list of categories across the starter
+ * templates. Used to drive the category filter on the selection screen.
+ */
+export function getTemplateCategories(
+  templates: HuntTemplate[] = STARTER_HUNT_TEMPLATES,
+): string[] {
+  return Array.from(new Set(templates.map((template) => template.category))).sort(
+    (a, b) => a.localeCompare(b),
+  )
 }
 
 export function buildDraftHuntsFromTemplate(template: HuntTemplate): HuntDraft[] {


### PR DESCRIPTION
## Summary

Closes #579.

Builds on the existing starter templates gallery to deliver the full **hunt templates library** described in the issue. Creators can now browse templates by category, start from a pre-configured starter, and share their own templates with the community.

## What changed

- **Category selection screen** — the templates page now filters starter *and* community templates by category via an accessible tab-style chip bar (`All` + each category). Extracted the interactive gallery into `components/HuntTemplatesGallery.tsx`; the page stays a Server Component for metadata/SEO.
- **New Nature Walk starter + pre-filled settings** — added a `nature-walk` template and an optional `settings` block on templates (`sequential`, `timerEnabled`, `rewardType`). When a template is loaded into the builder, these settings are applied automatically (still fully editable before publishing).
- **Community-submitted template support** — a new "Submit a template" dialog (`components/SubmitTemplateDialog.tsx`) lets contributors add their own templates. Submissions are validated, persisted in `localStorage` (`lib/communityTemplates.ts`), rendered in a dedicated "Community templates" section with an author credit, and load into the builder exactly like the built-in starters (`/hunty?template=<slug>` now resolves community slugs too).

## Acceptance criteria

- [x] Template selection screen with categories
- [x] Templates: City Explorer / Office Scavenger / Museum Tour / Nature Walk, etc.
- [x] Pre-filled clues and settings
- [x] Customizable after selection
- [x] Community-submitted template support

## Testing

- `lib/__tests__/huntTemplates.test.ts` — extended with Nature Walk + category helper coverage.
- `lib/__tests__/communityTemplates.test.ts` — new: slugging, validation, persistence, unique-slug collisions, and ordering.
- All 12 template tests pass; ESLint and `tsc` are clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)