### PR TITLE
feat: rich text editor for hunt descriptions (#575)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -236,6 +236,49 @@ html {
     @apply min-h-screen bg-background;
   }
 
+  /* Rendered markdown from the rich text editor (hunt & clue descriptions). */
+  .markdown-content {
+    @apply break-words;
+  }
+  .markdown-content > *:first-child {
+    @apply mt-0;
+  }
+  .markdown-content > *:last-child {
+    @apply mb-0;
+  }
+  .markdown-content h1,
+  .markdown-content h2,
+  .markdown-content h3,
+  .markdown-content h4,
+  .markdown-content h5,
+  .markdown-content h6 {
+    @apply font-semibold leading-tight mt-3 mb-1.5;
+  }
+  .markdown-content h1 { @apply text-xl; }
+  .markdown-content h2 { @apply text-lg; }
+  .markdown-content h3 { @apply text-base; }
+  .markdown-content p { @apply my-2; }
+  .markdown-content a {
+    @apply underline underline-offset-2 hover:opacity-80;
+  }
+  .markdown-content ul { @apply list-disc pl-5 my-2 space-y-1; }
+  .markdown-content ol { @apply list-decimal pl-5 my-2 space-y-1; }
+  .markdown-content blockquote {
+    @apply border-l-2 border-slate-300 pl-3 italic opacity-90 my-2 dark:border-slate-600;
+  }
+  .markdown-content code {
+    @apply rounded bg-black/10 px-1 py-0.5 text-[0.85em] font-mono dark:bg-white/10;
+  }
+  .markdown-content pre {
+    @apply overflow-x-auto rounded-lg bg-slate-900 p-3 my-2 text-slate-100;
+  }
+  .markdown-content pre code {
+    @apply bg-transparent p-0 text-[0.85em];
+  }
+  .markdown-content img {
+    @apply my-2 max-w-full rounded-lg;
+  }
+
   .sidebar {
     @apply hidden md:flex md:flex-col md:w-64 md:fixed md:inset-y-0 md:left-0 md:py-6 md:px-4 md:border-r md:border-sidebar-border;
     background: var(--sidebar);

--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -9,6 +9,7 @@ import picture from "@/public/static-images/image1.png";
 import { HuntCardSkeleton } from "@/components/LoadingSkeletons";
 import { cn } from "@/lib/utils";
 import sanitizeHtml from "@/lib/sanitizeHtml";
+import { MarkdownContent } from "@/components/MarkdownContent";
 import { submitAnswer, AnswerIncorrectError, pollTransaction } from "@/lib/contracts/hunt";
 import { getClueElapsedSeconds, recordClueAttempt } from "@/lib/huntAttemptHistory";
 import { calculateCluePoints, DEFAULT_SCORING_WEIGHTS } from "@/lib/scoring";
@@ -371,7 +372,11 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
         <h3 className="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2 print:text-3xl print:mb-4">
           {hunt.title || "Untitled Hunt"}
         </h3>
-        <p className="text-xs sm:text-sm opacity-90 mb-4 sm:mb-6 line-clamp-3 print:text-lg print:opacity-100 print:mb-8" dangerouslySetInnerHTML={{ __html: sanitizeHtml(hunt.description || "No description provided.") }} />
+        <MarkdownContent
+          markdown={hunt.description || ""}
+          fallback="No description provided."
+          className="markdown-content text-xs sm:text-sm opacity-90 mb-4 sm:mb-6 line-clamp-3 print:text-lg print:opacity-100 print:mb-8"
+        />
         <div className="flex justify-center">
           {hunt.link || hunt.image ? (
             <Image

--- a/components/HuntForm.tsx
+++ b/components/HuntForm.tsx
@@ -21,6 +21,7 @@ import { COVER_IMAGE_UPLOAD_ERROR_MESSAGE, uploadToIPFS } from "@/lib/ipfs"
 import { logger } from "@/lib/logger"
 import { toast } from "sonner"
 import { HuntCards } from "./HuntCards"
+import { RichTextEditor } from "./RichTextEditor"
 import type { CoverImageUploadState, HuntDraft } from "@/lib/types"
 
 interface HuntFormProps {
@@ -236,14 +237,15 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
           className="w-full pl-6 py-3"
         />
 
-        <div className="flex gap-1">
-          <Input
-            placeholder="Description"
-            aria-label="Hunt Description"
-            value={hunt.description}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => onUpdate("description", e.target.value)}
-            className="w-full pl-6 py-3"
-          />
+        <div className="flex items-start gap-1">
+          <div className="flex-1">
+            <RichTextEditor
+              value={hunt.description}
+              onChange={(value) => onUpdate("description", value)}
+              ariaLabel="Hunt Description"
+              placeholder="Describe the hunt… Markdown, images, links and code blocks supported."
+            />
+          </div>
         <div className="relative">
           <Button
             type="button"

--- a/components/MarkdownContent.tsx
+++ b/components/MarkdownContent.tsx
@@ -1,0 +1,31 @@
+import { renderMarkdown } from "@/lib/markdown"
+import { cn } from "@/lib/utils"
+
+interface MarkdownContentProps {
+  /** Raw markdown source (authored in the rich text editor). */
+  markdown: string
+  /** Fallback rendered when `markdown` is empty. */
+  fallback?: string
+  className?: string
+}
+
+/**
+ * Renders markdown as sanitized HTML. All output passes through DOMPurify via
+ * {@link renderMarkdown}, so it is safe to use with `dangerouslySetInnerHTML`.
+ */
+export function MarkdownContent({
+  markdown,
+  fallback = "",
+  className,
+}: MarkdownContentProps) {
+  const html = renderMarkdown(markdown?.trim() ? markdown : fallback)
+
+  return (
+    <div
+      className={cn("markdown-content", className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
+
+export default MarkdownContent

--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -1,0 +1,274 @@
+"use client"
+
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ReactNode,
+} from "react"
+import {
+  Bold,
+  Code,
+  Eye,
+  Heading,
+  Image as ImageIcon,
+  Italic,
+  Link as LinkIcon,
+  List,
+  Pencil,
+  Quote,
+  SquareCode,
+} from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { MarkdownContent } from "@/components/MarkdownContent"
+import { uploadToIPFS } from "@/lib/ipfs"
+import { logger } from "@/lib/logger"
+import { cn } from "@/lib/utils"
+
+interface RichTextEditorProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  /** Accessible label for the textarea. */
+  ariaLabel?: string
+  id?: string
+  className?: string
+  minRows?: number
+}
+
+type Selection = { start: number; end: number }
+
+/**
+ * Markdown rich-text editor with a formatting toolbar, IPFS image embedding,
+ * link/code-block insertion, and a live sanitized preview. Emits markdown as a
+ * plain string via `onChange`.
+ */
+export function RichTextEditor({
+  value,
+  onChange,
+  placeholder = "Write a description… Markdown supported.",
+  ariaLabel = "Description",
+  id,
+  className,
+  minRows = 5,
+}: RichTextEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const pendingSelection = useRef<Selection | null>(null)
+  const [mode, setMode] = useState<"write" | "preview">("write")
+  const [isUploading, setIsUploading] = useState(false)
+
+  // Re-apply the caret/selection after a controlled value update.
+  useLayoutEffect(() => {
+    if (pendingSelection.current && textareaRef.current) {
+      const { start, end } = pendingSelection.current
+      textareaRef.current.focus()
+      textareaRef.current.setSelectionRange(start, end)
+      pendingSelection.current = null
+    }
+  }, [value])
+
+  const getSelection = (): Selection => {
+    const el = textareaRef.current
+    if (!el) return { start: value.length, end: value.length }
+    return { start: el.selectionStart, end: el.selectionEnd }
+  }
+
+  const applyChange = (next: string, selection: Selection) => {
+    pendingSelection.current = selection
+    onChange(next)
+  }
+
+  /** Wraps the current selection with `before`/`after`, inserting a placeholder when empty. */
+  const wrapSelection = (before: string, after: string, placeholderText: string) => {
+    const { start, end } = getSelection()
+    const selected = value.slice(start, end) || placeholderText
+    const next = value.slice(0, start) + before + selected + after + value.slice(end)
+    const cursorStart = start + before.length
+    applyChange(next, { start: cursorStart, end: cursorStart + selected.length })
+  }
+
+  /** Prefixes each selected line (or the current line) with `prefix`. */
+  const prefixLines = (prefix: string) => {
+    const { start, end } = getSelection()
+    const lineStart = value.lastIndexOf("\n", start - 1) + 1
+    const segment = value.slice(lineStart, end)
+    const prefixed = segment
+      .split("\n")
+      .map((line) => `${prefix}${line}`)
+      .join("\n")
+    const next = value.slice(0, lineStart) + prefixed + value.slice(end)
+    applyChange(next, {
+      start: lineStart,
+      end: lineStart + prefixed.length,
+    })
+  }
+
+  const insertBlock = (block: string, selectFrom: number, selectTo: number) => {
+    const { start, end } = getSelection()
+    const prefixNeedsBreak = start > 0 && value[start - 1] !== "\n"
+    const lead = prefixNeedsBreak ? "\n\n" : ""
+    const next = value.slice(0, start) + lead + block + value.slice(end)
+    const base = start + lead.length
+    applyChange(next, { start: base + selectFrom, end: base + selectTo })
+  }
+
+  const insertLink = () => {
+    const { start, end } = getSelection()
+    const label = value.slice(start, end) || "link text"
+    const snippet = `[${label}](https://)`
+    const next = value.slice(0, start) + snippet + value.slice(end)
+    // Place the caret inside the empty parentheses so the URL can be typed.
+    const urlPos = start + label.length + 3
+    applyChange(next, { start: urlPos, end: urlPos + "https://".length })
+  }
+
+  const insertCodeBlock = () => {
+    insertBlock("```\ncode\n```", 4, 8)
+  }
+
+  const handleImageSelected = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setIsUploading(true)
+    try {
+      const ipfsUri = await uploadToIPFS(file)
+      const alt = file.name.replace(/\.[^.]+$/, "")
+      const { start, end } = getSelection()
+      const snippet = `![${alt}](${ipfsUri})`
+      const next = value.slice(0, start) + snippet + value.slice(end)
+      applyChange(next, {
+        start: start + snippet.length,
+        end: start + snippet.length,
+      })
+      toast.success("Image uploaded and embedded.")
+    } catch (error) {
+      logger.error("Rich text image upload failed:", error)
+      toast.error("Failed to upload image. Please try again.")
+    } finally {
+      setIsUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ""
+    }
+  }
+
+  const toolbarButton = (
+    label: string,
+    icon: ReactNode,
+    onClick: () => void,
+    disabled = false,
+  ) => (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className="h-8 w-8 text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
+    >
+      {icon}
+    </Button>
+  )
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white dark:border-white/10 dark:bg-slate-900/50",
+        className,
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-1 border-b border-slate-200 p-1.5 dark:border-white/10">
+        {toolbarButton("Bold", <Bold className="h-4 w-4" />, () =>
+          wrapSelection("**", "**", "bold text"),
+        )}
+        {toolbarButton("Italic", <Italic className="h-4 w-4" />, () =>
+          wrapSelection("*", "*", "italic text"),
+        )}
+        {toolbarButton("Heading", <Heading className="h-4 w-4" />, () =>
+          prefixLines("## "),
+        )}
+        {toolbarButton("Inline code", <Code className="h-4 w-4" />, () =>
+          wrapSelection("`", "`", "code"),
+        )}
+        {toolbarButton("Code block", <SquareCode className="h-4 w-4" />, insertCodeBlock)}
+        {toolbarButton("Bullet list", <List className="h-4 w-4" />, () =>
+          prefixLines("- "),
+        )}
+        {toolbarButton("Quote", <Quote className="h-4 w-4" />, () => prefixLines("> "))}
+        {toolbarButton("Insert link", <LinkIcon className="h-4 w-4" />, insertLink)}
+        {toolbarButton(
+          "Embed image",
+          isUploading ? (
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          ) : (
+            <ImageIcon className="h-4 w-4" />
+          ),
+          () => fileInputRef.current?.click(),
+          isUploading,
+        )}
+
+        <div className="ml-auto flex items-center gap-1">
+          <Button
+            type="button"
+            variant={mode === "write" ? "secondary" : "ghost"}
+            size="sm"
+            onClick={() => setMode("write")}
+            className="h-8 gap-1 px-2 text-xs"
+            aria-pressed={mode === "write"}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            Write
+          </Button>
+          <Button
+            type="button"
+            variant={mode === "preview" ? "secondary" : "ghost"}
+            size="sm"
+            onClick={() => setMode("preview")}
+            className="h-8 gap-1 px-2 text-xs"
+            aria-pressed={mode === "preview"}
+          >
+            <Eye className="h-3.5 w-3.5" />
+            Preview
+          </Button>
+        </div>
+      </div>
+
+      {mode === "write" ? (
+        <Textarea
+          id={id}
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          rows={minRows}
+          variant="ghost"
+          className="min-h-28 resize-y rounded-none border-0 bg-transparent px-3 py-2 focus-visible:ring-0"
+        />
+      ) : (
+        <MarkdownContent
+          markdown={value}
+          fallback="_Nothing to preview yet._"
+          className="markdown-content min-h-28 px-3 py-2 text-sm text-slate-700 dark:text-slate-200"
+        />
+      )}
+
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleImageSelected}
+        accept="image/*"
+        aria-label="Upload image to embed"
+        className="hidden"
+      />
+    </div>
+  )
+}
+
+export default RichTextEditor

--- a/lib/__tests__/markdown.test.ts
+++ b/lib/__tests__/markdown.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import { markdownToHtml, renderMarkdown } from "@/lib/markdown"
+
+describe("markdownToHtml", () => {
+  it("returns an empty string for empty input", () => {
+    expect(markdownToHtml("")).toBe("")
+  })
+
+  it("renders headings", () => {
+    expect(markdownToHtml("# Title")).toBe("<h1>Title</h1>")
+    expect(markdownToHtml("### Sub")).toBe("<h3>Sub</h3>")
+  })
+
+  it("renders bold and italic", () => {
+    expect(markdownToHtml("**bold**")).toBe("<p><strong>bold</strong></p>")
+    expect(markdownToHtml("_italic_")).toBe("<p><em>italic</em></p>")
+    expect(markdownToHtml("a *mid* b")).toBe("<p>a <em>mid</em> b</p>")
+  })
+
+  it("renders inline code and fenced code blocks", () => {
+    expect(markdownToHtml("`x = 1`")).toBe("<p><code>x = 1</code></p>")
+    expect(markdownToHtml("```js\nconst a = 1;\n```")).toBe(
+      '<pre><code class="language-js">const a = 1;</code></pre>',
+    )
+  })
+
+  it("does not treat markdown inside code fences as markdown", () => {
+    const html = markdownToHtml("```\n**not bold**\n```")
+    expect(html).toBe("<pre><code>**not bold**</code></pre>")
+  })
+
+  it("renders links with safe rel/target", () => {
+    expect(markdownToHtml("[hunty](https://hunty.app)")).toBe(
+      '<p><a href="https://hunty.app" target="_blank" rel="noopener noreferrer">hunty</a></p>',
+    )
+  })
+
+  it("renders unordered and ordered lists", () => {
+    expect(markdownToHtml("- one\n- two")).toBe("<ul><li>one</li><li>two</li></ul>")
+    expect(markdownToHtml("1. a\n2. b")).toBe("<ol><li>a</li><li>b</li></ol>")
+  })
+
+  it("renders blockquotes", () => {
+    expect(markdownToHtml("> quoted")).toBe("<blockquote>quoted</blockquote>")
+  })
+
+  it("resolves ipfs:// image URIs to a gateway URL", () => {
+    const html = markdownToHtml("![pic](ipfs://QmAbc123)")
+    expect(html).toContain("<img")
+    expect(html).toContain("/ipfs/QmAbc123")
+    expect(html).not.toContain("ipfs://")
+  })
+
+  it("separates paragraphs on blank lines and keeps single newlines as breaks", () => {
+    expect(markdownToHtml("a\nb")).toBe("<p>a<br />b</p>")
+    expect(markdownToHtml("a\n\nb")).toBe("<p>a</p>\n<p>b</p>")
+  })
+})
+
+describe("markdown security", () => {
+  it("escapes raw HTML in the source", () => {
+    const html = markdownToHtml("<b>hi</b>")
+    expect(html).toContain("&lt;b&gt;")
+    expect(html).not.toContain("<b>hi</b>")
+  })
+
+  it("drops javascript: link URLs", () => {
+    const html = markdownToHtml("[click](javascript:alert(1))")
+    expect(html).not.toContain("javascript:")
+    expect(html).not.toContain("<a")
+  })
+
+  it("does not emit a script tag from an image onerror payload", () => {
+    const html = markdownToHtml('![x](https://e.com/x.png"onerror="alert(1))')
+    // The quote in the URL is escaped, so no attribute breakout is possible.
+    expect(html).not.toContain('onerror="alert(1)"')
+  })
+
+  it("renderMarkdown produces no live script/handler markup for a hostile payload", () => {
+    const payload = [
+      "# Title <script>alert(1)</script>",
+      "",
+      "[x](javascript:alert(2))",
+      "",
+      "<img src=x onerror=alert(3)>",
+    ].join("\n")
+    const html = renderMarkdown(payload).toLowerCase()
+    // No live script element and no javascript: URL survives.
+    expect(html).not.toContain("<script")
+    expect(html).not.toContain("javascript:")
+    // The raw <img onerror> is escaped to inert text, not a live element.
+    expect(html).not.toContain("<img src=x onerror")
+    expect(html).toContain("&lt;img")
+  })
+})

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,201 @@
+/**
+ * Lightweight, dependency-free Markdown → HTML converter for hunt and clue
+ * descriptions.
+ *
+ * The output is intended to be passed through {@link sanitizeHtml} (DOMPurify)
+ * before it reaches the DOM — see {@link renderMarkdown}. The converter itself
+ * HTML-escapes all user text up front, so raw HTML in the source is rendered
+ * as inert text rather than markup. Sanitization is a second, defence-in-depth
+ * layer.
+ *
+ * Supported syntax (matches the rich-text editor toolbar):
+ *   - Headings            `# … ######`
+ *   - Bold / italic       `**bold**`, `*italic*`, `__bold__`, `_italic_`
+ *   - Inline code         `` `code` ``
+ *   - Fenced code blocks  ```` ```lang … ``` ````
+ *   - Links               `[text](https://…)`
+ *   - Images (IPFS/HTTP)  `![alt](ipfs://… | https://…)`
+ *   - Unordered lists     `- item` / `* item`
+ *   - Ordered lists       `1. item`
+ *   - Blockquotes         `> quote`
+ */
+
+import { resolveImageSrc } from "@/lib/ipfs"
+import { sanitizeHtml } from "@/lib/sanitizeHtml"
+
+// Matches a fenced code block: ```lang\n…\n```
+const FENCED_CODE_RE = /```([^\n`]*)\n([\s\S]*?)```/g
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+/**
+ * Returns a safe URL for links, or `null` when the scheme is not allowlisted.
+ * Blocks `javascript:`, `data:`, `vbscript:` and other script-bearing schemes.
+ */
+function safeLinkUrl(rawUrl: string): string | null {
+  const url = rawUrl.trim()
+  if (!url) return null
+  // Relative URLs and anchors are safe.
+  if (/^(\/|#|\.)/.test(url)) return url
+  // Allow only these explicit schemes.
+  if (/^(https?:|mailto:|tel:)/i.test(url)) return url
+  // Anything with a scheme we don't recognise is rejected.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return null
+  // Schemeless host (e.g. "example.com/path") — treat as https.
+  return `https://${url}`
+}
+
+/**
+ * Returns a safe image src (resolving `ipfs://` to a gateway URL), or `null`
+ * when the scheme is not allowlisted.
+ */
+function safeImageUrl(rawUrl: string): string | null {
+  const url = rawUrl.trim()
+  if (!url) return null
+  if (url.startsWith("ipfs://") || url.startsWith("Qm") || url.startsWith("bafy")) {
+    return resolveImageSrc(url)
+  }
+  if (/^https?:/i.test(url) || /^(\/|\.)/.test(url)) return url
+  if (/^data:image\//i.test(url)) return url
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return null
+  return `https://${url}`
+}
+
+/** Applies inline markdown (images, links, code, bold, italic) to escaped text. */
+function renderInline(text: string): string {
+  let out = text
+
+  // Images: ![alt](url) — process before links so the leading ! is consumed.
+  out = out.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_m, alt: string, url: string) => {
+    const safe = safeImageUrl(url)
+    if (!safe) return escapeHtml(alt)
+    return `<img src="${escapeHtml(safe)}" alt="${alt}" loading="lazy" />`
+  })
+
+  // Links: [text](url)
+  out = out.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_m, label: string, url: string) => {
+    const safe = safeLinkUrl(url)
+    if (!safe) return label
+    return `<a href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">${label}</a>`
+  })
+
+  // Inline code: `code`
+  out = out.replace(/`([^`]+)`/g, (_m, code: string) => `<code>${code}</code>`)
+
+  // Bold: **text** or __text__
+  out = out.replace(/(\*\*|__)(?=\S)([\s\S]+?\S)\1/g, "<strong>$2</strong>")
+
+  // Italic: *text* or _text_
+  out = out.replace(/(^|[^*])\*(?=\S)([^*]+?\S)\*/g, "$1<em>$2</em>")
+  out = out.replace(/(^|[^_\w])_(?=\S)([^_]+?\S)_(?=[^_\w]|$)/g, "$1<em>$2</em>")
+
+  return out
+}
+
+function renderListBlock(lines: string[], ordered: boolean): string {
+  const tag = ordered ? "ol" : "ul"
+  const items = lines
+    .map((line) =>
+      ordered ? line.replace(/^\s*\d+\.\s+/, "") : line.replace(/^\s*[-*]\s+/, ""),
+    )
+    .map((item) => `<li>${renderInline(escapeHtml(item))}</li>`)
+    .join("")
+  return `<${tag}>${items}</${tag}>`
+}
+
+function renderBlock(block: string): string {
+  const lines = block.split("\n")
+
+  // Heading
+  const heading = /^(#{1,6})\s+(.*)$/.exec(lines[0])
+  if (heading && lines.length === 1) {
+    const level = heading[1].length
+    return `<h${level}>${renderInline(escapeHtml(heading[2]))}</h${level}>`
+  }
+
+  // Blockquote
+  if (lines.every((line) => /^\s*>\s?/.test(line))) {
+    const inner = lines
+      .map((line) => line.replace(/^\s*>\s?/, ""))
+      .map((line) => renderInline(escapeHtml(line)))
+      .join("<br />")
+    return `<blockquote>${inner}</blockquote>`
+  }
+
+  // Ordered list
+  if (lines.every((line) => /^\s*\d+\.\s+/.test(line))) {
+    return renderListBlock(lines, true)
+  }
+
+  // Unordered list
+  if (lines.every((line) => /^\s*[-*]\s+/.test(line))) {
+    return renderListBlock(lines, false)
+  }
+
+  // Paragraph — single newlines become <br>.
+  const inner = lines.map((line) => renderInline(escapeHtml(line))).join("<br />")
+  return `<p>${inner}</p>`
+}
+
+/** Renders a non-code span of markdown (splits into blank-line-separated blocks). */
+function renderProse(source: string): string {
+  return source
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+    .map(renderBlock)
+    .join("\n")
+}
+
+function renderCodeBlock(lang: string, code: string): string {
+  const language = lang.trim().replace(/[^a-zA-Z0-9_-]/g, "")
+  const classAttr = language ? ` class="language-${language}"` : ""
+  return `<pre><code${classAttr}>${escapeHtml(code.replace(/\n$/, ""))}</code></pre>`
+}
+
+/**
+ * Converts a Markdown string to an HTML string. Does **not** touch the DOM and
+ * escapes all user text; still, always sanitize the result before rendering
+ * (use {@link renderMarkdown}).
+ */
+export function markdownToHtml(markdown: string): string {
+  if (!markdown) return ""
+
+  const normalized = markdown.replace(/\r\n?/g, "\n")
+
+  // Walk the source, alternating between fenced code blocks (rendered verbatim)
+  // and prose spans. This avoids any placeholder-collision risk.
+  const parts: string[] = []
+  let lastIndex = 0
+  FENCED_CODE_RE.lastIndex = 0
+
+  for (
+    let match = FENCED_CODE_RE.exec(normalized);
+    match !== null;
+    match = FENCED_CODE_RE.exec(normalized)
+  ) {
+    const prose = normalized.slice(lastIndex, match.index)
+    if (prose.trim()) parts.push(renderProse(prose))
+    parts.push(renderCodeBlock(match[1], match[2]))
+    lastIndex = match.index + match[0].length
+  }
+
+  const tail = normalized.slice(lastIndex)
+  if (tail.trim()) parts.push(renderProse(tail))
+
+  return parts.join("\n")
+}
+
+/**
+ * Converts Markdown to sanitized HTML ready for `dangerouslySetInnerHTML`.
+ * This is the function UI components should use.
+ */
+export function renderMarkdown(markdown: string): string {
+  return sanitizeHtml(markdownToHtml(markdown))
+}


### PR DESCRIPTION
## Summary

Closes #575.

Replaces the single-line hunt description `<Input>` with a **markdown rich text editor** (toolbar + live preview + IPFS image embedding) and renders descriptions as **sanitized HTML**.

## What changed

- **`lib/markdown.ts`** — dependency-free Markdown → HTML converter supporting headings, bold/italic, inline code, fenced code blocks, links, images, unordered/ordered lists, and blockquotes. It HTML-escapes all user text up front, rejects `javascript:`/unknown-scheme URLs, and resolves `ipfs://` image URIs to a gateway URL. `renderMarkdown()` passes the output through **DOMPurify** (the repo's existing `sanitizeHtml`) as a second, defence-in-depth layer.
- **`components/RichTextEditor.tsx`** — the editor: a formatting toolbar (bold, italic, heading, inline code, code block, bullet list, quote, link) with selection-aware insertion, an **Embed image** button that uploads to **IPFS** and inserts `![alt](ipfs://…)`, and a **Write / Preview** toggle showing the live sanitized render.
- **`components/MarkdownContent.tsx`** — a small shared renderer (`renderMarkdown` + `dangerouslySetInnerHTML`) reused by the editor preview and the hunt cards. `.markdown-content` styles added to `globals.css`.
- **`components/HuntForm.tsx`** — the hunt description now uses `RichTextEditor`; the cover-image button is preserved.
- **`components/HuntCards.tsx`** — the card description (already rendered as sanitized HTML) now renders markdown via `MarkdownContent`.

## Acceptance criteria

- [x] Markdown support with live preview
- [x] Image embedding via IPFS upload
- [x] Link insertion
- [x] Code block support for technical hunts
- [x] Sanitization of all HTML output

## Design note

I used a small in-repo Markdown converter + DOMPurify rather than pulling in `react-markdown`/`remark`. Rationale: the repo already standardizes on DOMPurify (`lib/sanitizeHtml.ts`) and has no markdown runtime, the required feature set is bounded, and a pure function is trivially unit-testable — including the security properties. All output is still sanitized by DOMPurify.

## Testing

- **`lib/__tests__/markdown.test.ts`** — 14 tests covering the converter (headings, emphasis, code, links, lists, quotes, IPFS image resolution, paragraph/line-break handling) and **security** (raw HTML escaped to inert text, `javascript:` URLs dropped, no live script/handler markup for a hostile payload). All passing.
- Full `lib/` suite: **504 passing**; the only failure (`queryOptimizer.test.ts`) is **pre-existing on `main`** and unrelated.
- `tsc --noEmit` error count **identical on branch and `main` (158)** — no new type errors. ESLint clean on the new files (two unused-var errors flagged in `HuntForm.tsx`/`HuntCards.tsx` are **pre-existing on `main`** and untouched by this change).

> Note: the existing `HuntForm.test.tsx` / `HuntCards.test.tsx` suites fail to parse under this local vitest/rolldown toolchain (JSX in `vi.mock`) — verified they fail identically on `main`, i.e. an environment issue independent of this change, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)