### PR TITLE
fix: add fallback placeholder and error boundary for failed IPFS image loads

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import { EmptyState } from "@/components/EmptyState"
 import { HuntOfTheWeekBanner } from "@/components/HuntOfTheWeekBanner"
 import { hankenGrotesk } from "@/lib/font"
 import { HuntCoverImage } from "@/components/HuntCoverImage"
+import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { Footer } from "@/components/Footer"
 import { usePlayerCounts } from "@/hooks/usePlayerCounts"
 import { useRecentlyCompleted } from "@/hooks/useRecentlyCompleted"
@@ -233,11 +234,22 @@ function VirtualizedActiveHuntsGrid({
               }}
             >
               {rowHunts.map((hunt) => (
-                <ActiveHuntCard
+                <ErrorBoundary
                   key={hunt.id}
-                  hunt={hunt}
-                  playerCount={playerCounts.get(String(hunt.id))}
-                />
+                  fallback={
+                    <div className="h-full rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 flex items-center justify-center min-h-[200px]">
+                      <div className="flex flex-col items-center gap-2 text-slate-400 dark:text-slate-500 p-4 text-center">
+                        <Image src="/icons/logo.png" alt="Hunty logo" width={40} height={40} className="opacity-40" />
+                        <span className="text-xs font-medium">Unable to load hunt card</span>
+                      </div>
+                    </div>
+                  }
+                >
+                  <ActiveHuntCard
+                    hunt={hunt}
+                    playerCount={playerCounts.get(String(hunt.id))}
+                  />
+                </ErrorBoundary>
               ))}
             </div>
           )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -696,7 +696,9 @@ export default function GameArcade() {
       {/* Main Content */}
       <div className="max-w-[1600px] px-14 pt-10 pb-12 bg-white dark:bg-slate-900 mx-auto rounded-4xl relative">
         {/* Featured Hunt of the Week Hero Banner */}
-        <HuntOfTheWeekBanner />
+        <ErrorBoundary fallback={null}>
+          <HuntOfTheWeekBanner />
+        </ErrorBoundary>
 
         {/* Logo and Title */}
         <div className="text-center mb-8">
@@ -834,7 +836,9 @@ export default function GameArcade() {
         </div>
 
         {/* Featured Hunts Hero Section */}
-        <FeaturedHunts />
+        <ErrorBoundary fallback={null}>
+          <FeaturedHunts />
+        </ErrorBoundary>
 
         {/* Recently Completed — derived from the same hunt list, no extra fetch */}
         <RecentlyCompletedSection hunts={recentlyCompleted} />

--- a/components/HuntCards.tsx
+++ b/components/HuntCards.tsx
@@ -4,7 +4,7 @@ import confetti from "canvas-confetti";
 import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { ArrowRight, CheckCircle2, Loader2, Printer } from "lucide-react";
+import { ArrowRight, CheckCircle2, Loader2, Printer, ImageOff } from "lucide-react";
 import picture from "@/public/static-images/image1.png";
 import { HuntCardSkeleton } from "@/components/LoadingSkeletons";
 import { cn } from "@/lib/utils";
@@ -104,6 +104,7 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
   // Ref-based guard to prevent concurrent submissions (avoids double-click race)
   const submittingRef = useRef(false);
   const [imgGatewayIdx, setImgGatewayIdx] = useState(0);
+  const [imgHasFailed, setImgHasFailed] = useState(false);
   const [hintRevealed, setHintRevealed] = useState(false);
   const [hintsUsed, setHintsUsed] = useState(0);
   const [keyboardInsetHeight, setKeyboardInsetHeight] = useState(0);
@@ -374,21 +375,32 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
         <p className="text-xs sm:text-sm opacity-90 mb-4 sm:mb-6 line-clamp-3 print:text-lg print:opacity-100 print:mb-8" dangerouslySetInnerHTML={{ __html: sanitizeHtml(hunt.description || "No description provided.") }} />
         <div className="flex justify-center">
           {hunt.link || hunt.image ? (
-            <Image
-              src={resolveImageSrc(hunt.link || hunt.image || "", imgGatewayIdx)}
-              alt="hunt"
-              width={180}
-              height={180}
-              loading="lazy"
-              sizes="180px"
-              onError={() => {
-                if (imgGatewayIdx < GATEWAY_COUNT - 1) {
-                  setImgGatewayIdx((i) => i + 1)
-                }
-              }}
-              unoptimized
-              className="w-[140px] h-[140px] sm:w-[180px] sm:h-[180px] object-contain print:w-64 print:h-auto print:rounded-xl"
-            />
+            imgHasFailed ? (
+              // All IPFS gateways failed — show branded placeholder
+              <div className="w-[140px] h-[140px] sm:w-[180px] sm:h-[180px] flex flex-col items-center justify-center gap-2 rounded-xl bg-white/10 text-white/50 print:hidden">
+                <ImageOff className="w-8 h-8" aria-hidden="true" />
+                <span className="text-[9px] font-medium uppercase tracking-wide">Image unavailable</span>
+              </div>
+            ) : (
+              <Image
+                src={resolveImageSrc(hunt.link || hunt.image || "", imgGatewayIdx)}
+                alt="hunt"
+                width={180}
+                height={180}
+                loading="lazy"
+                sizes="180px"
+                onError={() => {
+                  if (imgGatewayIdx < GATEWAY_COUNT - 1) {
+                    setImgGatewayIdx((i) => i + 1)
+                  } else {
+                    // All gateways exhausted — surface the fallback UI
+                    setImgHasFailed(true)
+                  }
+                }}
+                unoptimized
+                className="w-[140px] h-[140px] sm:w-[180px] sm:h-[180px] object-contain print:w-64 print:h-auto print:rounded-xl"
+              />
+            )
           ) : (
             <Image
               src={picture}

--- a/components/HuntCoverImage.tsx
+++ b/components/HuntCoverImage.tsx
@@ -14,8 +14,31 @@ interface HuntCoverImageProps {
 const BLUR_PLACEHOLDER =
   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4IiBoZWlnaHQ9IjgiPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9IiMxZTI5M2IiLz48L3N2Zz4=";
 
+/** Branded fallback shown when the IPFS image cannot be loaded from any gateway. */
+function ImageFallback({ alt, containerClass }: { alt: string; containerClass: string }) {
+  return (
+    <div
+      className={`${containerClass} flex items-center justify-center bg-slate-100 dark:bg-slate-800`}
+      role="img"
+      aria-label={alt}
+    >
+      <div className="flex flex-col items-center gap-2 text-slate-400 dark:text-slate-500 select-none">
+        <Image
+          src="/icons/logo.png"
+          alt="Hunty logo"
+          width={48}
+          height={48}
+          className="opacity-40"
+        />
+        <span className="text-[10px] font-medium tracking-wide uppercase">Image unavailable</span>
+      </div>
+    </div>
+  )
+}
+
 export function HuntCoverImage({ src, alt, className }: HuntCoverImageProps) {
   const [gatewayIdx, setGatewayIdx] = useState(0)
+  const [hasFailed, setHasFailed] = useState(false)
 
   // `fill` requires the container to be positioned. We always inject
   // `relative` so callers don't have to remember to add it themselves,
@@ -39,6 +62,11 @@ export function HuntCoverImage({ src, alt, className }: HuntCoverImageProps) {
     )
   }
 
+  // All IPFS gateways failed — show branded placeholder instead of a broken image.
+  if (hasFailed) {
+    return <ImageFallback alt={alt} containerClass={containerClass} />
+  }
+
   return (
     <div className={containerClass}>
       <Image
@@ -52,7 +80,11 @@ export function HuntCoverImage({ src, alt, className }: HuntCoverImageProps) {
         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
         onError={() => {
           if (gatewayIdx < GATEWAY_COUNT - 1) {
+            // Try the next available IPFS gateway.
             setGatewayIdx((idx) => idx + 1)
+          } else {
+            // All gateways exhausted — surface the branded fallback UI.
+            setHasFailed(true)
           }
         }}
       />


### PR DESCRIPTION
## Summary

Fixes #310

When a hunt's cover image CID is invalid or an IPFS gateway is unavailable, HuntCoverImage would leave a broken image element with no recovery path, crashing the surrounding component tree.

## Changes

### components/HuntCoverImage.tsx
- Added hasFailed state alongside the existing gatewayIdx state
- The onError handler now has two branches:
  - If more gateways remain: cycle to the next one (existing behaviour, unchanged)
  - If all gateways are exhausted: set hasFailed = true
- Added ImageFallback component rendered when hasFailed is true: shows the Hunty logo at reduced opacity with an Image unavailable label, preserving the card layout height and matching the brand

### app/page.tsx
- Imported the existing ErrorBoundary component
- Wrapped each ActiveHuntCard in the arcade grid with ErrorBoundary
- The ErrorBoundary fallback mirrors the card dimensions so the grid layout stays intact if an unexpected render error occurs

## Behaviour after this fix

| Scenario | Before | After |
|---|---|---|
| Valid CID, gateway available | image loads | unchanged |
| Invalid CID / all gateways fail | broken image / crash | branded placeholder shown |
| Unexpected render error in a card | entire arcade grid disappears | only that card shows fallback |

## Testing
1. Create a hunt with CID QmINVALID000000000000000000000000000000000000
2. Navigate to the Game Arcade
3. The card should display the Hunty logo placeholder instead of a broken image or a crashed section