### PR TITLE
refactor: shared @hunty/types package (#554)

### DIFF
--- a/lib/achievements/config.ts
+++ b/lib/achievements/config.ts
@@ -3,26 +3,12 @@
  * Defines all available achievements with their conditions and metadata.
  */
 
-export type AchievementId =
-  | "first_hunt_completed"
-  | "first_win"
-  | "five_wins"
-  | "ten_wins"
-  | "twenty_five_wins"
-  | "first_nft"
-  | "high_scorer"
-  | "speed_hunter"
-  | "veteran"
-  | "legend"
+// Achievement and AchievementId are defined in the shared @hunty/types package.
+// Imported for local use and re-exported so existing
+// "@/lib/achievements/config" imports keep working.
+import type { Achievement, AchievementId } from "@hunty/types"
 
-export interface Achievement {
-  id: AchievementId
-  title: string
-  description: string
-  icon: string // Emoji or icon identifier
-  rarity: "common" | "uncommon" | "rare" | "epic" | "legendary"
-  condition: string // Human-readable condition
-}
+export type { Achievement, AchievementId }
 
 export const ACHIEVEMENTS: Record<AchievementId, Achievement> = {
   first_hunt_completed: {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,109 +1,42 @@
 /**
  * Central type definitions for the Hunty application.
- * All shared interfaces and types live here — import from "@/lib/types".
+ *
+ * Platform-agnostic domain types (Hunt, Clue, Player, Reward, Achievement)
+ * live in the shared `@hunty/types` package and are re-exported here so that
+ * existing `@/lib/types` imports keep working. Web-only and React-coupled
+ * types (display entries, performance, chat, …) remain defined below.
  */
 
 import type { ReactNode } from "react"
 import type { ClueScoringBreakdown, HuntScoringBreakdown, ScoringWeights } from "./scoring"
+import type { ClueDifficulty, PlayerProgress, Reward as DomainReward } from "@hunty/types"
 
-// ─── Hunt ────────────────────────────────────────────────────────────────────
+// ─── Shared domain types (single source of truth: @hunty/types) ──────────────
 
-export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled"
-
-export interface StoredHunt {
-  id: number
-  title: string
-  description: string
-  cluesCount: number
-  /** Broad hunt category used in discovery filters. */
-  category?: "Urban" | "Campus" | "Office" | "Museum" | "General"
-  /** Overall hunt difficulty tag used in discovery filters. */
-  difficulty?: "Easy" | "Medium" | "Hard"
-  status: HuntStatus
-  rewardType: "XLM" | "NFT" | "Both"
-  /** When true, players must solve clues in order. */
-  sequential?: boolean
-  /** Total reward pool value used for creator-side sorting. */
-  rewardPool?: number
-  /** Per-place XLM reward buckets funded by the creator. */
-  rewards?: Reward[]
-  /** Escrow transaction hash proving the creator funded the XLM reward pool. */
-  rewardEscrowTxHash?: string
-  /** Amount still available in the XLM escrow. */
-  rewardEscrowBalance?: number
-  /** Creator-side participant count snapshot for dashboard sorting. */
-  playerCount?: number
-  /** Max number of participants for limited spots */
-  maxCapacity?: number
-  /** Unix timestamp in seconds when the hunt draft was created locally. */
-  createdAt?: number
-  /** Unix timestamp in seconds — when the hunt starts. */
-  startTime?: number
-  /** Unix timestamp in seconds — when the hunt ends. */
-  endTime?: number
-  creatorEmail?: string
-  emailNotifications?: boolean
-  /** When true, the hunt is hidden from the public arcade grid. */
-  is_private?: boolean
-  /** Optional game cover CID/URL for hunt cards and sharing previews. */
-  coverImageCid?: string
-  /** Active editorial banner showcase at the top of the Arcade. */
-  isFeaturedOfWeek?: boolean
-}
-
-export type HuntInfo = {
-  id: number
-  title: string
-  description: string
-  totalClues: number
-  status: string
-  sequential?: boolean
-  startTime?: number
-  endTime?: number
-  creatorEmail?: string
-  emailNotifications?: boolean
-}
-
-// ─── Clue ────────────────────────────────────────────────────────────────────
-
-export type ClueDifficulty = "Easy" | "Medium" | "Hard"
-
-export interface Clue {
-  id: number
-  huntId: number
-  question: string
-  answer: string
-  points: number
-  hint?: string
-  hintCost?: number
-  /** Optional difficulty tag set by the creator. */
-  difficulty?: ClueDifficulty
-  /** Center latitude for the clue's answer geofence. */
-  latitude?: number
-  /** Center longitude for the clue's answer geofence. */
-  longitude?: number
-  /** Allowed distance from the clue center in metres. Defaults to 100m. */
-  geofenceRadiusMeters?: number
-}
-
-export type ClueInfo = {
-  id: number
-  question: string
-  points: number
-  hint?: string
-  hintCost?: number
-  difficulty?: ClueDifficulty
-}
-
-export interface ClueRow {
-  id: number
-  question: string
-  answer: string
-  points: number
-  hint?: string
-  hintCost?: number
-  difficulty?: ClueDifficulty
-}
+export type {
+  HuntStatus,
+  HuntCategory,
+  HuntDifficulty,
+  StoredHunt,
+  HuntInfo,
+  HuntDraft,
+  ClueDifficulty,
+  Clue,
+  ClueInfo,
+  ClueRow,
+  PlayerProgress,
+  PlayerStats,
+  PlayerHuntProgress,
+  HuntProgressStatus,
+  RewardType,
+  RewardReceiptType,
+  RewardReceipt,
+  RewardHistoryType,
+  RewardHistoryEntry,
+  Achievement,
+  AchievementId,
+  AchievementRarity,
+} from "@hunty/types"
 
 // ─── Transaction Results ─────────────────────────────────────────────────────
 
@@ -184,15 +117,7 @@ export interface FastestPlayerDisplayEntry {
   icon: ReactNode
 }
 
-// ─── Player & Registration ───────────────────────────────────────────────────
-
-export type PlayerProgress = {
-  hunt_id: number
-  player: string
-  current_clue_index: number
-  completed: boolean
-  reward_claimed: boolean
-}
+// ─── Registration (PlayerProgress lives in @hunty/types) ─────────────────────
 
 export type RegistrationStatus = {
   isRegistered: boolean
@@ -250,11 +175,15 @@ export interface HuntAttemptTimeComparison {
   totalComparedPlayers: number
 }
 
-// ─── Reward ──────────────────────────────────────────────────────────────────
+// ─── Reward (web view) ───────────────────────────────────────────────────────
 
-export interface Reward {
-  place: number
-  amount: number
+/**
+ * Web-facing reward bucket. Extends the shared domain {@link DomainReward}
+ * with an optional rendered icon node used by the reward panels. The plain
+ * `{ place, amount }` domain shape (and the receipt/history types) live in
+ * `@hunty/types`.
+ */
+export interface Reward extends DomainReward {
   icon?: ReactNode
 }
 
@@ -263,35 +192,6 @@ export interface RewardPlayerProgress {
   reward_claimed: boolean
   hunt_id?: number | string
   reward_amount?: number
-}
-
-export type RewardReceiptType = "deposit" | "distribution" | "claim" | "refund"
-
-export interface RewardReceipt {
-  id: string
-  huntId: number
-  type: RewardReceiptType
-  txHash: string
-  amount: number
-  from?: string
-  to?: string
-  rank?: number
-  createdAt: number
-}
-
-export type RewardHistoryType = "XLM" | "NFT"
-
-export interface RewardHistoryEntry {
-  id: string
-  type: RewardHistoryType
-  amount?: number
-  description: string
-  txHash: string
-  earnedAt: string
-  huntId?: number
-  huntName?: string
-  recipient?: string
-  explorerUrl: string
 }
 
 // ─── Activity Feed ───────────────────────────────────────────────────────────
@@ -327,26 +227,7 @@ export interface HuntCard {
   difficulty?: ClueDifficulty
 }
 
-export interface HuntDraft {
-  id: number
-  title: string
-  description: string
-  link: string
-  code: string
-  image?: string
-  sequential?: boolean
-}
-
-export interface PlayerStats {
-  address: string
-  totalHuntsCompleted: number
-  totalPointsEarned: number
-  totalNftsReceived: number
-  totalCompletionTimeSeconds: number
-  completedHuntsTracked: number
-  averageCompletionTimeSeconds: number
-  lastUpdated: number
-}
+// HuntDraft and PlayerStats now live in @hunty/types (re-exported above).
 
 export type CoverImageUploadState = "idle" | "uploading" | "succeeded" | "failed"
 
@@ -396,19 +277,7 @@ export interface PlayerCountResult {
 }
 
 // ─── Profile Dashboard Types ───────────────────────────────────────────────────
-
-export type HuntProgressStatus = "Completed" | "In-Progress"
-
-export interface PlayerHuntProgress {
-  id: number
-  title: string
-  description: string
-  totalClues: number
-  status: HuntProgressStatus
-  pointsEarned: number
-  startedAt: string
-  completedAt?: string
-}
+// HuntProgressStatus and PlayerHuntProgress now live in @hunty/types.
 
 export interface NftAttribute {
   trait_type: string

--- a/mobile/app/(tabs)/hunts.tsx
+++ b/mobile/app/(tabs)/hunts.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@providers/ThemeProvider';
 import { useToast } from '@providers/ToastProvider';
 import { getAllHunts } from '@store/huntStore';
 import { usePlayerStore, useWalletStore } from '@store/useStore';
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 
 function rewardLabel(hunt: StoredHunt) {
   if (hunt.rewardType === 'Both') return '100 XLM + NFT';

--- a/mobile/app/(tabs)/play.tsx
+++ b/mobile/app/(tabs)/play.tsx
@@ -8,7 +8,7 @@ import { useTheme } from '@providers/ThemeProvider';
 import { useHaptics } from '@hooks/useHaptics';
 import { getHuntClues } from '@store/huntStore';
 import { usePlayerStore, useWalletStore } from '@store/useStore';
-import type { Clue } from '@lib/types';
+import type { Clue } from '@hunty/types';
 import { verifyQrAgainstClue } from '@lib/qrCodeDecryptor';
 import { matchesClueAnswer } from '@lib/clueAnswerVerification';
 import { useToast } from '@providers/ToastProvider';

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@providers/ThemeProvider';
 import { useToast } from '@providers/ToastProvider';
 import { getAllHunts } from '@store/huntStore';
 import { usePlayerStore, useWalletStore } from '@store/useStore';
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 
 function rewardLabel(hunt: StoredHunt) {
   if (hunt.rewardType === 'Both') return '100 XLM + NFT';

--- a/mobile/app/details.tsx
+++ b/mobile/app/details.tsx
@@ -5,7 +5,7 @@ import { ThemedCustomText, ThemedView } from '@components/themed';
 import { useTheme } from '@providers/ThemeProvider';
 import { getHuntById, getHuntClues } from '@store/huntStore';
 import { usePlayerStore } from '@store/useStore';
-import type { Clue, StoredHunt } from '@lib/types';
+import type { Clue, StoredHunt } from '@hunty/types';
 import { ClueMarkdownRenderer } from '@components/ClueMarkdownRenderer';
 
 export default function DetailsScreen() {

--- a/mobile/app/nested.tsx
+++ b/mobile/app/nested.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@providers/ThemeProvider';
 import { getHuntById, getHuntClues } from '@store/huntStore';
 import { usePlayerStore } from '@store/useStore';
 import { CluesList } from '@components/CluesList';
-import type { Clue, StoredHunt } from '@lib/types';
+import type { Clue, StoredHunt } from '@hunty/types';
 import { ClueMarkdownRenderer } from '@components/ClueMarkdownRenderer';
 import { verifyClueGeofence } from '@/lib/locationGate';
 import { useHaptics } from '@hooks/useHaptics';

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -22,6 +22,7 @@ module.exports = function (api) {
                 '@hooks': './hooks',
                 '@app': './app',
                 '@shared': '../shared',
+                '@hunty/types': '../packages/types/src',
               },
             },
           ],

--- a/mobile/components/ClueListItem.tsx
+++ b/mobile/components/ClueListItem.tsx
@@ -19,7 +19,7 @@ import Animated, {
   withSequence,
   runOnJS,
 } from 'react-native-reanimated';
-import type { ClueInfo } from '@lib/types';
+import type { ClueInfo } from '@hunty/types';
 
 interface ClueListItemProps {
   clue: ClueInfo;

--- a/mobile/components/CluesList.tsx
+++ b/mobile/components/CluesList.tsx
@@ -9,7 +9,7 @@
  */
 
 import { StyleSheet, ScrollView, Text, Pressable, View } from 'react-native';
-import type { Clue } from '@lib/types';
+import type { Clue } from '@hunty/types';
 
 interface CluesListProps {
   clues: Clue[];

--- a/mobile/components/GameMapScreen.tsx
+++ b/mobile/components/GameMapScreen.tsx
@@ -6,7 +6,7 @@ import { ThemedCustomText } from '@components/themed';
 import { usePlayerLocation } from '@app/hooks/usePlayerLocation';
 import { buildClueZones, zoneColor, type ClueZone } from '@/lib/clueZones';
 import { getAllHunts } from '@store/huntStore';
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 
 const INITIAL_DELTA = 0.02;
 

--- a/mobile/components/HuntCard.tsx
+++ b/mobile/components/HuntCard.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 import { ThemedCustomText, ThemedView } from '@components/themed';
 import { HuntCoverImage } from '@components/HuntCoverImage';
 import { useTheme } from '@providers/ThemeProvider';

--- a/mobile/components/HuntFeedItem.tsx
+++ b/mobile/components/HuntFeedItem.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 import { ThemedCustomText, ThemedView } from '@components/themed';
 import { useTheme } from '@providers/ThemeProvider';
 

--- a/mobile/components/OptimizedHuntFeed.tsx
+++ b/mobile/components/OptimizedHuntFeed.tsx
@@ -8,7 +8,7 @@ import { ThemedCustomText, ThemedView } from '@components/themed';
 import { useTheme } from '@providers/ThemeProvider';
 import { HuntyRefreshControl } from './HuntyRefreshControl';
 import { FeedItemSkeleton } from './skeletons/FeedItemSkeleton';
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 
 const PAGE_SIZE = 8;
 const INITIAL_PAGE_SIZE = 6;

--- a/mobile/lib/clueZones.ts
+++ b/mobile/lib/clueZones.ts
@@ -1,4 +1,4 @@
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 
 export type ClueZone = {
   huntId: number;

--- a/mobile/lib/graphql/hunts.ts
+++ b/mobile/lib/graphql/hunts.ts
@@ -1,4 +1,4 @@
-import type { HuntStatus, StoredHunt } from '@lib/types';
+import type { HuntStatus, StoredHunt } from '@hunty/types';
 import { graphqlRequest } from './client';
 import { ACTIVE_HUNTS_QUERY, HUNT_BY_ID_QUERY } from './queries';
 

--- a/mobile/lib/locationGate.ts
+++ b/mobile/lib/locationGate.ts
@@ -1,5 +1,5 @@
 import * as Location from 'expo-location';
-import type { Clue } from '@lib/types';
+import type { Clue } from '@hunty/types';
 import {
   DEFAULT_GEOFENCE_RADIUS_METERS,
   getClueGeofenceRadiusMeters,

--- a/mobile/path-alias.js
+++ b/mobile/path-alias.js
@@ -5,6 +5,7 @@ const alias = {
   "@lib": path.resolve(__dirname, "../lib"),
   "@store": path.resolve(__dirname, "./store"),
   "@providers": path.resolve(__dirname, "./providers"),
+  "@hunty/types": path.resolve(__dirname, "../packages/types/src"),
 };
 
 module.exports = alias;

--- a/mobile/services/huntsApi.ts
+++ b/mobile/services/huntsApi.ts
@@ -1,4 +1,4 @@
-import type { StoredHunt } from '@lib/types';
+import type { StoredHunt } from '@hunty/types';
 import { fetchActiveHuntsFromIndexer, fetchHuntByIdFromIndexer } from '@/lib/graphql/hunts';
 import { getActiveHuntsForFeed, getHuntById } from '@store/huntStore';
 

--- a/mobile/store/huntStore.ts
+++ b/mobile/store/huntStore.ts
@@ -4,9 +4,9 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
-import type { Clue, HuntStatus, StoredHunt } from '@lib/types';
+import type { Clue, HuntStatus, StoredHunt } from '@hunty/types';
 
-import type { HuntStatus, StoredHunt, Clue } from "@lib/types";
+import type { HuntStatus, StoredHunt, Clue } from "@hunty/types";
 import * as SecureStore from "expo-secure-store";
 import { scheduleHuntExpiryNotification } from "@utils/huntNotifications";
 const HUNTS_KEY = 'hunty_hunts';

--- a/mobile/store/useStore.ts
+++ b/mobile/store/useStore.ts
@@ -11,7 +11,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import * as SecureStore from "expo-secure-store";
-import type { PlayerProgress } from "@lib/types";
+import type { PlayerProgress } from "@hunty/types";
 
 // ─── Wallet Store ─────────────────────────────────────────────────────────────
 

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -15,7 +15,9 @@
       "@utils/*": ["./utils/*"],
       "@config/*": ["./config/*"],
       "@app/*": ["./app/*"],
-      "@shared/*": ["../shared/*"]
+      "@shared/*": ["../shared/*"],
+      "@hunty/types": ["../packages/types/src/index.ts"],
+      "@hunty/types/*": ["../packages/types/src/*"]
     }
   }
 }

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,45 @@
+# @hunty/types
+
+Shared TypeScript domain types for the Hunty **web** (`app/`, `lib/`) and
+**mobile** (`mobile/`) apps. Extracting these into one package keeps the two
+platforms in sync and removes mobile's dependency on reaching into the web
+app's `lib/`.
+
+## What's here
+
+| Module | Contents |
+| --- | --- |
+| `hunt.ts` | `StoredHunt`, `HuntInfo`, `HuntDraft`, `HuntStatus`, `HuntCategory`, `HuntDifficulty` |
+| `clue.ts` | `Clue`, `ClueInfo`, `ClueRow`, `ClueDifficulty` |
+| `player.ts` | `PlayerProgress`, `PlayerStats`, `PlayerHuntProgress`, `HuntProgressStatus` |
+| `reward.ts` | `Reward`, `RewardType`, `RewardReceipt`, `RewardHistoryEntry` |
+| `achievement.ts` | `Achievement`, `AchievementId`, `AchievementRarity` |
+| `guards.ts` | Type guards (`isStoredHunt`, `isClue`, …) and assertions (`assertStoredHunt`, …) |
+| `schemas.ts` | Zod schemas for runtime validation |
+
+## Usage
+
+```ts
+// Types + dependency-free runtime guards
+import { StoredHunt, isStoredHunt, assertClue } from "@hunty/types"
+
+// Zod schemas (opt-in — pulls in `zod`)
+import { storedHuntSchema } from "@hunty/types/schemas"
+
+const hunt = storedHuntSchema.parse(await res.json())
+```
+
+The main entry (`@hunty/types`) is **dependency-free** so it is safe to import
+from the mobile bundle. Zod schemas are isolated behind `@hunty/types/schemas`
+so consumers that only need static types never pull in `zod`.
+
+## Resolution
+
+This is a path-aliased workspace folder (no build step), matching the repo's
+existing `shared/` convention:
+
+- Web (`tsconfig.json`): `@hunty/types` → `packages/types/src`
+- Mobile (`mobile/tsconfig.json` + `babel.config.js`): `@hunty/types` → `../packages/types/src`
+
+The web app's `lib/types.ts` re-exports these domain types, so existing
+`@/lib/types` imports continue to work unchanged.

--- a/packages/types/__tests__/guards.test.ts
+++ b/packages/types/__tests__/guards.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  assertAchievement,
+  assertClue,
+  assertPlayerProgress,
+  assertReward,
+  assertStoredHunt,
+  isAchievement,
+  isAchievementId,
+  isClue,
+  isHuntStatus,
+  isPlayerProgress,
+  isReward,
+  isRewardType,
+  isStoredHunt,
+  type Achievement,
+  type Clue,
+  type PlayerProgress,
+  type Reward,
+  type StoredHunt,
+} from "../src/index"
+
+const validReward: Reward = { place: 1, amount: 10 }
+
+const validClue: Clue = {
+  id: 1,
+  huntId: 2,
+  question: "Where?",
+  answer: "here",
+  points: 5,
+}
+
+const validHunt: StoredHunt = {
+  id: 1,
+  title: "City Hunt",
+  description: "A hunt",
+  cluesCount: 3,
+  status: "Active",
+  rewardType: "XLM",
+  rewards: [validReward],
+}
+
+const validProgress: PlayerProgress = {
+  hunt_id: 1,
+  player: "GABC",
+  current_clue_index: 0,
+  completed: false,
+  reward_claimed: false,
+}
+
+const validAchievement: Achievement = {
+  id: "first_win",
+  title: "Victory Lap",
+  description: "Win your first hunt",
+  icon: "🏆",
+  rarity: "common",
+  condition: "Win 1 hunt",
+}
+
+describe("enum guards", () => {
+  it("recognises valid hunt statuses and reward types", () => {
+    expect(isHuntStatus("Active")).toBe(true)
+    expect(isHuntStatus("active")).toBe(false)
+    expect(isRewardType("Both")).toBe(true)
+    expect(isRewardType("DOGE")).toBe(false)
+    expect(isAchievementId("legend")).toBe(true)
+    expect(isAchievementId("nope")).toBe(false)
+  })
+})
+
+describe("shape guards", () => {
+  it("accepts valid domain objects", () => {
+    expect(isReward(validReward)).toBe(true)
+    expect(isClue(validClue)).toBe(true)
+    expect(isStoredHunt(validHunt)).toBe(true)
+    expect(isPlayerProgress(validProgress)).toBe(true)
+    expect(isAchievement(validAchievement)).toBe(true)
+  })
+
+  it("rejects malformed objects and non-objects", () => {
+    expect(isReward({ place: 1 })).toBe(false)
+    expect(isClue({ ...validClue, answer: 42 })).toBe(false)
+    expect(isStoredHunt({ ...validHunt, status: "Paused" })).toBe(false)
+    expect(isStoredHunt({ ...validHunt, rewards: [{ place: 1 }] })).toBe(false)
+    expect(isPlayerProgress(null)).toBe(false)
+    expect(isAchievement({ ...validAchievement, rarity: "mythic" })).toBe(false)
+    expect(isReward("nope")).toBe(false)
+  })
+})
+
+describe("assertion functions", () => {
+  it("pass through valid values", () => {
+    expect(() => assertStoredHunt(validHunt)).not.toThrow()
+    expect(() => assertClue(validClue)).not.toThrow()
+    expect(() => assertReward(validReward)).not.toThrow()
+    expect(() => assertPlayerProgress(validProgress)).not.toThrow()
+    expect(() => assertAchievement(validAchievement)).not.toThrow()
+  })
+
+  it("throw a TypeError describing what was received", () => {
+    expect(() => assertStoredHunt(null)).toThrow(TypeError)
+    expect(() => assertClue([])).toThrow(/received array/)
+    expect(() => assertReward(undefined)).toThrow(/Expected Reward/)
+  })
+})

--- a/packages/types/__tests__/schemas.test.ts
+++ b/packages/types/__tests__/schemas.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  achievementSchema,
+  clueSchema,
+  playerProgressSchema,
+  rewardSchema,
+  schemas,
+  storedHuntSchema,
+} from "../src/schemas"
+
+describe("zod schemas", () => {
+  it("parses a valid stored hunt", () => {
+    const parsed = storedHuntSchema.parse({
+      id: 1,
+      title: "City Hunt",
+      description: "A hunt",
+      cluesCount: 3,
+      status: "Active",
+      rewardType: "XLM",
+      rewards: [{ place: 1, amount: 10 }],
+    })
+
+    expect(parsed.title).toBe("City Hunt")
+  })
+
+  it("rejects an invalid hunt status", () => {
+    const result = storedHuntSchema.safeParse({
+      id: 1,
+      title: "City Hunt",
+      description: "A hunt",
+      cluesCount: 3,
+      status: "Paused",
+      rewardType: "XLM",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("validates reward, clue, progress, and achievement shapes", () => {
+    expect(rewardSchema.safeParse({ place: 1, amount: 5 }).success).toBe(true)
+    expect(rewardSchema.safeParse({ place: 1 }).success).toBe(false)
+
+    expect(
+      clueSchema.safeParse({
+        id: 1,
+        huntId: 1,
+        question: "Q",
+        answer: "A",
+        points: 1,
+      }).success,
+    ).toBe(true)
+
+    expect(
+      playerProgressSchema.safeParse({
+        hunt_id: 1,
+        player: "GABC",
+        current_clue_index: 0,
+        completed: false,
+        reward_claimed: false,
+      }).success,
+    ).toBe(true)
+
+    expect(
+      achievementSchema.safeParse({
+        id: "first_win",
+        title: "Victory Lap",
+        description: "Win your first hunt",
+        icon: "🏆",
+        rarity: "common",
+        condition: "Win 1 hunt",
+      }).success,
+    ).toBe(true)
+  })
+
+  it("exposes a schema lookup map", () => {
+    expect(Object.keys(schemas).sort()).toEqual([
+      "achievement",
+      "clue",
+      "playerProgress",
+      "reward",
+      "storedHunt",
+    ])
+  })
+})

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@hunty/types",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared TypeScript domain types, Zod schemas, and guards consumed by the Hunty web and mobile apps.",
+  "types": "./src/index.ts",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts"
+  },
+  "sideEffects": false,
+  "peerDependencies": {
+    "zod": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  }
+}

--- a/packages/types/src/achievement.ts
+++ b/packages/types/src/achievement.ts
@@ -1,0 +1,36 @@
+/**
+ * Achievement domain types shared across web and mobile.
+ *
+ * The concrete achievement catalogue (titles, conditions, unlock logic) lives
+ * with each app; this module owns only the shared shape and identifiers.
+ */
+
+export type AchievementId =
+  | "first_hunt_completed"
+  | "first_win"
+  | "five_wins"
+  | "ten_wins"
+  | "twenty_five_wins"
+  | "first_nft"
+  | "high_scorer"
+  | "speed_hunter"
+  | "veteran"
+  | "legend"
+
+export type AchievementRarity =
+  | "common"
+  | "uncommon"
+  | "rare"
+  | "epic"
+  | "legendary"
+
+export interface Achievement {
+  id: AchievementId
+  title: string
+  description: string
+  /** Emoji or icon identifier (platform-agnostic string). */
+  icon: string
+  rarity: AchievementRarity
+  /** Human-readable unlock condition. */
+  condition: string
+}

--- a/packages/types/src/clue.ts
+++ b/packages/types/src/clue.ts
@@ -1,0 +1,45 @@
+/**
+ * Clue domain types shared across web and mobile.
+ */
+
+export type ClueDifficulty = "Easy" | "Medium" | "Hard"
+
+/** A fully-specified clue as stored/served for a hunt. */
+export interface Clue {
+  id: number
+  huntId: number
+  question: string
+  answer: string
+  points: number
+  hint?: string
+  hintCost?: number
+  /** Optional difficulty tag set by the creator. */
+  difficulty?: ClueDifficulty
+  /** Center latitude for the clue's answer geofence. */
+  latitude?: number
+  /** Center longitude for the clue's answer geofence. */
+  longitude?: number
+  /** Allowed distance from the clue center in metres. Defaults to 100m. */
+  geofenceRadiusMeters?: number
+}
+
+/** Public projection of a clue (no answer) served to players. */
+export interface ClueInfo {
+  id: number
+  question: string
+  points: number
+  hint?: string
+  hintCost?: number
+  difficulty?: ClueDifficulty
+}
+
+/** Creator-side clue row including the answer. */
+export interface ClueRow {
+  id: number
+  question: string
+  answer: string
+  points: number
+  hint?: string
+  hintCost?: number
+  difficulty?: ClueDifficulty
+}

--- a/packages/types/src/guards.ts
+++ b/packages/types/src/guards.ts
@@ -1,0 +1,158 @@
+/**
+ * Runtime type guards and assertion functions for the shared domain types.
+ *
+ * These are dependency-free (no Zod) so they can be consumed by both the web
+ * and mobile apps without pulling a validation library into the bundle. For
+ * full schema validation of untrusted input, use the Zod schemas exported from
+ * `@hunty/types/schemas`.
+ */
+
+import type { Clue } from "./clue"
+import type { HuntStatus, StoredHunt } from "./hunt"
+import type { Achievement, AchievementId, AchievementRarity } from "./achievement"
+import type { PlayerProgress } from "./player"
+import type { Reward, RewardType } from "./reward"
+
+const HUNT_STATUSES: readonly HuntStatus[] = [
+  "Active",
+  "Completed",
+  "Draft",
+  "Cancelled",
+]
+
+const REWARD_TYPES: readonly RewardType[] = ["XLM", "NFT", "Both"]
+
+const ACHIEVEMENT_IDS: readonly AchievementId[] = [
+  "first_hunt_completed",
+  "first_win",
+  "five_wins",
+  "ten_wins",
+  "twenty_five_wins",
+  "first_nft",
+  "high_scorer",
+  "speed_hunter",
+  "veteran",
+  "legend",
+]
+
+const ACHIEVEMENT_RARITIES: readonly AchievementRarity[] = [
+  "common",
+  "uncommon",
+  "rare",
+  "epic",
+  "legendary",
+]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function isHuntStatus(value: unknown): value is HuntStatus {
+  return (
+    typeof value === "string" &&
+    (HUNT_STATUSES as readonly string[]).includes(value)
+  )
+}
+
+export function isRewardType(value: unknown): value is RewardType {
+  return (
+    typeof value === "string" &&
+    (REWARD_TYPES as readonly string[]).includes(value)
+  )
+}
+
+export function isAchievementId(value: unknown): value is AchievementId {
+  return (
+    typeof value === "string" &&
+    (ACHIEVEMENT_IDS as readonly string[]).includes(value)
+  )
+}
+
+export function isReward(value: unknown): value is Reward {
+  return (
+    isRecord(value) &&
+    typeof value.place === "number" &&
+    typeof value.amount === "number"
+  )
+}
+
+export function isClue(value: unknown): value is Clue {
+  return (
+    isRecord(value) &&
+    typeof value.id === "number" &&
+    typeof value.huntId === "number" &&
+    typeof value.question === "string" &&
+    typeof value.answer === "string" &&
+    typeof value.points === "number"
+  )
+}
+
+export function isStoredHunt(value: unknown): value is StoredHunt {
+  return (
+    isRecord(value) &&
+    typeof value.id === "number" &&
+    typeof value.title === "string" &&
+    typeof value.description === "string" &&
+    typeof value.cluesCount === "number" &&
+    isHuntStatus(value.status) &&
+    isRewardType(value.rewardType) &&
+    (value.rewards === undefined ||
+      (Array.isArray(value.rewards) && value.rewards.every(isReward)))
+  )
+}
+
+export function isPlayerProgress(value: unknown): value is PlayerProgress {
+  return (
+    isRecord(value) &&
+    typeof value.hunt_id === "number" &&
+    typeof value.player === "string" &&
+    typeof value.current_clue_index === "number" &&
+    typeof value.completed === "boolean" &&
+    typeof value.reward_claimed === "boolean"
+  )
+}
+
+export function isAchievement(value: unknown): value is Achievement {
+  return (
+    isRecord(value) &&
+    isAchievementId(value.id) &&
+    typeof value.title === "string" &&
+    typeof value.description === "string" &&
+    typeof value.icon === "string" &&
+    typeof value.rarity === "string" &&
+    (ACHIEVEMENT_RARITIES as readonly string[]).includes(value.rarity) &&
+    typeof value.condition === "string"
+  )
+}
+
+// ─── Assertion functions ─────────────────────────────────────────────────────
+
+function fail(label: string, value: unknown): never {
+  const received =
+    value === null ? "null" : Array.isArray(value) ? "array" : typeof value
+  throw new TypeError(`Expected ${label}, received ${received}`)
+}
+
+export function assertStoredHunt(value: unknown): asserts value is StoredHunt {
+  if (!isStoredHunt(value)) fail("StoredHunt", value)
+}
+
+export function assertClue(value: unknown): asserts value is Clue {
+  if (!isClue(value)) fail("Clue", value)
+}
+
+export function assertReward(value: unknown): asserts value is Reward {
+  if (!isReward(value)) fail("Reward", value)
+}
+
+export function assertPlayerProgress(
+  value: unknown,
+): asserts value is PlayerProgress {
+  if (!isPlayerProgress(value)) fail("PlayerProgress", value)
+}
+
+export function assertAchievement(
+  value: unknown,
+): asserts value is Achievement {
+  if (!isAchievement(value)) fail("Achievement", value)
+}

--- a/packages/types/src/hunt.ts
+++ b/packages/types/src/hunt.ts
@@ -1,0 +1,80 @@
+/**
+ * Hunt domain types shared across web and mobile.
+ */
+
+import type { Reward, RewardType } from "./reward"
+
+export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled"
+
+/** Broad hunt category used in discovery filters. */
+export type HuntCategory = "Urban" | "Campus" | "Office" | "Museum" | "General"
+
+/** Overall hunt difficulty tag used in discovery filters. */
+export type HuntDifficulty = "Easy" | "Medium" | "Hard"
+
+/** The canonical persisted shape of a hunt. */
+export interface StoredHunt {
+  id: number
+  title: string
+  description: string
+  cluesCount: number
+  /** Broad hunt category used in discovery filters. */
+  category?: HuntCategory
+  /** Overall hunt difficulty tag used in discovery filters. */
+  difficulty?: HuntDifficulty
+  status: HuntStatus
+  rewardType: RewardType
+  /** When true, players must solve clues in order. */
+  sequential?: boolean
+  /** Total reward pool value used for creator-side sorting. */
+  rewardPool?: number
+  /** Per-place XLM reward buckets funded by the creator. */
+  rewards?: Reward[]
+  /** Escrow transaction hash proving the creator funded the XLM reward pool. */
+  rewardEscrowTxHash?: string
+  /** Amount still available in the XLM escrow. */
+  rewardEscrowBalance?: number
+  /** Creator-side participant count snapshot for dashboard sorting. */
+  playerCount?: number
+  /** Max number of participants for limited spots */
+  maxCapacity?: number
+  /** Unix timestamp in seconds when the hunt draft was created locally. */
+  createdAt?: number
+  /** Unix timestamp in seconds — when the hunt starts. */
+  startTime?: number
+  /** Unix timestamp in seconds — when the hunt ends. */
+  endTime?: number
+  creatorEmail?: string
+  emailNotifications?: boolean
+  /** When true, the hunt is hidden from the public arcade grid. */
+  is_private?: boolean
+  /** Optional game cover CID/URL for hunt cards and sharing previews. */
+  coverImageCid?: string
+  /** Active editorial banner showcase at the top of the Arcade. */
+  isFeaturedOfWeek?: boolean
+}
+
+/** Lightweight hunt projection used by list/detail views. */
+export interface HuntInfo {
+  id: number
+  title: string
+  description: string
+  totalClues: number
+  status: string
+  sequential?: boolean
+  startTime?: number
+  endTime?: number
+  creatorEmail?: string
+  emailNotifications?: boolean
+}
+
+/** Editable draft clue used while building a hunt. */
+export interface HuntDraft {
+  id: number
+  title: string
+  description: string
+  link: string
+  code: string
+  image?: string
+  sequential?: boolean
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @hunty/types — shared domain types for the Hunty web and mobile apps.
+ *
+ * This entry point is intentionally dependency-free (types + plain runtime
+ * guards only) so it can be consumed anywhere. Zod schemas for validating
+ * untrusted input live in `@hunty/types/schemas`.
+ */
+
+export * from "./hunt"
+export * from "./clue"
+export * from "./player"
+export * from "./reward"
+export * from "./achievement"
+export * from "./guards"

--- a/packages/types/src/player.ts
+++ b/packages/types/src/player.ts
@@ -1,0 +1,38 @@
+/**
+ * Player domain types shared across web and mobile.
+ */
+
+/** A player's live progress within a single hunt. */
+export interface PlayerProgress {
+  hunt_id: number
+  player: string
+  current_clue_index: number
+  completed: boolean
+  reward_claimed: boolean
+}
+
+/** Aggregated lifetime stats for a player address. */
+export interface PlayerStats {
+  address: string
+  totalHuntsCompleted: number
+  totalPointsEarned: number
+  totalNftsReceived: number
+  totalCompletionTimeSeconds: number
+  completedHuntsTracked: number
+  averageCompletionTimeSeconds: number
+  lastUpdated: number
+}
+
+export type HuntProgressStatus = "Completed" | "In-Progress"
+
+/** A player's progress summary for a hunt shown on the profile dashboard. */
+export interface PlayerHuntProgress {
+  id: number
+  title: string
+  description: string
+  totalClues: number
+  status: HuntProgressStatus
+  pointsEarned: number
+  startedAt: string
+  completedAt?: string
+}

--- a/packages/types/src/reward.ts
+++ b/packages/types/src/reward.ts
@@ -1,0 +1,47 @@
+/**
+ * Reward domain types.
+ *
+ * Platform-agnostic: these describe the on-chain / stored shape of a reward
+ * bucket and its history. UI-only concerns (such as a rendered icon node) are
+ * layered on top by each consuming app.
+ */
+
+/** How a hunt pays out to winners. */
+export type RewardType = "XLM" | "NFT" | "Both"
+
+/** A single reward bucket funded by the hunt creator for a given placement. */
+export interface Reward {
+  /** Finishing place this bucket rewards (1 = first). */
+  place: number
+  /** Amount awarded for the placement (XLM for token rewards). */
+  amount: number
+}
+
+export type RewardReceiptType = "deposit" | "distribution" | "claim" | "refund"
+
+export interface RewardReceipt {
+  id: string
+  huntId: number
+  type: RewardReceiptType
+  txHash: string
+  amount: number
+  from?: string
+  to?: string
+  rank?: number
+  createdAt: number
+}
+
+export type RewardHistoryType = "XLM" | "NFT"
+
+export interface RewardHistoryEntry {
+  id: string
+  type: RewardHistoryType
+  amount?: number
+  description: string
+  txHash: string
+  earnedAt: string
+  huntId?: number
+  huntName?: string
+  recipient?: string
+  explorerUrl: string
+}

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -1,0 +1,107 @@
+/**
+ * Zod schemas for runtime validation of the shared domain types.
+ *
+ * Imported from `@hunty/types/schemas` so that consumers who only need the
+ * static types (e.g. the mobile app) don't pull Zod into their bundle. Each
+ * schema is designed to stay structurally in sync with its interface in the
+ * sibling modules.
+ */
+
+import { z } from "zod"
+
+export const rewardTypeSchema = z.enum(["XLM", "NFT", "Both"])
+
+export const huntStatusSchema = z.enum([
+  "Active",
+  "Completed",
+  "Draft",
+  "Cancelled",
+])
+
+export const clueDifficultySchema = z.enum(["Easy", "Medium", "Hard"])
+
+export const rewardSchema = z.object({
+  place: z.number(),
+  amount: z.number(),
+})
+
+export const clueSchema = z.object({
+  id: z.number(),
+  huntId: z.number(),
+  question: z.string(),
+  answer: z.string(),
+  points: z.number(),
+  hint: z.string().optional(),
+  hintCost: z.number().optional(),
+  difficulty: clueDifficultySchema.optional(),
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
+  geofenceRadiusMeters: z.number().optional(),
+})
+
+export const storedHuntSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  description: z.string(),
+  cluesCount: z.number(),
+  category: z
+    .enum(["Urban", "Campus", "Office", "Museum", "General"])
+    .optional(),
+  difficulty: z.enum(["Easy", "Medium", "Hard"]).optional(),
+  status: huntStatusSchema,
+  rewardType: rewardTypeSchema,
+  sequential: z.boolean().optional(),
+  rewardPool: z.number().optional(),
+  rewards: z.array(rewardSchema).optional(),
+  rewardEscrowTxHash: z.string().optional(),
+  rewardEscrowBalance: z.number().optional(),
+  playerCount: z.number().optional(),
+  maxCapacity: z.number().optional(),
+  createdAt: z.number().optional(),
+  startTime: z.number().optional(),
+  endTime: z.number().optional(),
+  creatorEmail: z.string().optional(),
+  emailNotifications: z.boolean().optional(),
+  is_private: z.boolean().optional(),
+  coverImageCid: z.string().optional(),
+  isFeaturedOfWeek: z.boolean().optional(),
+})
+
+export const playerProgressSchema = z.object({
+  hunt_id: z.number(),
+  player: z.string(),
+  current_clue_index: z.number(),
+  completed: z.boolean(),
+  reward_claimed: z.boolean(),
+})
+
+export const achievementIdSchema = z.enum([
+  "first_hunt_completed",
+  "first_win",
+  "five_wins",
+  "ten_wins",
+  "twenty_five_wins",
+  "first_nft",
+  "high_scorer",
+  "speed_hunter",
+  "veteran",
+  "legend",
+])
+
+export const achievementSchema = z.object({
+  id: achievementIdSchema,
+  title: z.string(),
+  description: z.string(),
+  icon: z.string(),
+  rarity: z.enum(["common", "uncommon", "rare", "epic", "legendary"]),
+  condition: z.string(),
+})
+
+/** Convenience map so callers can look up a schema by domain name. */
+export const schemas = {
+  reward: rewardSchema,
+  clue: clueSchema,
+  storedHunt: storedHuntSchema,
+  playerProgress: playerProgressSchema,
+  achievement: achievementSchema,
+} as const

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,9 @@
     ],
     "paths": {
       "@/*": ["./*"],
-      "@shared/*": ["./shared/*"]
+      "@shared/*": ["./shared/*"],
+      "@hunty/types": ["./packages/types/src/index.ts"],
+      "@hunty/types/*": ["./packages/types/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,11 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@hunty/types/schemas": path.resolve(
+        __dirname,
+        "./packages/types/src/schemas.ts",
+      ),
+      "@hunty/types": path.resolve(__dirname, "./packages/types/src/index.ts"),
       "@": path.resolve(__dirname, "./"),
     },
   },


### PR DESCRIPTION
## Summary

Closes #554.

Extracts the platform-agnostic domain model into a dedicated **`packages/types`** package (`@hunty/types`) so the **web** (`app/`, `lib/`) and **mobile** (`mobile/`) apps consume a single source of truth — instead of mobile reaching into the web app's `lib/types.ts`.

## What's in the package

`packages/types/src/`
- **`hunt.ts`** — `StoredHunt`, `HuntInfo`, `HuntDraft`, `HuntStatus`, `HuntCategory`, `HuntDifficulty`
- **`clue.ts`** — `Clue`, `ClueInfo`, `ClueRow`, `ClueDifficulty`
- **`player.ts`** — `PlayerProgress`, `PlayerStats`, `PlayerHuntProgress`, `HuntProgressStatus`
- **`reward.ts`** — `Reward`, `RewardType`, `RewardReceipt`, `RewardHistoryEntry`
- **`achievement.ts`** — `Achievement`, `AchievementId`, `AchievementRarity`
- **`guards.ts`** — dependency-free type guards (`isStoredHunt`, `isClue`, …) + assertion functions (`assertStoredHunt`, …)
- **`schemas.ts`** — Zod schemas for runtime validation

## Acceptance criteria

- [x] Create `packages/types` with all domain types
- [x] Define Hunt, Clue, Player, Reward, Achievement interfaces
- [x] Add Zod schemas for runtime validation
- [x] Export type guards and assertion functions
- [x] Update all imports across web and mobile

## Design decisions

- **Build-free, path-aliased package** matching the repo's existing `shared/` convention — `@hunty/types` is wired via tsconfig paths (web + mobile), mobile babel/`path-alias.js`, and the vitest resolver. No workspace build step (the repo's `pnpm-workspace.yaml` is not a real build workspace).
- **Zod isolated behind `@hunty/types/schemas`.** The main entry is dependency-free (types + plain guards) so the **mobile** bundle never pulls in `zod` (mobile doesn't depend on it). Web, which already has `zod`, opts in via the sub-path.
- **Backward-compatible bridge.** `lib/types.ts` re-exports the domain types from `@hunty/types`, so the ~hundreds of existing `@/lib/types` imports on web keep working unchanged. The web-only, React-coupled `Reward` view (`icon?: ReactNode`) and the display/performance/chat types remain defined locally; the pure `{ place, amount }` `Reward` lives in the package.
- **Mobile imports migrated** from `@lib/types` → `@hunty/types` for all domain-type-only imports (one mixed import that also pulls web-only `NftRewardDetail`/`ProfileSummary` stays on the `@/lib/types` bridge).

## Testing

- New: `packages/types/__tests__/guards.test.ts` and `schemas.test.ts` — 9 tests, all passing.
- Full `lib/` suite: **490 passing**, with the only failure (`queryOptimizer.test.ts`) confirmed **pre-existing on `main`** and unrelated to this change.
- `tsc --noEmit` error count is **identical on this branch and `main` (158)** — zero new type errors across the web codebase. The package typechecks cleanly on its own (`tsc -p packages/types/tsconfig.json`).
- ESLint clean on the changed files.

> Note: mobile dependencies weren't installed in this environment, so `mobile` tsc wasn't executed locally; the `@hunty/types` alias is wired in `mobile/tsconfig.json` + `babel.config.js` + `path-alias.js`, and the migrated imports use only package-exported types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)