### PR TITLE
 Implement hunt invitation / private access links FIX.

### DIFF
--- a/apps/web/app/hunt/[id]/share.tsx
+++ b/apps/web/app/hunt/[id]/share.tsx
@@ -2,45 +2,30 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { QrCode, Trophy } from "lucide-react";
-import { QrCodeModal } from "@/components/QrCodeModal";
-import { EmbedModal } from "@/components/EmbedModal";
-import { PlayGame } from "@/components/PlayGame";
-import { GameCompleteModal } from "@/components/GameCompleteModal";
-import { ChatWindow } from "@/components/ChatWindow";
-import { RegistrationButton } from "@/components/RegistrationButton";
-import { WaitlistDisplay } from "@/components/WaitlistDisplay";
-import { HuntReviewsSection } from "@/components/HuntReviewsSection";
-import type { StoredHunt, HuntRegistrationStatus } from "@/lib/types";
-import { updateHuntStatus } from "@/lib/huntStore";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect,useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { ChatWindow } from "@/components/ChatWindow";
+import { EmbedModal } from "@/components/EmbedModal";
 import { GameCompleteModal } from "@/components/GameCompleteModal";
 import { HuntControls } from "@/components/HuntControls";
+import { HuntReviewsSection } from "@/components/HuntReviewsSection";
 import { PlayGame } from "@/components/PlayGame";
 import { PlayInterfaceGuard } from "@/components/PlayInterfaceGuard";
-import { PlayGame } from "@/components/PlayGame";
-import { GameCompleteModal } from "@/components/GameCompleteModal";
+import { PrivateHuntAccessGate } from "@/components/PrivateHuntAccessGate";
 import { QrCodeModal } from "@/components/QrCodeModal";
 import { RegistrationButton } from "@/components/RegistrationButton";
 import { SponsorHuntButton } from "@/components/SponsorHuntButton";
 import { Button } from "@/components/ui/button";
 import { WaitlistDisplay } from "@/components/WaitlistDisplay";
-import { 
-  checkRegistrationStatus, 
+import {
+  checkRegistrationStatus,
   clearRegistrationCache,
   isWalletAvailable,
-  registerPlayer, 
+  registerPlayer,
 } from "@/lib/contracts/player-registration";
 import { distributeCompletionReward } from "@/lib/contracts/rewardManager";
 import { debounce } from "@/lib/debounce";
-import { prepareHuntReattempt } from "@/lib/huntAttemptHistory";
-import { updateHuntStatus } from "@/lib/huntStore";
-import { REGISTRATION_STATUS_DEBOUNCE_MS } from "@/lib/soroban/queryConfig";
-import { withTransactionToast } from "@/lib/txToast";
-import type { HuntRegistrationStatus,StoredHunt } from "@/lib/types";
-import type { RewardReceipt } from "@/lib/types";
 import {
   buildDeepLink,
   buildHuntOgImageUrl,
@@ -49,6 +34,19 @@ import {
   shareOnTwitter,
   shareOnWhatsApp,
 } from "@/lib/downloadAsImage";
+import { prepareHuntReattempt } from "@/lib/huntAttemptHistory";
+import {
+  getHuntById,
+  updateHuntStatus,
+  validateHuntInvite,
+} from "@/lib/huntStore";
+import { REGISTRATION_STATUS_DEBOUNCE_MS } from "@/lib/soroban/queryConfig";
+import { withTransactionToast } from "@/lib/txToast";
+import type {
+  HuntRegistrationStatus,
+  RewardReceipt,
+  StoredHunt,
+} from "@/lib/types";
 import { addToWaitlist, getWaitlistPosition } from "@/lib/waitlist";
 
 interface HuntDetailProps {
@@ -58,6 +56,8 @@ interface HuntDetailProps {
 export default function HuntShare({ hunt }: HuntDetailProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const inviteToken = searchParams.get("invite");
+  const inviteAccess = validateHuntInvite(hunt, inviteToken);
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
   const [completionScore, setCompletionScore] = useState(0);
   const [rewardReceipt, setRewardReceipt] = useState<RewardReceipt | null>(null);
@@ -82,6 +82,7 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
     prepareHuntReattempt(connectedPublicKey, hunt.id);
   }, [connectedPublicKey, hunt.id, searchParams]);
   
+  /* eslint-disable react-hooks/set-state-in-effect -- wallet detection synchronizes React with an external browser extension. */
   useEffect(() => {
     // Check if wallet is available
     if (!isWalletAvailable()) {
@@ -128,6 +129,7 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
       });
     }
   }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const refreshRegistrationStatus = useCallback(async (isActive: () => boolean = () => true) => {
     if (!walletCheckComplete || !isActive()) {
@@ -163,7 +165,7 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
       setRegistrationStatus({
         ...status,
         isWaitlisted: waitlistPosition !== null,
-        waitlistPosition: waitlistPosition,
+        waitlistPosition: waitlistPosition ?? undefined,
       });
     }
   }, [hunt.id, connectedPublicKey, walletCheckComplete]);
@@ -186,12 +188,25 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
     };
   }, [refreshRegistrationStatus]);
 
+  const assertCurrentInviteAccess = () => {
+    const latestHunt = getHuntById(hunt.id) ?? hunt;
+    const access = validateHuntInvite(latestHunt, inviteToken);
+
+    if (!access.isValid) {
+      const message = access.reason === "expired"
+        ? "Access denied. This invite link has expired."
+        : "Access denied. This invite link is invalid or has been revoked.";
+      throw new Error(message);
+    }
+  };
+
   // Handle player registration (Requirements 1.3, 1.4, 1.5)
   const handleRegister = async () => {
     if (!connectedPublicKey) {
       return;
     }
 
+    assertCurrentInviteAccess();
     const result = await registerPlayer(hunt.id, connectedPublicKey);
     
     if (result.success) {
@@ -210,6 +225,7 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
       return;
     }
 
+    assertCurrentInviteAccess();
     addToWaitlist(hunt.id, connectedPublicKey, `${connectedPublicKey.slice(0, 6)}...${connectedPublicKey.slice(-4)}`);
     await refreshRegistrationStatus();
   };
@@ -269,42 +285,44 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
       {/* Registration Section */}
       <div className="flex flex-col sm:flex-row items-center gap-4">
         {/* Registration Button - Requirements 1.2, 2.1 */}
-        {connectedPublicKey ? (
-          <div className="flex-1 w-full space-y-4">
-            <RegistrationButton
-              huntId={hunt.id}
-              playerAddress={connectedPublicKey}
-              registrationStatus={registrationStatus}
-              onRegister={handleRegister}
-              onWaitlist={handleWaitlist}
-              maxCapacity={maxCapacity}
-              currentPlayers={currentPlayers}
-            />
-            {/* Waitlist/Spot Display */}
-            {maxCapacity && (
-              <WaitlistDisplay
+        <PrivateHuntAccessGate hunt={hunt} inviteToken={inviteToken}>
+          {connectedPublicKey ? (
+            <div className="flex-1 w-full space-y-4">
+              <RegistrationButton
                 huntId={hunt.id}
-                currentPlayers={currentPlayers}
-                maxCapacity={maxCapacity}
                 playerAddress={connectedPublicKey}
+                registrationStatus={registrationStatus}
+                onRegister={handleRegister}
+                onWaitlist={handleWaitlist}
+                maxCapacity={maxCapacity}
+                currentPlayers={currentPlayers}
               />
-            )}
-          </div>
-        ) : (
-          <div className="flex-1 flex flex-col sm:flex-row items-stretch gap-4 w-full">
-            <div className="flex-1 flex items-center justify-center gap-2 bg-amber-500/10 text-amber-400 border border-amber-500/30 font-semibold text-base px-8 py-4 rounded-2xl">
-              Please connect your wallet to join this hunt
+              {/* Waitlist/Spot Display */}
+              {maxCapacity && (
+                <WaitlistDisplay
+                  huntId={hunt.id}
+                  currentPlayers={currentPlayers}
+                  maxCapacity={maxCapacity}
+                  playerAddress={connectedPublicKey}
+                />
+              )}
             </div>
-            <Button
-              variant="outline"
-              className="flex-1 border-[#3737A4] text-white hover:bg-[#3737A4]/20 py-4 h-auto font-semibold text-base rounded-2xl"
-              onClick={() => router.push(`/hunt/${hunt.id}/leaderboard`)}
-            >
-              <Trophy className="w-5 h-5 mr-2" />
-              Watch Live Leaderboard
-            </Button>
-          </div>
-        )}
+          ) : (
+            <div className="flex-1 flex flex-col sm:flex-row items-stretch gap-4 w-full">
+              <div className="flex-1 flex items-center justify-center gap-2 bg-amber-500/10 text-amber-400 border border-amber-500/30 font-semibold text-base px-8 py-4 rounded-2xl">
+                Please connect your wallet to join this hunt
+              </div>
+              <Button
+                variant="outline"
+                className="flex-1 border-[#3737A4] text-white hover:bg-[#3737A4]/20 py-4 h-auto font-semibold text-base rounded-2xl"
+                onClick={() => router.push(`/hunt/${hunt.id}/leaderboard`)}
+              >
+                <Trophy className="w-5 h-5 mr-2" />
+                Watch Live Leaderboard
+              </Button>
+            </div>
+          )}
+        </PrivateHuntAccessGate>
 
         {/* Share button */}
 
@@ -405,7 +423,7 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
       </div>
 
       {/* Play Interface Section - Protected by PlayInterfaceGuard (Requirements 3.1, 3.2, 3.3) */}
-      {connectedPublicKey && registrationStatus.isRegistered && (
+      {inviteAccess.isValid && connectedPublicKey && registrationStatus.isRegistered && (
         <PlayInterfaceGuard
           huntId={hunt.id}
           playerAddress={connectedPublicKey}

--- a/apps/web/components/HuntDashboard.tsx
+++ b/apps/web/components/HuntDashboard.tsx
@@ -1,57 +1,60 @@
-"use client"
+"use client";
 
-import { BarChart3, Copy, List,Plus, Trash2, Trophy, X } from "lucide-react"
-import Link from "next/link"
-import { useState, type MouseEvent as ReactMouseEvent } from "react"
-import { Plus, Trash2, Trophy, Copy, X, BarChart3, List, Eye } from "lucide-react"
-import { type MouseEvent as ReactMouseEvent,useState } from "react"
-import { toast } from "sonner"
+import {
+  BarChart3,
+  Copy,
+  Eye,
+  List,
+  Plus,
+  Trash2,
+  Trophy,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { type MouseEvent as ReactMouseEvent, useState } from "react";
+import { toast } from "sonner";
 
-import { ActivateHuntModal } from "@/components/ActivateHuntModal"
-import { CreatorAnalytics } from "@/components/CreatorAnalytics"
-import { LeaderboardTable } from "@/components/LeaderBoardTable"
-import { RewardPoolManager } from "@/components/RewardPoolManager"
-import { Button } from "@/components/ui/button"
-import { Card, CardDescription, CardTitle } from "@/components/ui/card"
-import { Checkbox } from "@/components/ui/checkbox"
+import { ActivateHuntModal } from "@/components/ActivateHuntModal";
+import { CreatorAnalytics } from "@/components/CreatorAnalytics";
+import { HuntInviteControls } from "@/components/HuntInviteControls";
+import { LeaderboardTable } from "@/components/LeaderBoardTable";
+import { RewardPoolManager } from "@/components/RewardPoolManager";
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
-import { ActivateHuntModal } from "@/components/ActivateHuntModal"
-import { RewardPoolManager } from "@/components/RewardPoolManager"
-import { LeaderboardTable } from "@/components/LeaderBoardTable"
-import { CreatorAnalytics } from "@/components/CreatorAnalytics"
-import { deleteHunts, archiveHunts, duplicateHunt } from "@/lib/huntStore"
-import { Input } from "@/components/ui/input"
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import {
   HUNT_HISTORY_STATUS_FILTERS,
   type HuntHistorySortOption,
   type HuntHistoryStatusFilter,
-} from "@/lib/huntHistory"
-import { archiveHunts,deleteHunts } from "@/lib/huntStore"
-import type { ClueRow, StoredHunt } from "@/lib/types"
-import { cn } from "@/lib/utils"
+} from "@/lib/huntHistory";
+import { archiveHunts, deleteHunts, duplicateHunt } from "@/lib/huntStore";
+import type { ClueRow, StoredHunt } from "@/lib/types";
+import { cn } from "@/lib/utils";
 
 interface HuntDashboardProps {
-  hunts: StoredHunt[]
-  totalHunts: number
-  filteredCount: number
-  currentPage: number
-  totalPages: number
-  pageSize: number
-  startItem: number
-  endItem: number
-  statusFilter: HuntHistoryStatusFilter
-  sortOption: HuntHistorySortOption
-  onStatusFilterChange: (status: HuntHistoryStatusFilter) => void
-  onSortChange: (sort: HuntHistorySortOption) => void
-  onPageChange: (page: number) => void
-  onActivate: (huntId: number) => Promise<void>
-  onRefresh: () => void
-  onSaveClues: (huntId: number, clues: ClueRow[]) => Promise<void>
+  hunts: StoredHunt[];
+  totalHunts: number;
+  filteredCount: number;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+  startItem: number;
+  endItem: number;
+  statusFilter: HuntHistoryStatusFilter;
+  sortOption: HuntHistorySortOption;
+  onStatusFilterChange: (status: HuntHistoryStatusFilter) => void;
+  onSortChange: (sort: HuntHistorySortOption) => void;
+  onPageChange: (page: number) => void;
+  onActivate: (huntId: number) => Promise<void>;
+  onRefresh: () => void;
+  onSaveClues: (huntId: number, clues: ClueRow[]) => Promise<void>;
 }
 
 function StatusBadge({ status }: { status: StoredHunt["status"] }) {
@@ -61,21 +64,21 @@ function StatusBadge({ status }: { status: StoredHunt["status"] }) {
       : status === "PendingReview"
         ? "border-violet-200 bg-violet-100 text-violet-800 dark:border-violet-800/50 dark:bg-violet-900/30 dark:text-violet-300"
         : status === "Completed"
-        ? "border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300"
-        : status === "Cancelled"
-          ? "border-rose-200 bg-rose-100 text-rose-700 dark:border-rose-800/50 dark:bg-rose-900/30 dark:text-rose-300"
-          : "border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-800/50 dark:bg-amber-900/30 dark:text-amber-400"
+          ? "border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300"
+          : status === "Cancelled"
+            ? "border-rose-200 bg-rose-100 text-rose-700 dark:border-rose-800/50 dark:bg-rose-900/30 dark:text-rose-300"
+            : "border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-800/50 dark:bg-amber-900/30 dark:text-amber-400";
 
   return (
     <span
       className={cn(
         "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium",
-        styles
+        styles,
       )}
     >
       {status}
     </span>
-  )
+  );
 }
 
 const STATUS_LABELS: Record<HuntHistoryStatusFilter, string> = {
@@ -84,14 +87,14 @@ const STATUS_LABELS: Record<HuntHistoryStatusFilter, string> = {
   completed: "Completed",
   draft: "Draft",
   cancelled: "Cancelled",
-}
+};
 
 const SORT_LABELS: Record<HuntHistorySortOption, string> = {
   newest: "Newest",
   oldest: "Oldest",
   "most-players": "Most Players",
   "highest-reward": "Highest Reward",
-}
+};
 
 export function HuntDashboard({
   hunts,
@@ -111,144 +114,165 @@ export function HuntDashboard({
   onRefresh,
   onSaveClues,
 }: HuntDashboardProps) {
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
-  const [modalHunt, setModalHunt] = useState<StoredHunt | null>(null)
-  const [activatingId, setActivatingId] = useState<number | null>(null)
-  const [clueModalHunt, setClueModalHunt] = useState<StoredHunt | null>(null)
-  const [leaderboardHunt, setLeaderboardHunt] = useState<StoredHunt | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [modalHunt, setModalHunt] = useState<StoredHunt | null>(null);
+  const [activatingId, setActivatingId] = useState<number | null>(null);
+  const [clueModalHunt, setClueModalHunt] = useState<StoredHunt | null>(null);
+  const [leaderboardHunt, setLeaderboardHunt] = useState<StoredHunt | null>(
+    null,
+  );
   const [clueRows, setClueRows] = useState<ClueRow[]>([
     { id: 1, question: "", answer: "", points: 10 },
-  ])
-  const [poolHuntId, setPoolHuntId] = useState<number | null>(null)
-  const [isSavingClues, setIsSavingClues] = useState(false)
-  const [activeTab, setActiveTab] = useState<"hunts" | "analytics">("hunts")
+  ]);
+  const [poolHuntId, setPoolHuntId] = useState<number | null>(null);
+  const [isSavingClues, setIsSavingClues] = useState(false);
+  const [activeTab, setActiveTab] = useState<"hunts" | "analytics">("hunts");
 
-  const visibleHuntIds = hunts.map((hunt) => hunt.id)
-  const selectedVisibleCount = visibleHuntIds.filter((id) => selectedIds.has(id)).length
-  const allVisibleSelected = hunts.length > 0 && selectedVisibleCount === hunts.length
-  const pageNumbers = Array.from({ length: totalPages }, (_, index) => index + 1).filter(
+  const visibleHuntIds = hunts.map((hunt) => hunt.id);
+  const selectedVisibleCount = visibleHuntIds.filter((id) =>
+    selectedIds.has(id),
+  ).length;
+  const allVisibleSelected =
+    hunts.length > 0 && selectedVisibleCount === hunts.length;
+  const pageNumbers = Array.from(
+    { length: totalPages },
+    (_, index) => index + 1,
+  ).filter(
     (pageNumber) =>
       pageNumber === 1 ||
       pageNumber === totalPages ||
-      Math.abs(pageNumber - currentPage) <= 1
-  )
+      Math.abs(pageNumber - currentPage) <= 1,
+  );
 
   const toggleSelect = (id: number) => {
-    const next = new Set(selectedIds)
-    if (next.has(id)) next.delete(id)
-    else next.add(id)
-    setSelectedIds(next)
-  }
+    const next = new Set(selectedIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelectedIds(next);
+  };
 
   const toggleSelectAll = () => {
-    const next = new Set(selectedIds)
+    const next = new Set(selectedIds);
 
     if (allVisibleSelected) {
-      visibleHuntIds.forEach((id) => next.delete(id))
+      visibleHuntIds.forEach((id) => next.delete(id));
     } else {
-      visibleHuntIds.forEach((id) => next.add(id))
+      visibleHuntIds.forEach((id) => next.add(id));
     }
 
-    setSelectedIds(next)
-  }
+    setSelectedIds(next);
+  };
 
   const handleBatchDelete = () => {
-    if (selectedIds.size === 0) return
+    if (selectedIds.size === 0) return;
     if (confirm(`Are you sure you want to delete ${selectedIds.size} hunts?`)) {
-      deleteHunts(Array.from(selectedIds))
-      setSelectedIds(new Set())
-      onRefresh()
-      toast.success("Hunts deleted successfully")
+      deleteHunts(Array.from(selectedIds));
+      setSelectedIds(new Set());
+      onRefresh();
+      toast.success("Hunts deleted successfully");
     }
-  }
+  };
 
   const handleBatchArchive = () => {
-    if (selectedIds.size === 0) return
-    archiveHunts(Array.from(selectedIds))
-    setSelectedIds(new Set())
-    onRefresh()
-    toast.success("Hunts archived successfully")
-  }
+    if (selectedIds.size === 0) return;
+    archiveHunts(Array.from(selectedIds));
+    setSelectedIds(new Set());
+    onRefresh();
+    toast.success("Hunts archived successfully");
+  };
 
   const handleCopyId = (event: ReactMouseEvent<HTMLElement>, id: number) => {
-    event.preventDefault()
-    event.stopPropagation()
-    navigator.clipboard.writeText(id.toString())
-    toast.success("Copied Hunt ID to clipboard!")
-  }
+    event.preventDefault();
+    event.stopPropagation();
+    navigator.clipboard.writeText(id.toString());
+    toast.success("Copied Hunt ID to clipboard!");
+  };
 
-  const handleDuplicate = (event: ReactMouseEvent<HTMLElement>, hunt: StoredHunt) => {
-    event.preventDefault()
-    event.stopPropagation()
-    const duplicated = duplicateHunt(hunt.id)
+  const handleDuplicate = (
+    event: ReactMouseEvent<HTMLElement>,
+    hunt: StoredHunt,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const duplicated = duplicateHunt(hunt.id);
     if (duplicated) {
-      toast.success(`"${duplicated.title}" created`)
-      onRefresh()
+      toast.success(`"${duplicated.title}" created`);
+      onRefresh();
     } else {
-      toast.error("Failed to duplicate hunt")
+      toast.error("Failed to duplicate hunt");
     }
-  }
+  };
 
   const handleActivateClick = (hunt: StoredHunt) => {
-    setModalHunt(hunt)
-  }
+    setModalHunt(hunt);
+  };
 
   const handleConfirmActivate = async () => {
-    if (!modalHunt) return
-    setActivatingId(modalHunt.id)
+    if (!modalHunt) return;
+    setActivatingId(modalHunt.id);
     try {
-      await onActivate(modalHunt.id)
-      onRefresh()
-      setModalHunt(null)
+      await onActivate(modalHunt.id);
+      onRefresh();
+      setModalHunt(null);
     } finally {
-      setActivatingId(null)
+      setActivatingId(null);
     }
-  }
+  };
 
   const openClueModal = (hunt: StoredHunt) => {
-    setClueRows([{ id: 1, question: "", answer: "", points: 10 }])
-    setClueModalHunt(hunt)
-  }
+    setClueRows([{ id: 1, question: "", answer: "", points: 10 }]);
+    setClueModalHunt(hunt);
+  };
 
   const addClueRow = () => {
-    const newId = clueRows.length > 0 ? Math.max(...clueRows.map((row) => row.id)) + 1 : 1
-    setClueRows([...clueRows, { id: newId, question: "", answer: "", points: 10 }])
-  }
+    const newId =
+      clueRows.length > 0 ? Math.max(...clueRows.map((row) => row.id)) + 1 : 1;
+    setClueRows([
+      ...clueRows,
+      { id: newId, question: "", answer: "", points: 10 },
+    ]);
+  };
 
   const removeClueRow = (id: number) => {
     if (clueRows.length > 1) {
-      setClueRows(clueRows.filter((row) => row.id !== id))
+      setClueRows(clueRows.filter((row) => row.id !== id));
     }
-  }
+  };
 
   const updateClueRow = (
     id: number,
     field: keyof Omit<ClueRow, "id">,
-    value: string | number
+    value: string | number,
   ) => {
-    setClueRows(clueRows.map((row) => (row.id === id ? { ...row, [field]: value } : row)))
-  }
+    setClueRows(
+      clueRows.map((row) => (row.id === id ? { ...row, [field]: value } : row)),
+    );
+  };
 
   const handleSaveClues = async () => {
-    if (!clueModalHunt) return
-    const validRows = clueRows.filter((row) => row.question.trim() && row.answer.trim())
-    if (!validRows.length) return
+    if (!clueModalHunt) return;
+    const validRows = clueRows.filter(
+      (row) => row.question.trim() && row.answer.trim(),
+    );
+    if (!validRows.length) return;
 
-    setIsSavingClues(true)
+    setIsSavingClues(true);
     try {
-      await onSaveClues(clueModalHunt.id, validRows)
-      onRefresh()
-      setClueModalHunt(null)
+      await onSaveClues(clueModalHunt.id, validRows);
+      onRefresh();
+      setClueModalHunt(null);
     } finally {
-      setIsSavingClues(false)
+      setIsSavingClues(false);
     }
-  }
+  };
 
-  const cluesAreValid = clueRows.some((row) => row.question.trim() && row.answer.trim())
+  const cluesAreValid = clueRows.some(
+    (row) => row.question.trim() && row.answer.trim(),
+  );
   const resultsLabel =
     filteredCount === totalHunts
       ? `${totalHunts} total hunts`
-      : `${filteredCount} of ${totalHunts} hunts`
+      : `${filteredCount} of ${totalHunts} hunts`;
 
   return (
     <>
@@ -260,7 +284,7 @@ export function HuntDashboard({
             "flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all",
             activeTab === "hunts"
               ? "bg-[#3737A4] text-white shadow-sm"
-              : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
+              : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white",
           )}
         >
           <List className="w-4 h-4" />
@@ -272,7 +296,7 @@ export function HuntDashboard({
             "flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all",
             activeTab === "analytics"
               ? "bg-[#3737A4] text-white shadow-sm"
-              : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
+              : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white",
           )}
         >
           <BarChart3 className="w-4 h-4" />
@@ -282,324 +306,347 @@ export function HuntDashboard({
 
       {activeTab === "analytics" ? (
         <CreatorAnalytics hunts={hunts} />
-      ) : (<>
-      <div className="mb-6 rounded-3xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-950/60">
-        <div className="flex flex-col gap-5 border-b border-slate-200 pb-5 dark:border-white/10 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <p className="text-sm font-medium text-slate-500 dark:text-slate-400">
-              Hunt history
-            </p>
-            <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
-              <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
-                {resultsLabel}
-              </h2>
-              <span className="text-sm text-slate-500 dark:text-slate-400">
-                Page {currentPage} of {totalPages}
-              </span>
-              <span className="text-sm text-slate-500 dark:text-slate-400">
-                {startItem === 0 ? "No hunts match this view" : `Showing ${startItem}-${endItem}`}
-              </span>
-            </div>
-          </div>
-
-          <label className="flex flex-col gap-1 text-sm font-medium text-slate-600 dark:text-slate-300">
-            Sort by
-            <select
-              value={sortOption}
-              onChange={(event) => onSortChange(event.target.value as HuntHistorySortOption)}
-              className="h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#3737A4] dark:border-white/10 dark:bg-slate-900 dark:text-slate-100"
-            >
-              {Object.entries(SORT_LABELS).map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          {HUNT_HISTORY_STATUS_FILTERS.map((filter) => {
-            const isActiveFilter = filter === statusFilter
-
-            return (
-              <Button
-                key={filter}
-                type="button"
-                size="sm"
-                variant={isActiveFilter ? "default" : "outline"}
-                onClick={() => onStatusFilterChange(filter)}
-                className={
-                  isActiveFilter
-                    ? "rounded-full bg-[#3737A4] text-white hover:bg-[#2d2d8d]"
-                    : "rounded-full border-slate-200 text-slate-600 hover:border-slate-300 hover:text-slate-900 dark:border-white/10 dark:text-slate-300 dark:hover:text-white"
-                }
-              >
-                {STATUS_LABELS[filter]}
-              </Button>
-            )
-          })}
-        </div>
-
-        <div className="mt-5 flex flex-wrap items-center justify-between gap-4">
-          <div className="flex items-center gap-2">
-            <Checkbox
-              id="select-all"
-              checked={allVisibleSelected}
-              onCheckedChange={toggleSelectAll}
-            />
-            <label
-              htmlFor="select-all"
-              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-slate-300"
-            >
-              Select Page
-            </label>
-          </div>
-
-          {selectedIds.size > 0 && (
-            <div className="flex animate-in items-center gap-3 fade-in slide-in-from-top-2">
-              <span className="text-sm font-medium text-slate-500 dark:text-slate-400">
-                {selectedIds.size} selected
-              </span>
-              <div className="h-4 w-[1px] bg-slate-200 dark:bg-white/10" />
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleBatchArchive}
-                className="h-8 border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100"
-              >
-                Archive
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleBatchDelete}
-                className="h-8 border-red-200 bg-red-50 text-red-700 hover:bg-red-100"
-              >
-                <Trash2 className="mr-1 h-3 w-3" />
-                Delete
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => setSelectedIds(new Set())}
-                className="h-8 px-2 text-slate-500"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {hunts.length === 0 ? (
-        <div className="col-span-full rounded-3xl border border-dashed border-slate-300 bg-white/70 px-6 py-14 text-center shadow-sm dark:border-white/10 dark:bg-slate-950/50">
-          <p className="text-lg font-semibold text-slate-900 dark:text-white">
-            No hunts found for this filter
-          </p>
-          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-            Try another status or sort option to explore your hunt history.
-          </p>
-        </div>
       ) : (
-          hunts.map((hunt) => {
-            const isDraft = hunt.status === "Draft"
-            const isActive = hunt.status === "Active"
-            const isCompleted = hunt.status === "Completed"
-            const isPendingReview = hunt.status === "PendingReview"
-            const hasClues = hunt.cluesCount > 0
-            const canActivate = isDraft && hasClues && !isPendingReview
-
-            return (
-              <Card
-                key={hunt.id}
-                className={cn(
-                  "group relative overflow-hidden rounded-2xl border transition-all",
-                  selectedIds.has(hunt.id)
-                    ? "border-blue-400 dark:border-blue-500 bg-blue-50/30 dark:bg-blue-900/10 ring-1 ring-blue-400 dark:ring-blue-500"
-                    : "border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 hover:border-slate-300 dark:hover:border-white/20 shadow-sm"
-                )}
-              >
-                <div className="absolute right-3 top-3 z-10">
-                  <Checkbox
-                    checked={selectedIds.has(hunt.id)}
-                    onCheckedChange={() => toggleSelect(hunt.id)}
-                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                    className="h-5 w-5 rounded-md border-slate-300 dark:border-white/20"
-                    aria-label={`Select hunt ${hunt.title}`}
-                  />
+        <>
+          <div className="mb-6 rounded-3xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-950/60">
+            <div className="flex flex-col gap-5 border-b border-slate-200 pb-5 dark:border-white/10 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                  Hunt history
+                </p>
+                <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
+                  <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+                    {resultsLabel}
+                  </h2>
+                  <span className="text-sm text-slate-500 dark:text-slate-400">
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <span className="text-sm text-slate-500 dark:text-slate-400">
+                    {startItem === 0
+                      ? "No hunts match this view"
+                      : `Showing ${startItem}-${endItem}`}
+                  </span>
                 </div>
-                <Link href={`/hunt/${hunt.id}`}>
-                  <div className="p-5">
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2">
-                        <CardTitle className="line-clamp-2 text-lg dark:text-white">{hunt.title}</CardTitle>
-                        <div className="flex items-center gap-1 bg-slate-100 dark:bg-white/5 px-2 py-0.5 rounded-md text-xs text-slate-500 dark:text-slate-400 font-mono">
-                          #{hunt.id}
-                          <button
-                            onClick={(e) => handleCopyId(e, hunt.id)}
-                            aria-label={`Copy hunt ID ${hunt.id}`}
-                            className="hover:text-slate-800 dark:hover:text-white transition-colors"
-                          >
-                            <Copy className="w-3 h-3" />
-                          </button>
+              </div>
+
+              <label className="flex flex-col gap-1 text-sm font-medium text-slate-600 dark:text-slate-300">
+                Sort by
+                <select
+                  value={sortOption}
+                  onChange={(event) =>
+                    onSortChange(event.target.value as HuntHistorySortOption)
+                  }
+                  className="h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#3737A4] dark:border-white/10 dark:bg-slate-900 dark:text-slate-100"
+                >
+                  {Object.entries(SORT_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              {HUNT_HISTORY_STATUS_FILTERS.map((filter) => {
+                const isActiveFilter = filter === statusFilter;
+
+                return (
+                  <Button
+                    key={filter}
+                    type="button"
+                    size="sm"
+                    variant={isActiveFilter ? "default" : "outline"}
+                    onClick={() => onStatusFilterChange(filter)}
+                    className={
+                      isActiveFilter
+                        ? "rounded-full bg-[#3737A4] text-white hover:bg-[#2d2d8d]"
+                        : "rounded-full border-slate-200 text-slate-600 hover:border-slate-300 hover:text-slate-900 dark:border-white/10 dark:text-slate-300 dark:hover:text-white"
+                    }
+                  >
+                    {STATUS_LABELS[filter]}
+                  </Button>
+                );
+              })}
+            </div>
+
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-4">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="select-all"
+                  checked={allVisibleSelected}
+                  onCheckedChange={toggleSelectAll}
+                />
+                <label
+                  htmlFor="select-all"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-slate-300"
+                >
+                  Select Page
+                </label>
+              </div>
+
+              {selectedIds.size > 0 && (
+                <div className="flex animate-in items-center gap-3 fade-in slide-in-from-top-2">
+                  <span className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                    {selectedIds.size} selected
+                  </span>
+                  <div className="h-4 w-[1px] bg-slate-200 dark:bg-white/10" />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleBatchArchive}
+                    className="h-8 border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100"
+                  >
+                    Archive
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleBatchDelete}
+                    className="h-8 border-red-200 bg-red-50 text-red-700 hover:bg-red-100"
+                  >
+                    <Trash2 className="mr-1 h-3 w-3" />
+                    Delete
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setSelectedIds(new Set())}
+                    className="h-8 px-2 text-slate-500"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {hunts.length === 0 ? (
+              <div className="col-span-full rounded-3xl border border-dashed border-slate-300 bg-white/70 px-6 py-14 text-center shadow-sm dark:border-white/10 dark:bg-slate-950/50">
+                <p className="text-lg font-semibold text-slate-900 dark:text-white">
+                  No hunts found for this filter
+                </p>
+                <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                  Try another status or sort option to explore your hunt
+                  history.
+                </p>
+              </div>
+            ) : (
+              hunts.map((hunt) => {
+                const isDraft = hunt.status === "Draft";
+                const isActive = hunt.status === "Active";
+                const isCompleted = hunt.status === "Completed";
+                const isPendingReview = hunt.status === "PendingReview";
+                const hasClues = hunt.cluesCount > 0;
+                const canActivate = isDraft && hasClues && !isPendingReview;
+
+                return (
+                  <Card
+                    key={hunt.id}
+                    className={cn(
+                      "group relative overflow-hidden rounded-2xl border transition-all",
+                      selectedIds.has(hunt.id)
+                        ? "border-blue-400 dark:border-blue-500 bg-blue-50/30 dark:bg-blue-900/10 ring-1 ring-blue-400 dark:ring-blue-500"
+                        : "border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900 hover:border-slate-300 dark:hover:border-white/20 shadow-sm",
+                    )}
+                  >
+                    <div className="absolute right-3 top-3 z-10">
+                      <Checkbox
+                        checked={selectedIds.has(hunt.id)}
+                        onCheckedChange={() => toggleSelect(hunt.id)}
+                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                        className="h-5 w-5 rounded-md border-slate-300 dark:border-white/20"
+                        aria-label={`Select hunt ${hunt.title}`}
+                      />
+                    </div>
+                    <Link href={`/hunt/${hunt.id}`}>
+                      <div className="p-5">
+                        <div className="mb-2 flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2">
+                            <CardTitle className="line-clamp-2 text-lg dark:text-white">
+                              {hunt.title}
+                            </CardTitle>
+                            <div className="flex items-center gap-1 bg-slate-100 dark:bg-white/5 px-2 py-0.5 rounded-md text-xs text-slate-500 dark:text-slate-400 font-mono">
+                              #{hunt.id}
+                              <button
+                                onClick={(e) => handleCopyId(e, hunt.id)}
+                                aria-label={`Copy hunt ID ${hunt.id}`}
+                                className="hover:text-slate-800 dark:hover:text-white transition-colors"
+                              >
+                                <Copy className="w-3 h-3" />
+                              </button>
+                            </div>
+                          </div>
+                          <StatusBadge status={hunt.status} />
                         </div>
-                      </div>
-                      <StatusBadge status={hunt.status} />
-                    </div>
-                    <CardDescription className="mb-4 line-clamp-3 text-sm text-slate-600 dark:text-slate-400">
-                      {hunt.description}
-                    </CardDescription>
-                    <div className="mb-4 flex flex-wrap gap-2">
-                      <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 dark:bg-white/5 dark:text-slate-300">
-                        {hunt.playerCount ?? 0} players
-                      </span>
-                      <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 dark:bg-white/5 dark:text-slate-300">
-                        {hunt.rewardPool ?? 0} XLM reward pool
-                      </span>
-                    </div>
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <span className="text-xs text-slate-500 dark:text-slate-400">
-                        {hunt.cluesCount} {hunt.cluesCount === 1 ? "clue" : "clues"}
-                      </span>
-                      <div className="flex gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={(e) => handleDuplicate(e, hunt)}
-                          className="border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-white/20 dark:text-slate-300 dark:hover:bg-white/5"
-                        >
-                          <Copy className="mr-1 h-3 w-3" />
-                          Duplicate
-                        </Button>
-                        {isDraft && (
-                          <>
+                        <CardDescription className="mb-4 line-clamp-3 text-sm text-slate-600 dark:text-slate-400">
+                          {hunt.description}
+                        </CardDescription>
+                        <div className="mb-4 flex flex-wrap gap-2">
+                          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 dark:bg-white/5 dark:text-slate-300">
+                            {hunt.playerCount ?? 0} players
+                          </span>
+                          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 dark:bg-white/5 dark:text-slate-300">
+                            {hunt.rewardPool ?? 0} XLM reward pool
+                          </span>
+                          {hunt.is_private && (
+                            <span className="rounded-full bg-violet-100 px-2.5 py-1 text-xs font-medium text-violet-700 dark:bg-violet-900/30 dark:text-violet-300">
+                              Private
+                            </span>
+                          )}
+                        </div>
+                        <HuntInviteControls hunt={hunt} onRefresh={onRefresh} />
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <span className="text-xs text-slate-500 dark:text-slate-400">
+                            {hunt.cluesCount}{" "}
+                            {hunt.cluesCount === 1 ? "clue" : "clues"}
+                          </span>
+                          <div className="flex gap-2">
                             <Button
                               size="sm"
                               variant="outline"
-                              onClick={() => openClueModal(hunt)}
-                              className="border-[#3737A4] text-[#3737A4] hover:bg-[#3737A4] hover:text-white"
+                              onClick={(e) => handleDuplicate(e, hunt)}
+                              className="border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-white/20 dark:text-slate-300 dark:hover:bg-white/5"
                             >
-                              <Plus className="mr-1 h-3 w-3" />
-                              Add Clues
+                              <Copy className="mr-1 h-3 w-3" />
+                              Duplicate
                             </Button>
-                            {hasClues && (
+                            {isDraft && (
+                              <>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => openClueModal(hunt)}
+                                  className="border-[#3737A4] text-[#3737A4] hover:bg-[#3737A4] hover:text-white"
+                                >
+                                  <Plus className="mr-1 h-3 w-3" />
+                                  Add Clues
+                                </Button>
+                                {hasClues && (
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    asChild
+                                    className="border-amber-400 text-amber-700 hover:bg-amber-50 dark:border-amber-600 dark:text-amber-400 dark:hover:bg-amber-900/20"
+                                    onClick={(e: React.MouseEvent) =>
+                                      e.stopPropagation()
+                                    }
+                                  >
+                                    <Link href={`/hunt/${hunt.id}/preview`}>
+                                      <Eye className="mr-1 h-3 w-3" />
+                                      Preview
+                                    </Link>
+                                  </Button>
+                                )}
+                              </>
+                            )}
+                            {(isActive || isCompleted) && (
                               <Button
                                 size="sm"
                                 variant="outline"
                                 asChild
-                                className="border-amber-400 text-amber-700 hover:bg-amber-50 dark:border-amber-600 dark:text-amber-400 dark:hover:bg-amber-900/20"
-                                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                                className="flex items-center gap-1.5 border-[#3737A4] text-[#3737A4] hover:bg-[#3737A4] hover:text-white"
                               >
-                                <Link href={`/hunt/${hunt.id}/preview`}>
-                                  <Eye className="mr-1 h-3 w-3" />
-                                  Preview
+                                <Link
+                                  href={`/dashboard/hunts/${hunt.id}/leaderboard`}
+                                >
+                                  <Trophy className="h-4 w-4" />
+                                  Leaderboard
                                 </Link>
                               </Button>
                             )}
-                          </>
-                        )}
-                        {(isActive || isCompleted) && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            asChild
-                            className="flex items-center gap-1.5 border-[#3737A4] text-[#3737A4] hover:bg-[#3737A4] hover:text-white"
-                          >
-                            <Link href={`/dashboard/hunts/${hunt.id}/leaderboard`}>
-                              <Trophy className="h-4 w-4" />
-                              Leaderboard
-                            </Link>
-                          </Button>
-                        )}
-                        {isPendingReview && (
-                          <span className="rounded-full bg-violet-100 px-2.5 py-1 text-xs font-semibold text-violet-800 dark:bg-violet-900/30 dark:text-violet-300">
-                            Awaiting moderation
-                          </span>
-                        )}
-                        {isDraft && (
-                          <Button
-                            size="sm"
-                            onClick={() => handleActivateClick(hunt)}
-                            disabled={!canActivate}
-                            className="bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 disabled:pointer-events-none disabled:opacity-50"
-                          >
-                            Submit for review
-                          </Button>
+                            {isPendingReview && (
+                              <span className="rounded-full bg-violet-100 px-2.5 py-1 text-xs font-semibold text-violet-800 dark:bg-violet-900/30 dark:text-violet-300">
+                                Awaiting moderation
+                              </span>
+                            )}
+                            {isDraft && (
+                              <Button
+                                size="sm"
+                                onClick={() => handleActivateClick(hunt)}
+                                disabled={!canActivate}
+                                className="bg-gradient-to-b from-[#39A437] to-[#194F0C] hover:bg-green-700 disabled:pointer-events-none disabled:opacity-50"
+                              >
+                                Submit for review
+                              </Button>
+                            )}
+                          </div>
+                        </div>
+                        {isDraft && !hasClues && (
+                          <p className="mt-2 text-xs text-amber-600">
+                            Add at least one clue to activate.
+                          </p>
                         )}
                       </div>
-                    </div>
-                    {isDraft && !hasClues && (
-                      <p className="mt-2 text-xs text-amber-600">
-                        Add at least one clue to activate.
-                      </p>
+                    </Link>
+                  </Card>
+                );
+              })
+            )}
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {filteredCount <= pageSize
+                ? "Everything fits on one page."
+                : `Browsing ${filteredCount} hunts in pages of ${pageSize}.`}
+            </p>
+
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={currentPage === 1}
+                onClick={() => onPageChange(currentPage - 1)}
+              >
+                Previous
+              </Button>
+
+              {pageNumbers.map((pageNumber, index) => {
+                const previousPage = pageNumbers[index - 1];
+                const shouldShowGap =
+                  typeof previousPage === "number" &&
+                  pageNumber - previousPage > 1;
+
+                return (
+                  <div key={pageNumber} className="flex items-center gap-2">
+                    {shouldShowGap && (
+                      <span className="px-1 text-sm text-slate-400">…</span>
                     )}
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={
+                        pageNumber === currentPage ? "default" : "outline"
+                      }
+                      onClick={() => onPageChange(pageNumber)}
+                      className={
+                        pageNumber === currentPage
+                          ? "min-w-9 bg-[#3737A4] text-white hover:bg-[#2d2d8d]"
+                          : "min-w-9"
+                      }
+                    >
+                      {pageNumber}
+                    </Button>
                   </div>
-                </Link>
-              </Card>
-            )
-          })
-        )}
-      </div>
+                );
+              })}
 
-      <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          {filteredCount <= pageSize
-            ? "Everything fits on one page."
-            : `Browsing ${filteredCount} hunts in pages of ${pageSize}.`}
-        </p>
-
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={currentPage === 1}
-            onClick={() => onPageChange(currentPage - 1)}
-          >
-            Previous
-          </Button>
-
-          {pageNumbers.map((pageNumber, index) => {
-            const previousPage = pageNumbers[index - 1]
-            const shouldShowGap =
-              typeof previousPage === "number" && pageNumber - previousPage > 1
-
-            return (
-              <div key={pageNumber} className="flex items-center gap-2">
-                {shouldShowGap && (
-                  <span className="px-1 text-sm text-slate-400">…</span>
-                )}
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={pageNumber === currentPage ? "default" : "outline"}
-                  onClick={() => onPageChange(pageNumber)}
-                  className={
-                    pageNumber === currentPage
-                      ? "min-w-9 bg-[#3737A4] text-white hover:bg-[#2d2d8d]"
-                      : "min-w-9"
-                  }
-                >
-                  {pageNumber}
-                </Button>
-              </div>
-            )
-          })}
-
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={currentPage === totalPages}
-            onClick={() => onPageChange(currentPage + 1)}
-          >
-            Next
-          </Button>
-        </div>
-      </div>
-      </>)}
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={currentPage === totalPages}
+                onClick={() => onPageChange(currentPage + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
 
       <ActivateHuntModal
         isOpen={!!modalHunt}
@@ -609,8 +656,14 @@ export function HuntDashboard({
         isActivating={activatingId !== null}
       />
 
-      <Dialog open={!!leaderboardHunt} onOpenChange={(open) => !open && setLeaderboardHunt(null)}>
-        <DialogContent showCloseButton className="bg-[#f9f9ff] sm:max-w-2xl dark:bg-slate-950">
+      <Dialog
+        open={!!leaderboardHunt}
+        onOpenChange={(open) => !open && setLeaderboardHunt(null)}
+      >
+        <DialogContent
+          showCloseButton
+          className="bg-[#f9f9ff] sm:max-w-2xl dark:bg-slate-950"
+        >
           <DialogHeader className="mb-4">
             <DialogTitle className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-center text-2xl font-bold text-transparent">
               Leaderboard - {leaderboardHunt?.title}
@@ -618,12 +671,17 @@ export function HuntDashboard({
           </DialogHeader>
 
           <div className="rounded-2xl border border-slate-100 bg-white p-6 shadow-inner dark:border-white/5 dark:bg-slate-900">
-            {leaderboardHunt && <LeaderboardTable huntId={leaderboardHunt.id} />}
+            {leaderboardHunt && (
+              <LeaderboardTable huntId={leaderboardHunt.id} />
+            )}
           </div>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={!!clueModalHunt} onOpenChange={(open) => !open && setClueModalHunt(null)}>
+      <Dialog
+        open={!!clueModalHunt}
+        onOpenChange={(open) => !open && setClueModalHunt(null)}
+      >
         <DialogContent showCloseButton className="sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle className="bg-gradient-to-b from-[#3737A4] to-[#0C0C4F] bg-clip-text text-2xl font-bold text-transparent">
@@ -646,7 +704,10 @@ export function HuntDashboard({
             </div>
 
             {clueRows.map((row, index) => (
-              <div key={row.id} className="grid grid-cols-[1fr_1fr_56px_32px] items-center gap-2">
+              <div
+                key={row.id}
+                className="grid grid-cols-[1fr_1fr_56px_32px] items-center gap-2"
+              >
                 <div className="flex items-center gap-1.5">
                   <span className="w-4 shrink-0 text-xs text-slate-400 dark:text-slate-500">
                     {index + 1}.
@@ -654,14 +715,18 @@ export function HuntDashboard({
                   <Input
                     placeholder="e.g. What has keys but no locks?"
                     value={row.question}
-                    onChange={(event) => updateClueRow(row.id, "question", event.target.value)}
+                    onChange={(event) =>
+                      updateClueRow(row.id, "question", event.target.value)
+                    }
                     className="py-2 pl-3 text-sm"
                   />
                 </div>
                 <Input
                   placeholder="Answer (e.g. keyboard|laptop)"
                   value={row.answer}
-                  onChange={(event) => updateClueRow(row.id, "answer", event.target.value)}
+                  onChange={(event) =>
+                    updateClueRow(row.id, "answer", event.target.value)
+                  }
                   className="py-2 pl-3 text-sm"
                 />
                 <Input
@@ -670,7 +735,11 @@ export function HuntDashboard({
                   value={row.points}
                   min={1}
                   onChange={(event) =>
-                    updateClueRow(row.id, "points", parseInt(event.target.value, 10) || 0)
+                    updateClueRow(
+                      row.id,
+                      "points",
+                      parseInt(event.target.value, 10) || 0,
+                    )
                   }
                   className="py-2 pl-3 text-sm"
                 />
@@ -716,8 +785,12 @@ export function HuntDashboard({
       </Dialog>
 
       {poolHuntId !== null && (
-        <RewardPoolManager huntId={poolHuntId} isOpen={poolHuntId !== null} onClose={() => setPoolHuntId(null)} />
+        <RewardPoolManager
+          huntId={poolHuntId}
+          isOpen={poolHuntId !== null}
+          onClose={() => setPoolHuntId(null)}
+        />
       )}
     </>
-  )
+  );
 }

--- a/apps/web/components/HuntInviteControls.tsx
+++ b/apps/web/components/HuntInviteControls.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Copy, Link2, RefreshCw, ShieldOff } from "lucide-react";
+import { type MouseEvent as ReactMouseEvent, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { buildHuntInviteUrl, generateHuntInvite, revokeHuntInvite } from "@/lib/huntStore";
+import type { HuntInvite, StoredHunt } from "@/lib/types";
+
+interface HuntInviteControlsProps {
+  hunt: StoredHunt;
+  onRefresh: () => void;
+}
+
+function stopCardNavigation(event: ReactMouseEvent<HTMLElement>) {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+async function copyInvite(huntId: number, invite: HuntInvite): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) return false;
+
+  try {
+    const url = buildHuntInviteUrl(huntId, invite.token);
+    await navigator.clipboard.writeText(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function HuntInviteControls({ hunt, onRefresh }: HuntInviteControlsProps) {
+  const [renderedAt] = useState(Date.now);
+
+  if (!hunt.is_private) return null;
+
+  const inviteIsActive = Boolean(hunt.invite && hunt.invite.expiresAt > renderedAt);
+  const inviteIsExpired = Boolean(hunt.invite && !inviteIsActive);
+
+  const handleGenerate = async (event: ReactMouseEvent<HTMLButtonElement>) => {
+    stopCardNavigation(event);
+
+    try {
+      const invite = generateHuntInvite(hunt.id);
+      onRefresh();
+
+      if (await copyInvite(hunt.id, invite)) {
+        toast.success("Invite link generated and copied to clipboard");
+      } else {
+        toast.success("Invite link generated. Use Copy invite link to share it.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to generate invite link");
+    }
+  };
+
+  const handleCopy = async (event: ReactMouseEvent<HTMLButtonElement>) => {
+    stopCardNavigation(event);
+    if (!hunt.invite || !inviteIsActive) return;
+
+    if (await copyInvite(hunt.id, hunt.invite)) {
+      toast.success("Invite link copied to clipboard");
+    } else {
+      toast.error("Failed to copy invite link");
+    }
+  };
+
+  const handleRevoke = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    stopCardNavigation(event);
+
+    if (!window.confirm("Revoke this invite link? Anyone using it will lose access.")) {
+      return;
+    }
+
+    if (revokeHuntInvite(hunt.id)) {
+      onRefresh();
+      toast.success("Invite link revoked");
+    } else {
+      toast.error("No active invite link to revoke");
+    }
+  };
+
+  return (
+    <div
+      className="mb-4 rounded-xl border border-violet-200 bg-violet-50/70 p-3 dark:border-violet-800/50 dark:bg-violet-950/20"
+      onClick={stopCardNavigation}
+      aria-label={`Invite controls for ${hunt.title}`}
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-violet-800 dark:text-violet-300">
+          <Link2 className="h-3.5 w-3.5" />
+          Private invite
+        </span>
+        {inviteIsActive && hunt.invite ? (
+          <span className="text-[11px] text-violet-600 dark:text-violet-400">
+            Expires {new Date(hunt.invite.expiresAt).toLocaleDateString()}
+          </span>
+        ) : inviteIsExpired ? (
+          <span className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
+            Invite expired
+          </span>
+        ) : (
+          <span className="text-[11px] text-slate-500 dark:text-slate-400">No active link</span>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {inviteIsActive ? (
+          <>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={handleCopy}
+              aria-label={`Copy invite link for ${hunt.title}`}
+              className="border-violet-300 text-violet-700 hover:bg-violet-100 dark:border-violet-700 dark:text-violet-300"
+            >
+              <Copy className="h-3.5 w-3.5" />
+              Copy invite link
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleRevoke}
+              aria-label={`Revoke invite link for ${hunt.title}`}
+              className="text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:text-rose-400 dark:hover:bg-rose-950/30"
+            >
+              <ShieldOff className="h-3.5 w-3.5" />
+              Revoke
+            </Button>
+          </>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={handleGenerate}
+            aria-label={`${inviteIsExpired ? "Generate new" : "Generate"} invite link for ${hunt.title}`}
+            className="border-violet-300 text-violet-700 hover:bg-violet-100 dark:border-violet-700 dark:text-violet-300"
+          >
+            {inviteIsExpired ? (
+              <RefreshCw className="h-3.5 w-3.5" />
+            ) : (
+              <Link2 className="h-3.5 w-3.5" />
+            )}
+            {inviteIsExpired ? "Generate new link" : "Generate invite link"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/PrivateHuntAccessGate.tsx
+++ b/apps/web/components/PrivateHuntAccessGate.tsx
@@ -1,0 +1,39 @@
+import { LockKeyhole } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { validateHuntInvite } from "@/lib/huntStore";
+import type { StoredHunt } from "@/lib/types";
+
+interface PrivateHuntAccessGateProps {
+  hunt: StoredHunt;
+  inviteToken: string | null | undefined;
+  children: ReactNode;
+}
+
+const ACCESS_DENIED_MESSAGES = {
+  required: "This private hunt requires a valid invite link. Ask the creator for access.",
+  invalid: "This invite link is invalid or has been revoked. Ask the creator for a new link.",
+  expired: "This invite link has expired. Ask the creator for a new link.",
+} as const;
+
+export function PrivateHuntAccessGate({ hunt, inviteToken, children }: PrivateHuntAccessGateProps) {
+  const access = validateHuntInvite(hunt, inviteToken);
+
+  if (access.isValid) return <>{children}</>;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex-1 rounded-2xl border border-rose-500/30 bg-rose-500/10 px-6 py-5 text-rose-200"
+    >
+      <div className="flex items-start gap-3">
+        <LockKeyhole className="mt-0.5 h-5 w-5 shrink-0 text-rose-400" />
+        <div>
+          <p className="font-semibold text-rose-300">Access denied</p>
+          <p className="mt-1 text-sm text-rose-200/90">{ACCESS_DENIED_MESSAGES[access.reason]}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/__tests__/HuntInviteControls.test.tsx
+++ b/apps/web/components/__tests__/HuntInviteControls.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HuntInviteControls } from "@/components/HuntInviteControls";
+import { addHunt, getHuntById } from "@/lib/huntStore";
+import type { StoredHunt } from "@/lib/types";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const hunt: StoredHunt = {
+  id: 450,
+  title: "Dashboard private hunt",
+  description: "Private",
+  cluesCount: 1,
+  status: "Active",
+  rewardType: "XLM",
+  is_private: true,
+};
+
+function InviteControlsHarness() {
+  const [currentHunt, setCurrentHunt] = useState(() => getHuntById(hunt.id)!);
+
+  return (
+    <HuntInviteControls
+      hunt={currentHunt}
+      onRefresh={() => setCurrentHunt(getHuntById(hunt.id)!)}
+    />
+  );
+}
+
+describe("HuntInviteControls", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    addHunt(hunt);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("lets a creator generate, copy, and revoke a private-hunt invite", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<InviteControlsHarness />);
+
+    await user.click(
+      screen.getByRole("button", { name: /generate invite link for dashboard private hunt/i })
+    );
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringMatching(/^http:\/\/localhost(?::\d+)?\/hunt\/450\?invite=/)
+      );
+    });
+    expect(
+      screen.getByRole("button", { name: /copy invite link for dashboard private hunt/i })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /copy invite link for dashboard private hunt/i })
+    );
+    expect(writeText).toHaveBeenCalledTimes(2);
+
+    await user.click(
+      screen.getByRole("button", { name: /revoke invite link for dashboard private hunt/i })
+    );
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(getHuntById(hunt.id)?.invite).toBeUndefined();
+    expect(
+      screen.getByRole("button", { name: /generate invite link for dashboard private hunt/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render invite actions for a public hunt", () => {
+    render(<HuntInviteControls hunt={{ ...hunt, is_private: false }} onRefresh={vi.fn()} />);
+
+    expect(screen.queryByText(/private invite/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/__tests__/PrivateHuntAccessGate.test.tsx
+++ b/apps/web/components/__tests__/PrivateHuntAccessGate.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PrivateHuntAccessGate } from "@/components/PrivateHuntAccessGate";
+import type { StoredHunt } from "@/lib/types";
+
+const invite = {
+  token: "3b2da18f-8f95-4f7a-9a53-358d74617602",
+  createdAt: Date.now() - 1_000,
+  expiresAt: Date.now() + 60_000,
+};
+
+const privateHunt: StoredHunt = {
+  id: 300,
+  title: "Secret hunt",
+  description: "Private",
+  cluesCount: 1,
+  status: "Active",
+  rewardType: "XLM",
+  is_private: true,
+  invite,
+};
+
+describe("PrivateHuntAccessGate", () => {
+  it("renders registration content for a valid private-hunt invite", () => {
+    render(
+      <PrivateHuntAccessGate hunt={privateHunt} inviteToken={invite.token}>
+        <button>Join Hunt</button>
+      </PrivateHuntAccessGate>
+    );
+
+    expect(screen.getByRole("button", { name: "Join Hunt" })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("gates registration and explains that an invite is required", () => {
+    render(
+      <PrivateHuntAccessGate hunt={privateHunt} inviteToken={null}>
+        <button>Join Hunt</button>
+      </PrivateHuntAccessGate>
+    );
+
+    expect(screen.queryByRole("button", { name: "Join Hunt" })).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Access denied");
+    expect(screen.getByRole("alert")).toHaveTextContent(/requires a valid invite link/i);
+  });
+
+  it("shows an invalid-or-revoked message for a bad token", () => {
+    render(
+      <PrivateHuntAccessGate hunt={privateHunt} inviteToken="wrong-token">
+        <button>Join Hunt</button>
+      </PrivateHuntAccessGate>
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/invalid or has been revoked/i);
+  });
+
+  it("shows an expiration-specific access-denied message", () => {
+    render(
+      <PrivateHuntAccessGate
+        hunt={{ ...privateHunt, invite: { ...invite, expiresAt: Date.now() - 1 } }}
+        inviteToken={invite.token}
+      >
+        <button>Join Hunt</button>
+      </PrivateHuntAccessGate>
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/expired/i);
+  });
+
+  it("does not gate public hunts", () => {
+    render(
+      <PrivateHuntAccessGate
+        hunt={{ ...privateHunt, is_private: false, invite: undefined }}
+        inviteToken={null}
+      >
+        <button>Join Hunt</button>
+      </PrivateHuntAccessGate>
+    );
+
+    expect(screen.getByRole("button", { name: "Join Hunt" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/lib/__tests__/huntInvite.test.ts
+++ b/apps/web/lib/__tests__/huntInvite.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addHunt,
+  buildHuntInviteUrl,
+  DEFAULT_HUNT_INVITE_TTL_MS,
+  generateHuntInvite,
+  getHuntById,
+  revokeHuntInvite,
+  validateHuntInvite,
+  validateHuntInviteToken,
+} from "@/lib/huntStore";
+import type { StoredHunt } from "@/lib/types";
+
+const privateHunt: StoredHunt = {
+  id: 8801,
+  title: "Invitation only",
+  description: "A private test hunt",
+  cluesCount: 2,
+  status: "Active",
+  rewardType: "XLM",
+  is_private: true,
+};
+
+const publicHunt: StoredHunt = {
+  ...privateHunt,
+  id: 8802,
+  title: "Public hunt",
+  is_private: false,
+};
+
+describe("private hunt invites", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T10:00:00.000Z"));
+    addHunt(privateHunt);
+    addHunt(publicHunt);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it("generates a UUID invite and persists its expiration with the hunt", () => {
+    const invite = generateHuntInvite(privateHunt.id);
+
+    expect(invite.token).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+    expect(invite.createdAt).toBe(Date.now());
+    expect(invite.expiresAt).toBe(Date.now() + DEFAULT_HUNT_INVITE_TTL_MS);
+    expect(getHuntById(privateHunt.id)?.invite).toEqual(invite);
+  });
+
+  it("accepts only the current token for the matching private hunt", () => {
+    const firstInvite = generateHuntInvite(privateHunt.id);
+    expect(validateHuntInviteToken(privateHunt.id, firstInvite.token)).toEqual({
+      isValid: true,
+      reason: "valid",
+    });
+
+    const replacement = generateHuntInvite(privateHunt.id);
+    expect(replacement.token).not.toBe(firstInvite.token);
+    expect(validateHuntInviteToken(privateHunt.id, firstInvite.token)).toEqual({
+      isValid: false,
+      reason: "invalid",
+    });
+    expect(validateHuntInviteToken(privateHunt.id, replacement.token).isValid).toBe(true);
+  });
+
+  it("denies missing and invalid tokens", () => {
+    generateHuntInvite(privateHunt.id);
+
+    expect(validateHuntInviteToken(privateHunt.id, null)).toEqual({
+      isValid: false,
+      reason: "required",
+    });
+    expect(validateHuntInviteToken(privateHunt.id, "not-the-token")).toEqual({
+      isValid: false,
+      reason: "invalid",
+    });
+  });
+
+  it("reports an expired matching token", () => {
+    const invite = generateHuntInvite(privateHunt.id, 60_000);
+
+    expect(validateHuntInviteToken(privateHunt.id, invite.token, invite.expiresAt)).toEqual({
+      isValid: false,
+      reason: "expired",
+    });
+  });
+
+  it("revokes the current link and denies its token", () => {
+    const invite = generateHuntInvite(privateHunt.id);
+
+    expect(revokeHuntInvite(privateHunt.id)).toBe(true);
+    expect(getHuntById(privateHunt.id)?.invite).toBeUndefined();
+    expect(validateHuntInviteToken(privateHunt.id, invite.token)).toEqual({
+      isValid: false,
+      reason: "invalid",
+    });
+    expect(revokeHuntInvite(privateHunt.id)).toBe(false);
+  });
+
+  it("does not require an invite for public hunts", () => {
+    expect(validateHuntInvite(publicHunt, null)).toEqual({
+      isValid: true,
+      reason: "public",
+    });
+  });
+
+  it("does not generate invites for public or missing hunts", () => {
+    expect(() => generateHuntInvite(publicHunt.id)).toThrow(/private hunts/i);
+    expect(() => generateHuntInvite(999_999)).toThrow(/not found/i);
+    expect(() => generateHuntInvite(privateHunt.id, 0)).toThrow(/expiration/i);
+  });
+
+  it("builds the canonical encoded invite URL", () => {
+    expect(buildHuntInviteUrl(42, "token/with spaces", "https://example.com/")).toBe(
+      "https://example.com/hunt/42?invite=token%2Fwith%20spaces"
+    );
+  });
+});

--- a/apps/web/lib/huntStore.ts
+++ b/apps/web/lib/huntStore.ts
@@ -3,42 +3,46 @@
  * Persisted in localStorage so activated hunts appear in the arcade after refresh.
  */
 
-import type { HuntStatus, StoredHunt, Clue } from "@/lib/types"
-import { getHuntsWithRatings } from "@/lib/reviews"
-import { applyHuntScheduleTransitions } from "@/lib/huntScheduling"
-import { normalizeHuntStatus } from "@/lib/huntStatus"
-import { migrateHuntScheduleFieldsInCollection } from "@/lib/huntScheduleMigration"
-import type { Clue,HuntStatus, StoredHunt } from "@/lib/types"
+import { migrateHuntScheduleFieldsInCollection } from "@/lib/huntScheduleMigration";
+import { applyHuntScheduleTransitions } from "@/lib/huntScheduling";
+import { normalizeHuntStatus } from "@/lib/huntStatus";
+import { getHuntsWithRatings } from "@/lib/reviews";
+import type { Clue, HuntInvite, HuntStatus, StoredHunt } from "@/lib/types";
 
-export type { Clue,HuntStatus, StoredHunt }
+export type { Clue, HuntInvite, HuntStatus, StoredHunt };
+
+export type HuntInviteValidation =
+  | { isValid: true; reason: "public" | "valid" }
+  | { isValid: false; reason: "required" | "invalid" | "expired" };
 
 export type HuntStoreSnapshot = {
-  hunts: StoredHunt[]
-  clues: Clue[]
-}
+  hunts: StoredHunt[];
+  clues: Clue[];
+};
 
 export interface HuntProgressSnapshot {
-  huntId: number
-  currentClueIndex: number
-  startedAt: number
-  completed: boolean
-  completedAt?: number
+  huntId: number;
+  currentClueIndex: number;
+  startedAt: number;
+  completed: boolean;
+  completedAt?: number;
 }
 
 export interface HuntStorageGcResult {
-  huntId: number
-  reclaimedBytes: number
-  removedKeys: string[]
+  huntId: number;
+  reclaimedBytes: number;
+  removedKeys: string[];
 }
 
-const STORAGE_KEY = "hunty_hunts"
-const CLUES_KEY = "hunty_clues"
-const HUNT_PROGRESS_KEY_PREFIX = "hunty_hunt_progress_"
+const STORAGE_KEY = "hunty_hunts";
+const CLUES_KEY = "hunty_clues";
+const HUNT_PROGRESS_KEY_PREFIX = "hunty_hunt_progress_";
 
-export const MAX_CLUES_PER_HUNT = 10
+export const MAX_CLUES_PER_HUNT = 10;
+export const DEFAULT_HUNT_INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 // Seed timestamps: active hunts end 7 days from first load, completed hunts in the past.
-const NOW_SECONDS = Math.floor(Date.now() / 1000)
+const NOW_SECONDS = Math.floor(Date.now() / 1000);
 
 export const SEED_HUNTS: StoredHunt[] = [
   {
@@ -47,7 +51,6 @@ export const SEED_HUNTS: StoredHunt[] = [
     description: "Race across town to uncover hidden murals and landmarks.",
     cluesCount: 5,
     category: "Urban",
-    difficulty: "Medium",
     status: "Active",
     rewardType: "XLM",
     rewardPool: 150,
@@ -69,7 +72,6 @@ export const SEED_HUNTS: StoredHunt[] = [
     description: "Solve riddles scattered around campus before the timer ends.",
     cluesCount: 7,
     category: "Campus",
-    difficulty: "Hard",
     status: "Active",
     rewardType: "NFT",
     rewardPool: 40,
@@ -87,7 +89,6 @@ export const SEED_HUNTS: StoredHunt[] = [
     description: "A playful intro game for new teammates around the office.",
     cluesCount: 4,
     category: "Office",
-    difficulty: "Easy",
     status: "Completed",
     rewardType: "Both",
     rewardPool: 250,
@@ -129,115 +130,153 @@ export const SEED_HUNTS: StoredHunt[] = [
     playerCount: 0,
     createdAt: NOW_SECONDS - 86400,
   },
-]
+];
 
 function readClues(): Clue[] {
-  if (typeof window === "undefined") return []
+  if (typeof window === "undefined") return [];
   try {
-    const raw = localStorage.getItem(CLUES_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw) as Clue[]
-    return Array.isArray(parsed) ? parsed : []
+    const raw = localStorage.getItem(CLUES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Clue[];
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
-    return []
+    return [];
   }
 }
 
 function writeClues(clues: Clue[]): void {
-  if (typeof window === "undefined") return
+  if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(CLUES_KEY, JSON.stringify(clues))
+    localStorage.setItem(CLUES_KEY, JSON.stringify(clues));
   } catch {
     // ignore
   }
 }
 
 function readHunts(): StoredHunt[] {
-  if (typeof window === "undefined") return [...SEED_HUNTS]
+  if (typeof window === "undefined") return [...SEED_HUNTS];
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return [...SEED_HUNTS]
-    const parsed = JSON.parse(raw) as StoredHunt[]
-    return Array.isArray(parsed) ? migrateHuntScheduleFieldsInCollection(parsed) : migrateHuntScheduleFieldsInCollection([...SEED_HUNTS])
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [...SEED_HUNTS];
+    const parsed = JSON.parse(raw) as StoredHunt[];
+    return Array.isArray(parsed)
+      ? migrateHuntScheduleFieldsInCollection(parsed)
+      : migrateHuntScheduleFieldsInCollection([...SEED_HUNTS]);
   } catch {
-    return [...SEED_HUNTS]
+    return [...SEED_HUNTS];
   }
 }
 
 function writeHunts(hunts: StoredHunt[]): void {
-  if (typeof window === "undefined") return
+  if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(hunts))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(hunts));
   } catch {
     // ignore
   }
 }
 
+function createInviteUuid(): string {
+  const cryptoApi = globalThis.crypto;
+
+  if (typeof cryptoApi?.randomUUID === "function") {
+    return cryptoApi.randomUUID();
+  }
+
+  if (typeof cryptoApi?.getRandomValues !== "function") {
+    throw new Error(
+      "Secure random token generation is not available in this browser.",
+    );
+  }
+
+  const bytes = cryptoApi.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10).join(""),
+  ].join("-");
+}
+
 function getProgressKey(huntId: number): string {
-  return `${HUNT_PROGRESS_KEY_PREFIX}${huntId}`
+  return `${HUNT_PROGRESS_KEY_PREFIX}${huntId}`;
 }
 
 function readProgressEntry(huntId: number): HuntProgressSnapshot | null {
-  if (typeof window === "undefined") return null
+  if (typeof window === "undefined") return null;
   try {
-    const raw = localStorage.getItem(getProgressKey(huntId))
-    return raw ? (JSON.parse(raw) as HuntProgressSnapshot) : null
+    const raw = localStorage.getItem(getProgressKey(huntId));
+    return raw ? (JSON.parse(raw) as HuntProgressSnapshot) : null;
   } catch {
-    return null
+    return null;
   }
 }
 
 function writeProgressEntry(progress: HuntProgressSnapshot): void {
-  if (typeof window === "undefined") return
+  if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(getProgressKey(progress.huntId), JSON.stringify(progress))
+    localStorage.setItem(
+      getProgressKey(progress.huntId),
+      JSON.stringify(progress),
+    );
   } catch {
     // ignore
   }
 }
 
 function measureStorageEntrySize(key: string, value: string): number {
-  return new TextEncoder().encode(`${key}:${value}`).length
+  return new TextEncoder().encode(`${key}:${value}`).length;
 }
 
-function removeStorageKeysByPrefix(prefix: string): { reclaimedBytes: number; removedKeys: string[] } {
+function removeStorageKeysByPrefix(prefix: string): {
+  reclaimedBytes: number;
+  removedKeys: string[];
+} {
   if (typeof window === "undefined") {
-    return { reclaimedBytes: 0, removedKeys: [] }
+    return { reclaimedBytes: 0, removedKeys: [] };
   }
 
-  const removedKeys: string[] = []
-  let reclaimedBytes = 0
+  const removedKeys: string[] = [];
+  let reclaimedBytes = 0;
 
-  const keys: string[] = []
+  const keys: string[] = [];
   for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i)
+    const key = localStorage.key(i);
     if (key && key.startsWith(prefix)) {
-      keys.push(key)
+      keys.push(key);
     }
   }
 
   for (const key of keys) {
-    const value = localStorage.getItem(key) ?? ""
-    reclaimedBytes += measureStorageEntrySize(key, value)
-    localStorage.removeItem(key)
-    removedKeys.push(key)
+    const value = localStorage.getItem(key) ?? "";
+    reclaimedBytes += measureStorageEntrySize(key, value);
+    localStorage.removeItem(key);
+    removedKeys.push(key);
   }
 
-  return { reclaimedBytes, removedKeys }
+  return { reclaimedBytes, removedKeys };
 }
 
-function validateClueDraft(clue: Omit<Clue, "id">, index: number): Omit<Clue, "id"> {
-  const question = clue.question.trim()
-  const answer = clue.answer.trim()
+function validateClueDraft(
+  clue: Omit<Clue, "id">,
+  index: number,
+): Omit<Clue, "id"> {
+  const question = clue.question.trim();
+  const answer = clue.answer.trim();
 
   if (!question) {
-    throw new Error(`Clue ${index + 1} question is required.`)
+    throw new Error(`Clue ${index + 1} question is required.`);
   }
   if (!answer) {
-    throw new Error(`Clue ${index + 1} answer is required.`)
+    throw new Error(`Clue ${index + 1} answer is required.`);
   }
   if (!Number.isFinite(clue.points) || clue.points <= 0) {
-    throw new Error(`Clue ${index + 1} points must be greater than 0.`)
+    throw new Error(`Clue ${index + 1} points must be greater than 0.`);
   }
 
   return {
@@ -245,45 +284,49 @@ function validateClueDraft(clue: Omit<Clue, "id">, index: number): Omit<Clue, "i
     question,
     answer,
     hint: clue.hint?.trim() || undefined,
-  }
+  };
 }
 
 function getExistingClueCount(huntId: number): number {
-  return getHuntClues(huntId).length
+  return getHuntClues(huntId).length;
 }
 
 /** All hunts (for Game Arcade: filter by status === "Active"). Private, archived, and soft-deleted hunts are excluded. */
 export function getAllHunts(): StoredHunt[] {
-  return getHuntsWithRatings(readHunts().filter((h) => !h.is_private))
-  return readHunts().filter((h) => !h.is_private && !h.isArchived && !h.deletedAt)
-  return applyHuntScheduleTransitions(readHunts()).filter((h) => !h.is_private)
+  return getHuntsWithRatings(readHunts().filter((h) => !h.is_private));
+  return readHunts().filter(
+    (h) => !h.is_private && !h.isArchived && !h.deletedAt,
+  );
+  return applyHuntScheduleTransitions(readHunts()).filter((h) => !h.is_private);
 }
 
 /** All hunts including private ones (for creator dashboard). */
 export function getAllHuntsIncludingPrivate(): StoredHunt[] {
-  return applyHuntScheduleTransitions(readHunts())
+  return applyHuntScheduleTransitions(readHunts());
 }
 
 /** Creator hunts for dashboard (all stored hunts including private; excludes soft-deleted). */
 export function getCreatorHunts(): StoredHunt[] {
-  return readHunts().filter((h) => !h.deletedAt)
-  return applyHuntScheduleTransitions(readHunts())
+  return readHunts().filter((h) => !h.deletedAt);
+  return applyHuntScheduleTransitions(readHunts());
 }
 
 /** Get hunts for a creator (creator public-key filter not implemented yet; returns all hunts). */
 export function getHuntsByCreator(creator?: string): StoredHunt[] {
-  const hunts = applyHuntScheduleTransitions(readHunts())
-  if (!creator) return hunts
+  const hunts = applyHuntScheduleTransitions(readHunts());
+  if (!creator) return hunts;
   return hunts.filter((hunt) => {
-    const withCreator = hunt as StoredHunt & { creator?: string }
-    return !withCreator.creator || withCreator.creator === creator
-  })
+    const withCreator = hunt as StoredHunt & { creator?: string };
+    return !withCreator.creator || withCreator.creator === creator;
+  });
 }
 
 /** Update a hunt's status (e.g. Draft → Active after activate_hunt). */
 export function updateHuntStatus(huntId: number, status: HuntStatus): void {
-  const hunts = readHunts().map((h) => (h.id === huntId ? { ...h, status } : h))
-  writeHunts(hunts)
+  const hunts = readHunts().map((h) =>
+    h.id === huntId ? { ...h, status } : h,
+  );
+  writeHunts(hunts);
 }
 
 /**
@@ -291,29 +334,31 @@ export function updateHuntStatus(huntId: number, status: HuntStatus): void {
  * Scans localStorage for keys of the form `hunt_registered_{huntId}_{address}`.
  */
 export function getRegisteredWallets(huntId: number): string[] {
-  if (typeof window === "undefined") return []
-  const prefix = `hunt_registered_${huntId}_`
-  const wallets: string[] = []
+  if (typeof window === "undefined") return [];
+  const prefix = `hunt_registered_${huntId}_`;
+  const wallets: string[] = [];
   for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i)
+    const key = localStorage.key(i);
     if (key?.startsWith(prefix) && localStorage.getItem(key) === "true") {
-      wallets.push(key.slice(prefix.length))
+      wallets.push(key.slice(prefix.length));
     }
   }
-  return wallets
+  return wallets;
 }
 
 /** Update a hunt's end time (e.g. after extend_end_time). */
 export function updateHuntEndTime(huntId: number, newEndTime: number): void {
-  const hunts = readHunts().map((h) => (h.id === huntId ? { ...h, endTime: newEndTime } : h))
-  writeHunts(hunts)
+  const hunts = readHunts().map((h) =>
+    h.id === huntId ? { ...h, endTime: newEndTime } : h,
+  );
+  writeHunts(hunts);
 }
 
 /** Update reward escrow metadata after deposits, payouts, or refunds. */
 export function updateHuntRewardEscrow(
   huntId: number,
   rewardEscrowBalance: number,
-  rewardEscrowTxHash?: string
+  rewardEscrowTxHash?: string,
 ): void {
   const hunts = readHunts().map((h) =>
     h.id === huntId
@@ -322,243 +367,377 @@ export function updateHuntRewardEscrow(
           rewardEscrowBalance,
           ...(rewardEscrowTxHash ? { rewardEscrowTxHash } : {}),
         }
-      : h
-  )
-  writeHunts(hunts)
+      : h,
+  );
+  writeHunts(hunts);
 }
 
 /** Delete multiple hunts by IDs. */
 export function deleteHunts(ids: number[]): void {
-  const hunts = readHunts().filter((h) => !ids.includes(h.id))
-  writeHunts(hunts)
-  
+  const hunts = readHunts().filter((h) => !ids.includes(h.id));
+  writeHunts(hunts);
+
   // Also clean up clues for these hunts
-  const allClues = readClues()
-  const remainingClues = allClues.filter((c) => !ids.includes(c.huntId))
-  writeClues(remainingClues)
+  const allClues = readClues();
+  const remainingClues = allClues.filter((c) => !ids.includes(c.huntId));
+  writeClues(remainingClues);
 }
 
 /** Archive (Cancel) multiple hunts by IDs. */
 export function archiveHunts(ids: number[]): void {
   const hunts = readHunts().map((h) =>
-    ids.includes(h.id) ? { ...h, status: "Cancelled" as HuntStatus } : h
-  )
-  writeHunts(hunts)
+    ids.includes(h.id) ? { ...h, status: "Cancelled" as HuntStatus } : h,
+  );
+  writeHunts(hunts);
   ids.forEach((huntId) => {
-    gcHunt(huntId)
-  })
+    gcHunt(huntId);
+  });
 }
 
 /** Hide hunts from public view (data preserved) — used by creator archive/unarchive flow. */
 export function hideHuntsFromPublic(ids: number[]): void {
   const hunts = readHunts().map((h) =>
-    ids.includes(h.id) ? { ...h, isArchived: true } : h
-  )
-  writeHunts(hunts)
+    ids.includes(h.id) ? { ...h, isArchived: true } : h,
+  );
+  writeHunts(hunts);
 }
 
 /** Restore hidden hunts to public view. */
 export function unhideHuntsFromPublic(ids: number[]): void {
   const hunts = readHunts().map((h) =>
-    ids.includes(h.id) ? { ...h, isArchived: false } : h
-  )
-  writeHunts(hunts)
+    ids.includes(h.id) ? { ...h, isArchived: false } : h,
+  );
+  writeHunts(hunts);
 }
 
 /** Soft delete multiple hunts by IDs with 30-day recovery window. */
 export function softDeleteHunts(ids: number[]): void {
-  const now = Math.floor(Date.now() / 1000)
-  const recoveryWindow = 30 * 86400 // 30 days in seconds
+  const now = Math.floor(Date.now() / 1000);
+  const recoveryWindow = 30 * 86400; // 30 days in seconds
   const hunts = readHunts().map((h) =>
-    ids.includes(h.id) ? { ...h, deletedAt: now, recoveryWindow } : h
-  )
-  writeHunts(hunts)
+    ids.includes(h.id) ? { ...h, deletedAt: now, recoveryWindow } : h,
+  );
+  writeHunts(hunts);
 }
 
 /** Restore soft-deleted hunts by IDs. */
 export function restoreHunts(ids: number[]): void {
   const hunts = readHunts().map((h) =>
-    ids.includes(h.id) ? { ...h, deletedAt: undefined, recoveryWindow: undefined } : h
-  )
-  writeHunts(hunts)
+    ids.includes(h.id)
+      ? { ...h, deletedAt: undefined, recoveryWindow: undefined }
+      : h,
+  );
+  writeHunts(hunts);
 }
 
 /** Permanently delete hunts (irreversible). */
 export function permanentDeleteHunts(ids: number[]): void {
-  const hunts = readHunts().filter((h) => !ids.includes(h.id))
-  writeHunts(hunts)
+  const hunts = readHunts().filter((h) => !ids.includes(h.id));
+  writeHunts(hunts);
 
   // Also clean up clues for these hunts
-  const allClues = readClues()
-  const remainingClues = allClues.filter((c) => !ids.includes(c.huntId))
-  writeClues(remainingClues)
+  const allClues = readClues();
+  const remainingClues = allClues.filter((c) => !ids.includes(c.huntId));
+  writeClues(remainingClues);
 }
 
 /** Get archived hunts. */
 export function getArchivedHunts(): StoredHunt[] {
-  return readHunts().filter((h) => h.isArchived)
+  return readHunts().filter((h) => h.isArchived);
 }
 
 /** Get soft-deleted hunts that are still within recovery window. */
 export function getSoftDeletedHunts(): StoredHunt[] {
-  const now = Math.floor(Date.now() / 1000)
+  const now = Math.floor(Date.now() / 1000);
   return readHunts().filter((h) => {
-    if (!h.deletedAt) return false
-    const recoveryDeadline = h.deletedAt + (h.recoveryWindow || 30 * 86400)
-    return now < recoveryDeadline
-  })
+    if (!h.deletedAt) return false;
+    const recoveryDeadline = h.deletedAt + (h.recoveryWindow || 30 * 86400);
+    return now < recoveryDeadline;
+  });
 }
 
 /** Get hunts that are past recovery window (eligible for cleanup). */
 export function getExpiredSoftDeletedHunts(): StoredHunt[] {
-  const now = Math.floor(Date.now() / 1000)
+  const now = Math.floor(Date.now() / 1000);
   return readHunts().filter((h) => {
-    if (!h.deletedAt) return false
-    const recoveryDeadline = h.deletedAt + (h.recoveryWindow || 30 * 86400)
-    return now >= recoveryDeadline
-  })
+    if (!h.deletedAt) return false;
+    const recoveryDeadline = h.deletedAt + (h.recoveryWindow || 30 * 86400);
+    return now >= recoveryDeadline;
+  });
 }
 
 /** Get a single hunt by ID */
 export function getHuntById(id: number): StoredHunt | undefined {
-  const hunt = readHunts().find((h) => h.id === id)
-  if (!hunt) return undefined
-  return getHuntsWithRatings([hunt])[0]
-  return applyHuntScheduleTransitions(readHunts()).find((h) => h.id === id)
+  const hunt = applyHuntScheduleTransitions(readHunts()).find(
+    (candidate) => candidate.id === id,
+  );
+  return hunt ? getHuntsWithRatings([hunt])[0] : undefined;
+}
+
+/**
+ * Generate and persist a new invite for a private hunt.
+ * Generating a new invite immediately invalidates any previously issued link.
+ */
+export function generateHuntInvite(
+  huntId: number,
+  ttlMs = DEFAULT_HUNT_INVITE_TTL_MS,
+): HuntInvite {
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new Error("Invite expiration must be greater than 0.");
+  }
+
+  const hunts = readHunts();
+  const hunt = hunts.find((candidate) => candidate.id === huntId);
+
+  if (!hunt) {
+    throw new Error("Hunt not found.");
+  }
+  if (!hunt.is_private) {
+    throw new Error("Invite links can only be generated for private hunts.");
+  }
+
+  const createdAt = Date.now();
+  const invite: HuntInvite = {
+    token: createInviteUuid(),
+    createdAt,
+    expiresAt: createdAt + ttlMs,
+  };
+
+  writeHunts(
+    hunts.map((candidate) =>
+      candidate.id === huntId ? { ...candidate, invite } : candidate,
+    ),
+  );
+
+  return invite;
+}
+
+/** Remove the active invite from a private hunt, invalidating its URL immediately. */
+export function revokeHuntInvite(huntId: number): boolean {
+  const hunts = readHunts();
+  const hunt = hunts.find((candidate) => candidate.id === huntId);
+
+  if (!hunt?.invite) return false;
+
+  writeHunts(
+    hunts.map((candidate) => {
+      if (candidate.id !== huntId) return candidate;
+      const withoutInvite = { ...candidate };
+      delete withoutInvite.invite;
+      return withoutInvite;
+    }),
+  );
+
+  return true;
+}
+
+/** Validate a supplied bearer token against a hunt's current invite record. */
+export function validateHuntInvite(
+  hunt: StoredHunt | undefined,
+  suppliedToken: string | null | undefined,
+  now = Date.now(),
+): HuntInviteValidation {
+  if (!hunt) return { isValid: false, reason: "invalid" };
+  if (!hunt.is_private) return { isValid: true, reason: "public" };
+  if (!suppliedToken) return { isValid: false, reason: "required" };
+  if (!hunt.invite || suppliedToken !== hunt.invite.token) {
+    return { isValid: false, reason: "invalid" };
+  }
+  if (!Number.isFinite(hunt.invite.expiresAt) || hunt.invite.expiresAt <= now) {
+    return { isValid: false, reason: "expired" };
+  }
+
+  return { isValid: true, reason: "valid" };
+}
+
+/** Validate an invite using the latest hunt record in the local hunt store. */
+export function validateHuntInviteToken(
+  huntId: number,
+  suppliedToken: string | null | undefined,
+  now = Date.now(),
+): HuntInviteValidation {
+  return validateHuntInvite(getHuntById(huntId), suppliedToken, now);
+}
+
+/** Build the canonical URL creators copy from the dashboard. */
+export function buildHuntInviteUrl(
+  huntId: number,
+  token: string,
+  baseUrl?: string,
+): string {
+  const origin =
+    baseUrl ??
+    (typeof window !== "undefined" ? window.location.origin : undefined) ??
+    process.env.NEXT_PUBLIC_BASE_URL ??
+    "https://hunty.app";
+  const normalizedOrigin = origin.replace(/\/$/, "");
+
+  return `${normalizedOrigin}/hunt/${huntId}?invite=${encodeURIComponent(token)}`;
 }
 
 /** Get reward-pool related data for a hunt. */
 export function getHuntPool(huntId: number) {
-  const hunt = getHuntById(huntId)
-  if (!hunt) return null
+  const hunt = getHuntById(huntId);
+  if (!hunt) return null;
   return {
     rewardPool: hunt.rewardPool ?? 0,
     poolBalance: hunt.poolBalance ?? hunt.rewardPool ?? 0,
     distribution: hunt.rewardDistribution ?? [],
-    lowThreshold: hunt.poolLowBalanceThreshold ?? Math.max(1, (hunt.rewardPool ?? 0) * 0.2),
-  }
+    lowThreshold:
+      hunt.poolLowBalanceThreshold ?? Math.max(1, (hunt.rewardPool ?? 0) * 0.2),
+  };
 }
 
 /** Deposit XLM into a hunt's reward pool. Updates both `rewardPool` and `poolBalance`. */
 export function depositToPool(huntId: number, amount: number): boolean {
-  if (amount <= 0) return false
+  if (amount <= 0) return false;
   const hunts = readHunts().map((h) => {
-    if (h.id !== huntId) return h
-    const prevTotal = h.rewardPool ?? 0
-    const prevBalance = h.poolBalance ?? prevTotal
-    return { ...h, rewardPool: prevTotal + amount, poolBalance: prevBalance + amount }
-  })
-  writeHunts(hunts)
-  return true
+    if (h.id !== huntId) return h;
+    const prevTotal = h.rewardPool ?? 0;
+    const prevBalance = h.poolBalance ?? prevTotal;
+    return {
+      ...h,
+      rewardPool: prevTotal + amount,
+      poolBalance: prevBalance + amount,
+    };
+  });
+  writeHunts(hunts);
+  return true;
 }
 
 /** Alias for deposit. */
 export function topUpPool(huntId: number, amount: number): boolean {
-  return depositToPool(huntId, amount)
+  return depositToPool(huntId, amount);
 }
 
 /** Withdraw unclaimed rewards after a hunt ends or is not active anymore. */
-export function withdrawUnclaimedRewards(huntId: number, amount: number): boolean {
-  const hunt = getHuntById(huntId)
-  if (!hunt) return false
-  if (hunt.status === "Active") return false
-  const prevBalance = hunt.poolBalance ?? hunt.rewardPool ?? 0
-  const withdrawAmount = Math.min(amount, prevBalance)
+export function withdrawUnclaimedRewards(
+  huntId: number,
+  amount: number,
+): boolean {
+  const hunt = getHuntById(huntId);
+  if (!hunt) return false;
+  if (hunt.status === "Active") return false;
+  const prevBalance = hunt.poolBalance ?? hunt.rewardPool ?? 0;
+  const withdrawAmount = Math.min(amount, prevBalance);
   const hunts = readHunts().map((h) =>
-    h.id === huntId ? { ...h, poolBalance: prevBalance - withdrawAmount, rewardPool: Math.max(0, (h.rewardPool ?? 0) - withdrawAmount) } : h
-  )
-  writeHunts(hunts)
-  return true
+    h.id === huntId
+      ? {
+          ...h,
+          poolBalance: prevBalance - withdrawAmount,
+          rewardPool: Math.max(0, (h.rewardPool ?? 0) - withdrawAmount),
+        }
+      : h,
+  );
+  writeHunts(hunts);
+  return true;
 }
 
 /** Set a distribution plan for a hunt's reward pool. */
-export function setDistributionPlan(huntId: number, distribution: { place: number; amount: number }[]) {
+export function setDistributionPlan(
+  huntId: number,
+  distribution: { place: number; amount: number }[],
+) {
   const hunts = readHunts().map((h) =>
-    h.id === huntId ? { ...h, rewardDistribution: distribution, rewardPool: distribution.reduce((s, d) => s + d.amount, 0), poolBalance: distribution.reduce((s, d) => s + d.amount, 0) } : h
-  )
-  writeHunts(hunts)
+    h.id === huntId
+      ? {
+          ...h,
+          rewardDistribution: distribution,
+          rewardPool: distribution.reduce((s, d) => s + d.amount, 0),
+          poolBalance: distribution.reduce((s, d) => s + d.amount, 0),
+        }
+      : h,
+  );
+  writeHunts(hunts);
 }
 
 /** Returns whether the pool is considered low based on configured threshold. */
 export function isPoolLow(huntId: number): boolean {
-  const hunt = getHuntById(huntId)
-  if (!hunt) return false
-  const balance = hunt.poolBalance ?? hunt.rewardPool ?? 0
-  const threshold = hunt.poolLowBalanceThreshold ?? Math.max(1, (hunt.rewardPool ?? 0) * 0.2)
-  return balance < threshold
+  const hunt = getHuntById(huntId);
+  if (!hunt) return false;
+  const balance = hunt.poolBalance ?? hunt.rewardPool ?? 0;
+  const threshold =
+    hunt.poolLowBalanceThreshold ?? Math.max(1, (hunt.rewardPool ?? 0) * 0.2);
+  return balance < threshold;
 }
 
 /** Add a new hunt (e.g. after createHunt). */
 export function addHunt(hunt: StoredHunt): void {
-  const hunts = readHunts()
-  if (hunts.some((h) => h.id === hunt.id)) return
+  const hunts = readHunts();
+  if (hunts.some((h) => h.id === hunt.id)) return;
   const normalized = {
     ...hunt,
     status: normalizeHuntStatus(hunt.status) as StoredHunt["status"],
-  }
-  writeHunts([...hunts, normalized])
+  };
+  writeHunts([...hunts, normalized]);
 }
 
 /** Get all clues for a specific hunt. */
 export function getHuntClues(huntId: number): Clue[] {
-  return readClues().filter((c) => c.huntId === huntId)
+  return readClues().filter((c) => c.huntId === huntId);
 }
 
 /** Persist a new clue locally and increment the hunt's cluesCount. */
 export function saveClueLocally(clue: Omit<Clue, "id">): number {
-  const ids = saveCluesLocallyBatch([clue])
-  return ids[0]
+  const ids = saveCluesLocallyBatch([clue]);
+  return ids[0];
 }
 
 /** Persist multiple new clues locally in one write. */
 export function saveCluesLocallyBatch(clues: Omit<Clue, "id">[]): number[] {
   if (clues.length === 0) {
-    return []
+    return [];
   }
 
-  const normalized = clues.map((clue, index) => validateClueDraft(clue, index))
-  const huntId = normalized[0]?.huntId
+  const normalized = clues.map((clue, index) => validateClueDraft(clue, index));
+  const huntId = normalized[0]?.huntId;
   if (normalized.some((clue) => clue.huntId !== huntId)) {
-    throw new Error("All clues in a batch must belong to the same hunt.")
+    throw new Error("All clues in a batch must belong to the same hunt.");
   }
 
   if (getExistingClueCount(huntId) + normalized.length > MAX_CLUES_PER_HUNT) {
-    throw new Error(`A hunt can have at most ${MAX_CLUES_PER_HUNT} clues.`)
+    throw new Error(`A hunt can have at most ${MAX_CLUES_PER_HUNT} clues.`);
   }
 
-  const all = readClues()
-  const nextId = all.length > 0 ? Math.max(...all.map((c) => c.id)) + 1 : 1
+  const all = readClues();
+  const nextId = all.length > 0 ? Math.max(...all.map((c) => c.id)) + 1 : 1;
   const withIds = normalized.map((clue, index) => ({
     ...clue,
     id: nextId + index,
-  }))
+  }));
 
-  writeClues([...all, ...withIds])
+  writeClues([...all, ...withIds]);
 
   const hunts = readHunts().map((hunt) =>
-    hunt.id === huntId ? { ...hunt, cluesCount: hunt.cluesCount + withIds.length } : hunt
-  )
-  writeHunts(hunts)
+    hunt.id === huntId
+      ? { ...hunt, cluesCount: hunt.cluesCount + withIds.length }
+      : hunt,
+  );
+  writeHunts(hunts);
 
-  return withIds.map((clue) => clue.id)
+  return withIds.map((clue) => clue.id);
 }
 
 /** Update an existing clue's answer or other fields. Returns true if updated. */
-export function updateClueAnswer(huntId: number, clueId: number, answer: string): boolean {
-  const all = readClues()
-  const idx = all.findIndex((c) => c.huntId === huntId && c.id === clueId)
-  if (idx === -1) return false
-  const updated = [...all]
-  updated[idx] = { ...updated[idx], answer }
-  writeClues(updated)
-  return true
+export function updateClueAnswer(
+  huntId: number,
+  clueId: number,
+  answer: string,
+): boolean {
+  const all = readClues();
+  const idx = all.findIndex((c) => c.huntId === huntId && c.id === clueId);
+  if (idx === -1) return false;
+  const updated = [...all];
+  updated[idx] = { ...updated[idx], answer };
+  writeClues(updated);
+  return true;
 }
 
 /** Reads the current per-hunt progress snapshot. */
 export function getHuntProgress(huntId: number): HuntProgressSnapshot {
-  const existing = readProgressEntry(huntId)
+  const existing = readProgressEntry(huntId);
   if (existing) {
-    return existing
+    return existing;
   }
 
   const initial: HuntProgressSnapshot = {
@@ -566,20 +745,20 @@ export function getHuntProgress(huntId: number): HuntProgressSnapshot {
     currentClueIndex: 0,
     startedAt: Date.now(),
     completed: false,
-  }
-  writeProgressEntry(initial)
-  return initial
+  };
+  writeProgressEntry(initial);
+  return initial;
 }
 
 /** Records that a hunt has started for the current browser session. */
 export function startHuntProgress(huntId: number): HuntProgressSnapshot {
-  const current = getHuntProgress(huntId)
+  const current = getHuntProgress(huntId);
   const next: HuntProgressSnapshot = {
     ...current,
     startedAt: current.startedAt || Date.now(),
-  }
-  writeProgressEntry(next)
-  return next
+  };
+  writeProgressEntry(next);
+  return next;
 }
 
 /** Advances the tracked progress to the next clue index. */
@@ -588,22 +767,22 @@ export function advanceHuntProgress(
   nextClueIndex: number,
   totalClues: number,
 ): HuntProgressSnapshot {
-  const current = getHuntProgress(huntId)
-  const completed = nextClueIndex >= totalClues
+  const current = getHuntProgress(huntId);
+  const completed = nextClueIndex >= totalClues;
   const next: HuntProgressSnapshot = {
     ...current,
     currentClueIndex: Math.max(current.currentClueIndex, nextClueIndex),
     completed,
     completedAt: completed ? Date.now() : current.completedAt,
-  }
-  writeProgressEntry(next)
-  return next
+  };
+  writeProgressEntry(next);
+  return next;
 }
 
 /** Clears the tracked hunt progress for the current browser session. */
 export function clearHuntProgress(huntId: number): void {
-  if (typeof window === "undefined") return
-  localStorage.removeItem(getProgressKey(huntId))
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(getProgressKey(huntId));
 }
 
 /**
@@ -612,16 +791,16 @@ export function clearHuntProgress(huntId: number): void {
  */
 export function gcHunt(huntId: number): HuntStorageGcResult {
   if (typeof window === "undefined") {
-    return { huntId, reclaimedBytes: 0, removedKeys: [] }
+    return { huntId, reclaimedBytes: 0, removedKeys: [] };
   }
 
-  const hunt = getHuntById(huntId)
+  const hunt = getHuntById(huntId);
   if (!hunt || hunt.status !== "Cancelled") {
-    return { huntId, reclaimedBytes: 0, removedKeys: [] }
+    return { huntId, reclaimedBytes: 0, removedKeys: [] };
   }
 
-  const removedKeys: string[] = []
-  let reclaimedBytes = 0
+  const removedKeys: string[] = [];
+  let reclaimedBytes = 0;
 
   const prefixes = [
     `hunt_clue_start_${huntId}_`,
@@ -636,17 +815,18 @@ export function gcHunt(huntId: number): HuntStorageGcResult {
     `hunt_completion_time_${huntId}`,
     `hunt_completers_${huntId}`,
     `hunt_stats_${huntId}_`,
-  ]
+  ];
 
   for (const prefix of prefixes) {
-    const { reclaimedBytes: prefixBytes, removedKeys: prefixKeys } = removeStorageKeysByPrefix(prefix)
-    reclaimedBytes += prefixBytes
-    removedKeys.push(...prefixKeys)
+    const { reclaimedBytes: prefixBytes, removedKeys: prefixKeys } =
+      removeStorageKeysByPrefix(prefix);
+    reclaimedBytes += prefixBytes;
+    removedKeys.push(...prefixKeys);
   }
 
-  clearHuntProgress(huntId)
+  clearHuntProgress(huntId);
 
-  return { huntId, reclaimedBytes, removedKeys }
+  return { huntId, reclaimedBytes, removedKeys };
 }
 
 /** Snapshot current hunts/clues for optimistic UI rollback. */
@@ -654,62 +834,64 @@ export function takeHuntStoreSnapshot(): HuntStoreSnapshot {
   return {
     hunts: readHunts(),
     clues: readClues(),
-  }
+  };
 }
 
 /** Restore hunts/clues after an optimistic update fails. */
 export function restoreHuntStoreSnapshot(snapshot: HuntStoreSnapshot): void {
-  writeHunts(snapshot.hunts)
-  writeClues(snapshot.clues)
+  writeHunts(snapshot.hunts);
+  writeClues(snapshot.clues);
 }
 
 /** Get a single hunt by string ID */
 export const getHunt = (id: string) => {
-  return readHunts().find((c) => c.id === Number(id))
-}
+  return readHunts().find((c) => c.id === Number(id));
+};
 
 /**
  * Return up to `limit` featured hunts, ranked by a trending score.
  * Score factors: clue count, reward type variety, time remaining, recency.
  */
 export function getFeaturedHunts(limit = 3): StoredHunt[] {
-  const now = Math.floor(Date.now() / 1000)
-  const active = readHunts().filter((h) => h.status === "Active" && !h.is_private)
+  const now = Math.floor(Date.now() / 1000);
+  const active = readHunts().filter(
+    (h) => h.status === "Active" && !h.is_private,
+  );
 
   const scored = active.map((hunt) => {
-    let score = 0
+    let score = 0;
     // More clues = higher quality hunt
-    score += hunt.cluesCount * 10
+    score += hunt.cluesCount * 10;
     // Dual-reward hunts are more attractive
-    if (hunt.rewardType === "Both") score += 20
-    else if (hunt.rewardType === "NFT") score += 10
+    if (hunt.rewardType === "Both") score += 20;
+    else if (hunt.rewardType === "NFT") score += 10;
     // Hunts ending soon get a boost (urgency)
     if (hunt.endTime) {
-      const hoursLeft = (hunt.endTime - now) / 3600
-      if (hoursLeft > 0 && hoursLeft < 48) score += 15
+      const hoursLeft = (hunt.endTime - now) / 3600;
+      if (hoursLeft > 0 && hoursLeft < 48) score += 15;
     }
     // Recently started hunts get a freshness boost
     if (hunt.startTime) {
-      const daysSinceStart = (now - hunt.startTime) / 86400
-      if (daysSinceStart < 3) score += 10
+      const daysSinceStart = (now - hunt.startTime) / 86400;
+      if (daysSinceStart < 3) score += 10;
     }
-    return { hunt, score }
-  })
+    return { hunt, score };
+  });
 
   return scored
     .sort((a, b) => b.score - a.score)
     .slice(0, limit)
-    .map((s) => s.hunt)
+    .map((s) => s.hunt);
 }
 
 /** Duplicate a hunt, returning the new hunt or undefined if original not found. */
 export function duplicateHunt(huntId: number): StoredHunt | undefined {
-  const original = getHuntById(huntId)
-  if (!original) return undefined
+  const original = getHuntById(huntId);
+  if (!original) return undefined;
 
-  const hunts = readHunts()
-  const newId = hunts.length > 0 ? Math.max(...hunts.map((h) => h.id)) + 1 : 1
-  const nowSeconds = Math.floor(Date.now() / 1000)
+  const hunts = readHunts();
+  const newId = hunts.length > 0 ? Math.max(...hunts.map((h) => h.id)) + 1 : 1;
+  const nowSeconds = Math.floor(Date.now() / 1000);
 
   const duplicate: StoredHunt = {
     id: newId,
@@ -732,11 +914,11 @@ export function duplicateHunt(huntId: number): StoredHunt | undefined {
     is_private: original.is_private,
     coverImageCid: original.coverImageCid,
     isFeaturedOfWeek: false,
-  }
+  };
 
-  addHunt(duplicate)
+  addHunt(duplicate);
 
-  const originalClues = getHuntClues(huntId)
+  const originalClues = getHuntClues(huntId);
   for (const clue of originalClues) {
     saveClueLocally({
       huntId: newId,
@@ -749,10 +931,10 @@ export function duplicateHunt(huntId: number): StoredHunt | undefined {
       latitude: clue.latitude,
       longitude: clue.longitude,
       geofenceRadiusMeters: clue.geofenceRadiusMeters,
-    })
+    });
   }
 
-  return duplicate
+  return duplicate;
 }
 
 /** Set/unset a hunt as the featured Hunt of the Week in local storage. */
@@ -760,6 +942,6 @@ export function setLocalFeaturedHunt(huntId: number | null): void {
   const hunts = readHunts().map((h) => ({
     ...h,
     isFeaturedOfWeek: h.id === huntId ? true : false,
-  }))
-  writeHunts(hunts)
+  }));
+  writeHunts(hunts);
 }

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -7,29 +7,45 @@
  * types (display entries, performance, chat, …) remain defined below.
  */
 
-import type { ReactNode } from "react"
-import type { HuntCategoryId } from "./categories"
-import type { CollaboratorRole, HuntCollaborator } from "./collaboration"
-import type { AnswerStrictness } from "./fuzzyAnswer"
+import type {
+  HuntCategory as DomainHuntCategory,
+  HuntInvite,
+  PlayerProgress,
+  Reward as DomainReward,
+} from "@hunty/types";
+import type { ReactNode } from "react";
 
-import type { ClueScoringBreakdown, HuntScoringBreakdown, ScoringWeights } from "./scoring"
-import type { ClueDifficulty, PlayerProgress, Reward as DomainReward } from "@hunty/types"
+import type { HuntCategoryId } from "./categories";
+import type { CollaboratorRole, HuntCollaborator } from "./collaboration";
+import type { AnswerStrictness } from "./fuzzyAnswer";
+import type {
+  ClueScoringBreakdown,
+  HuntScoringBreakdown,
+  ScoringWeights,
+} from "./scoring";
 
 // ─── Shared domain types (single source of truth: @hunty/types) ──────────────
 
 export interface HuntReview {
-  id: string
-  huntId: number
-  playerAddress: string
-  rating: number // 1 to 5
-  text?: string
-  createdAt: number
-  moderated?: boolean
-  flagged?: boolean
+  id: string;
+  huntId: number;
+  playerAddress: string;
+  rating: number; // 1 to 5
+  text?: string;
+  createdAt: number;
+  moderated?: boolean;
+  flagged?: boolean;
 }
 
-export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled"
-export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled" | "PendingReview"
+export type HuntStatus =
+  | "Active"
+  | "Completed"
+  | "Draft"
+  | "Cancelled"
+  | "PendingReview"
+  | "scheduled"
+  | "active"
+  | "ended";
 
 /**
  * Hunt-level difficulty rating set by the creator so players can gauge
@@ -37,105 +53,96 @@ export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled" | "Pendi
  * individual clues. Older hunts without a difficulty field render as
  * unrated (no badge).
  */
-export type HuntDifficulty = "Easy" | "Medium" | "Hard" | "Expert"
-export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled" | "scheduled" | "active" | "ended"
+export type HuntDifficulty = "Easy" | "Medium" | "Hard" | "Expert";
 
 export interface StoredHunt {
-  id: number
-  title: string
-  description: string
-  cluesCount: number
-  /** Broad hunt category used in discovery filters. */
-  category?: "Urban" | "Campus" | "Office" | "Museum" | "General"
+  id: number;
+  title: string;
+  description: string;
+  cluesCount: number;
+  /** Broad category used by legacy and current discovery filters. */
+  category?: DomainHuntCategory | HuntCategoryId;
   /** Overall hunt difficulty tag used in discovery filters. */
-  difficulty?: "Easy" | "Medium" | "Hard"
-  status: HuntStatus
-  rewardType: "XLM" | "NFT" | "Both"
+  difficulty?: HuntDifficulty;
+  status: HuntStatus;
+  rewardType: "XLM" | "NFT" | "Both";
   /** When true, players must solve clues in order. */
-  sequential?: boolean
+  sequential?: boolean;
   /** Total reward pool value used for creator-side sorting. */
-  rewardPool?: number
+  rewardPool?: number;
   /** Per-place XLM reward buckets funded by the creator. */
-  rewards?: Reward[]
+  rewards?: Reward[];
   /** Reward distribution plan for the pool. */
-  rewardDistribution?: { place: number; amount: number }[]
+  rewardDistribution?: Reward[];
   /** Current balance in the reward pool. */
-  poolBalance?: number
+  poolBalance?: number;
   /** Low balance threshold for the pool. */
-  poolLowBalanceThreshold?: number
+  poolLowBalanceThreshold?: number;
   /** Escrow transaction hash proving the creator funded the XLM reward pool. */
-  rewardEscrowTxHash?: string
+  rewardEscrowTxHash?: string;
   /** Amount still available in the XLM escrow. */
-  rewardEscrowBalance?: number
+  rewardEscrowBalance?: number;
   /** Creator-side participant count snapshot for dashboard sorting. */
-  playerCount?: number
-  /** Max number of participants for limited spots */
-  maxCapacity?: number
+  playerCount?: number;
+  /** Max number of participants for limited spots. */
+  maxCapacity?: number;
   /** Unix timestamp in seconds when the hunt draft was created locally. */
-  createdAt?: number
+  createdAt?: number;
   /** Unix timestamp in seconds — when the hunt starts. */
-  startTime?: number
+  startTime?: number;
   /** Unix timestamp in seconds — when the hunt ends. */
-  endTime?: number
+  endTime?: number;
   /** Canonical UTC timestamp for scheduled lifecycle transitions. */
-  startAt?: number
+  startAt?: number;
   /** Canonical UTC timestamp for scheduled lifecycle transitions. */
-  endAt?: number
-  creatorEmail?: string
-  emailNotifications?: boolean
+  endAt?: number;
+  creatorEmail?: string;
+  emailNotifications?: boolean;
   /** When true, the hunt is hidden from the public arcade grid. */
-  is_private?: boolean
+  is_private?: boolean;
+  /** The active private-hunt invite. Replaced on regeneration and removed on revoke. */
+  invite?: HuntInvite;
   /** Optional game cover CID/URL for hunt cards and sharing previews. */
-  coverImageCid?: string
+  coverImageCid?: string;
   /** Active editorial banner showcase at the top of the Arcade. */
-  isFeaturedOfWeek?: boolean
-  /** Creator's wallet public key */
-  creator?: string
-  /** Average user rating (1-5) */
-  averageRating?: number
-  /** Number of user reviews */
-  reviewCount?: number
-  poolBalance?: number
-  rewardDistribution?: Reward[]
-  poolLowBalanceThreshold?: number
+  isFeaturedOfWeek?: boolean;
+  /** Creator's wallet public key. */
+  creator?: string;
+  /** Average user rating (1-5). */
+  averageRating?: number;
+  /** Number of user reviews. */
+  reviewCount?: number;
   /** When true, the hunt is archived (hidden from public but data preserved). */
-  isArchived?: boolean
+  isArchived?: boolean;
   /** Unix timestamp in seconds when the hunt was soft-deleted. */
-  deletedAt?: number
+  deletedAt?: number;
   /** Recovery window in seconds (default: 30 days = 2592000 seconds). */
-  recoveryWindow?: number
-  /** Predefined discovery category. */
-  category?: HuntCategoryId
+  recoveryWindow?: number;
   /** Free-form discovery tags (normalized kebab-case). */
-  tags?: string[]
+  tags?: string[];
   /** Primary owner wallet (Stellar G-address). */
-  ownerAddress?: string
+  ownerAddress?: string;
   /** Collaborators snapshot (authoritative list may live in collaboration store). */
-  collaborators?: HuntCollaborator[]
-  /**
-   * Creator-set difficulty rating surfaced on cards and the Arcade filter.
-   * Optional for backward compatibility with pre-existing StoredHunt records.
-   */
-  difficulty?: HuntDifficulty
+  collaborators?: HuntCollaborator[];
 }
 
 export type HuntInfo = {
-  id: number
-  title: string
-  description: string
-  totalClues: number
-  status: string
-  sequential?: boolean
-  startTime?: number
-  endTime?: number
-  creatorEmail?: string
-  emailNotifications?: boolean
-  difficulty?: HuntDifficulty
-}
+  id: number;
+  title: string;
+  description: string;
+  totalClues: number;
+  status: string;
+  sequential?: boolean;
+  startTime?: number;
+  endTime?: number;
+  creatorEmail?: string;
+  emailNotifications?: boolean;
+  difficulty?: HuntDifficulty;
+};
 
 // ─── Clue ────────────────────────────────────────────────────────────────────
 
-export type ClueDifficulty = "Easy" | "Medium" | "Hard"
+export type ClueDifficulty = "Easy" | "Medium" | "Hard";
 
 /**
  * A single progressive hint entry. Creators can define up to 3 hints per clue.
@@ -145,235 +152,226 @@ export type ClueDifficulty = "Easy" | "Medium" | "Hard"
  */
 export interface ClueHint {
   /** The hint text shown to the player. */
-  text: string
+  text: string;
   /** Points deducted from the clue score when this hint is revealed. */
-  penalty: number
+  penalty: number;
   /** Seconds the player must wait after the previous hint before revealing this one. */
-  delaySeconds: number
+  delaySeconds: number;
 }
 
 export interface Clue {
-  id: number
-  huntId: number
-  question: string
-  answer: string
-  points: number
+  id: number;
+  huntId: number;
+  question: string;
+  answer: string;
+  points: number;
   /**
    * Progressive hints array (up to 3). Takes precedence over the legacy
    * `hint` / `hintCost` fields when present.
    */
-  hints?: ClueHint[]
+  hints?: ClueHint[];
   /** @deprecated Use `hints[0]` instead. Kept for backwards compatibility. */
-  hint?: string
+  hint?: string;
   /** @deprecated Use `hints[0].penalty` instead. Kept for backwards compatibility. */
-  hintCost?: number
+  hintCost?: number;
   /** Optional difficulty tag set by the creator. */
-  difficulty?: ClueDifficulty
+  difficulty?: ClueDifficulty;
   /** Center latitude for the clue's answer geofence. */
-  latitude?: number
+  latitude?: number;
   /** Center longitude for the clue's answer geofence. */
-  longitude?: number
+  longitude?: number;
   /** Allowed distance from the clue center in metres. Defaults to 100m. */
-  geofenceRadiusMeters?: number
+  geofenceRadiusMeters?: number;
   /** Creator-specified accepted alternative answers (plaintext). */
-  alternativeAnswers?: string[]
+  alternativeAnswers?: string[];
   /** Fuzzy matching strictness for this clue. Defaults to "normal". */
-  answerStrictness?: AnswerStrictness
+  answerStrictness?: AnswerStrictness;
 }
 
 export type ClueInfo = {
-  id: number
-  question: string
-  points: number
+  id: number;
+  question: string;
+  points: number;
   /** Progressive hints (up to 3). Supersedes the legacy `hint`/`hintCost` fields. */
-  hints?: ClueHint[]
+  hints?: ClueHint[];
   /** @deprecated Use `hints[0]` instead. */
-  hint?: string
+  hint?: string;
   /** @deprecated Use `hints[0].penalty` instead. */
-  hintCost?: number
-  difficulty?: ClueDifficulty
-}
+  hintCost?: number;
+  difficulty?: ClueDifficulty;
+};
 
 export interface ClueRow {
-  id: number
-  question: string
-  answer: string
-  points: number
-  hints?: ClueHint[]
+  id: number;
+  question: string;
+  answer: string;
+  points: number;
+  hints?: ClueHint[];
   /** @deprecated */
-  hint?: string
+  hint?: string;
   /** @deprecated */
-  hintCost?: number
-  difficulty?: ClueDifficulty
-  alternativeAnswers?: string[]
-  answerStrictness?: AnswerStrictness
+  hintCost?: number;
+  difficulty?: ClueDifficulty;
+  alternativeAnswers?: string[];
+  answerStrictness?: AnswerStrictness;
 }
 export type {
-  HuntStatus,
-  HuntCategory,
-  HuntDifficulty,
-  StoredHunt,
-  HuntInfo,
-  HuntDraft,
-  ClueDifficulty,
-  Clue,
-  ClueInfo,
-  ClueRow,
-  PlayerProgress,
-  PlayerStats,
-  PlayerHuntProgress,
-  HuntProgressStatus,
-  RewardType,
-  RewardReceiptType,
-  RewardReceipt,
-  RewardHistoryType,
-  RewardHistoryEntry,
   Achievement,
   AchievementId,
   AchievementRarity,
-} from "@hunty/types"
+  HuntCategory,
+  HuntInvite,
+  HuntProgressStatus,
+  PlayerHuntProgress,
+  PlayerProgress,
+  RewardHistoryEntry,
+  RewardHistoryType,
+  RewardReceipt,
+  RewardReceiptType,
+  RewardType,
+} from "@hunty/types";
 
-export type { HuntCategoryId, CollaboratorRole, AnswerStrictness }
+export type { AnswerStrictness, CollaboratorRole, HuntCategoryId };
 
 // ─── Transaction Results ─────────────────────────────────────────────────────
 
 export type CreateHuntResult = {
-  txHash: string
-}
+  txHash: string;
+};
 
 export type ClaimRewardResult = {
-  txHash: string
+  txHash: string;
   /** ipfs:// URI for the SEP-0039 compliant metadata JSON uploaded before minting. */
-  metadataUri: string
-}
+  metadataUri: string;
+};
 
 export type SubmitAnswerResult = {
-  txHash: string
+  txHash: string;
   /** The contract event emitted on success. */
-  event: "ClueCompleted"
-}
+  event: "ClueCompleted";
+};
 
 export type ActivateHuntResult = {
-  txHash: string
-}
+  txHash: string;
+};
 
 export type AddClueResult = {
-  txHash: string
-}
+  txHash: string;
+};
 
 export type ExtendHuntResult = {
-  txHash: string
-  newEndTime: number
-}
+  txHash: string;
+  newEndTime: number;
+};
 
 // ─── Leaderboard ─────────────────────────────────────────────────────────────
 
-export type LeaderboardTimePeriod = "today" | "week" | "month" | "all"
-export type LeaderboardMetric = "points" | "completions"
+export type LeaderboardTimePeriod = "today" | "week" | "month" | "all";
+export type LeaderboardMetric = "points" | "completions";
 
 export type LeaderboardEntry = {
-  address: string
-  name?: string
-  points: number
-  completionCount?: number
-  completedAt?: number
-  category?: string
-  difficulty?: ClueDifficulty
-}
+  address: string;
+  name?: string;
+  points: number;
+  completionCount?: number;
+  completedAt?: number;
+  category?: string;
+  difficulty?: ClueDifficulty;
+};
 
 export interface LeaderboardFilters {
-  timePeriod: LeaderboardTimePeriod
-  category: string
-  difficulty: ClueDifficulty | "all"
-  metric: LeaderboardMetric
+  timePeriod: LeaderboardTimePeriod;
+  category: string;
+  difficulty: ClueDifficulty | "all";
+  metric: LeaderboardMetric;
 }
 
 export type FastestPlayerEntry = {
-  address: string
-  name?: string
-  points?: number
-  completionTimeSeconds: number
-}
+  address: string;
+  name?: string;
+  points?: number;
+  completionTimeSeconds: number;
+};
 
 export interface LeaderboardDisplayEntry {
-  position: number
-  name: string
-  points: number
-  icon: ReactNode
-  completionCount?: number
-  completedAt?: number
-  category?: string
-  difficulty?: ClueDifficulty
+  position: number;
+  name: string;
+  points: number;
+  icon: ReactNode;
+  completionCount?: number;
+  completedAt?: number;
+  category?: string;
+  difficulty?: ClueDifficulty;
   /** Full Stellar address for this row, when known. Drives the identicon, copy button, and explorer link. */
-  address?: string
+  address?: string;
   /** True when `name` is a player-chosen display name rather than a truncated address. */
-  hasDisplayName?: boolean
+  hasDisplayName?: boolean;
 }
 
 export interface FastestPlayerDisplayEntry {
-  position: number
-  name: string
-  completionTimeLabel: string
-  points?: number
-  icon: ReactNode
+  position: number;
+  name: string;
+  completionTimeLabel: string;
+  points?: number;
+  icon: ReactNode;
 }
 
 // ─── Registration (PlayerProgress lives in @hunty/types) ─────────────────────
 
 export type RegistrationStatus = {
-  isRegistered: boolean
-  progressData?: PlayerProgress
-  loading: boolean
-  error?: string
-}
+  isRegistered: boolean;
+  progressData?: PlayerProgress;
+  loading: boolean;
+  error?: string;
+};
 
 export type RegistrationResult = {
-  success: boolean
-  error?: string
-  transactionHash?: string
-}
+  success: boolean;
+  error?: string;
+  transactionHash?: string;
+};
 
-export type HuntAttemptStatus = "completed" | "abandoned" | "in_progress"
+export type HuntAttemptStatus = "completed" | "abandoned" | "in_progress";
 
 export interface ClueAttemptRecord {
-  clueId: number
-  clueIndex: number
-  question: string
-  answerGiven: string
-  timeTakenSeconds: number
-  pointsEarned: number
-  answeredAt: string
-  hintsUsed: number // Number of hints used for this clue
-  scoringBreakdown?: ClueScoringBreakdown // Detailed scoring breakdown
+  clueId: number;
+  clueIndex: number;
+  question: string;
+  answerGiven: string;
+  timeTakenSeconds: number;
+  pointsEarned: number;
+  answeredAt: string;
+  hintsUsed: number; // Number of hints used for this clue
+  scoringBreakdown?: ClueScoringBreakdown; // Detailed scoring breakdown
 }
 
 export interface HuntAttemptRecord {
-  id: string
-  huntId: number
-  huntTitle: string
-  playerAddress: string
-  status: HuntAttemptStatus
-  startedAt: string
-  completedAt?: string
-  totalTimeSeconds: number
-  totalPoints: number
-  clues: ClueAttemptRecord[]
-  attemptNumber: number
-  currentStreak: number // Current consecutive clues solved streak
-  scoringWeights?: ScoringWeights // Scoring weights used for this attempt
-  scoringBreakdown?: HuntScoringBreakdown // Detailed scoring breakdown for the entire attempt
-  isFirstToComplete?: boolean // Whether this was the first completion of the hunt
+  id: string;
+  huntId: number;
+  huntTitle: string;
+  playerAddress: string;
+  status: HuntAttemptStatus;
+  startedAt: string;
+  completedAt?: string;
+  totalTimeSeconds: number;
+  totalPoints: number;
+  clues: ClueAttemptRecord[];
+  attemptNumber: number;
+  currentStreak: number; // Current consecutive clues solved streak
+  scoringWeights?: ScoringWeights; // Scoring weights used for this attempt
+  scoringBreakdown?: HuntScoringBreakdown; // Detailed scoring breakdown for the entire attempt
+  isFirstToComplete?: boolean; // Whether this was the first completion of the hunt
 }
 
 export interface HuntAttemptTimeComparison {
-  playerTimeSeconds: number
-  playerTimeLabel: string
-  fastestTimeSeconds: number | null
-  fastestTimeLabel: string | null
-  averageTimeSeconds: number | null
-  averageTimeLabel: string | null
-  rankAmongFastest: number | null
-  totalComparedPlayers: number
+  playerTimeSeconds: number;
+  playerTimeLabel: string;
+  fastestTimeSeconds: number | null;
+  fastestTimeLabel: string | null;
+  averageTimeSeconds: number | null;
+  averageTimeLabel: string | null;
+  rankAmongFastest: number | null;
+  totalComparedPlayers: number;
 }
 
 // ─── Reward (web view) ───────────────────────────────────────────────────────
@@ -385,67 +383,70 @@ export interface HuntAttemptTimeComparison {
  * `@hunty/types`.
  */
 export interface Reward extends DomainReward {
-  icon?: ReactNode
+  icon?: ReactNode;
 }
 
 export interface RewardPlayerProgress {
-  is_completed: boolean
-  reward_claimed: boolean
-  hunt_id?: number | string
-  reward_amount?: number
+  is_completed: boolean;
+  reward_claimed: boolean;
+  hunt_id?: number | string;
+  reward_amount?: number;
 }
 
 // ─── Activity Feed ───────────────────────────────────────────────────────────
 
-export type ActivityEventType = "HuntCompleted" | "ClueCompleted" | "HuntSponsored"
+export type ActivityEventType =
+  | "HuntCompleted"
+  | "ClueCompleted"
+  | "HuntSponsored";
 
 export interface ActivityEvent {
-  id: string
+  id: string;
   /** Full Stellar G-address of the participant */
-  address: string
+  address: string;
   /** Optional display name resolved from the player's profile */
-  displayName?: string
-  huntTitle: string
-  huntId: number
-  timestamp: number
-  type: ActivityEventType
+  displayName?: string;
+  huntTitle: string;
+  huntId: number;
+  timestamp: number;
+  type: ActivityEventType;
   /** Amount for sponsored events */
-  amount?: number
+  amount?: number;
 }
 
 // ─── Component-level Hunt (used by PlayGame, HuntForm, GamePreview, HuntCards) ─
 
 export interface HuntCard {
-  id: number
-  title?: string
-  description?: string
-  link?: string
-  code?: string
-  image?: string
+  id: number;
+  title?: string;
+  description?: string;
+  link?: string;
+  code?: string;
+  image?: string;
   /** Progressive hints (up to 3). Supersedes `hint`/`hintCost` when present. */
-  hints?: ClueHint[]
+  hints?: ClueHint[];
   /** @deprecated Use `hints[0]` instead. */
-  hint?: string
+  hint?: string;
   /** @deprecated Use `hints[0].penalty` instead. */
-  hintCost?: number
-  points?: number
+  hintCost?: number;
+  points?: number;
   /**
    * Hunt-level difficulty rating surfaced as a badge on the card.
    * HuntCards historically also accepts legacy ClueDifficulty values
    * (passed in from individual clue views), so both are allowed here.
    */
-  difficulty?: HuntDifficulty | ClueDifficulty
+  difficulty?: HuntDifficulty | ClueDifficulty;
 }
 
 // HuntDraft and PlayerStats now live in @hunty/types (re-exported above).
 export interface HuntDraft {
-  id: number
-  title: string
-  description: string
-  link: string
-  code: string
-  image?: string
-  sequential?: boolean
+  id: number;
+  title: string;
+  description: string;
+  link: string;
+  code: string;
+  image?: string;
+  sequential?: boolean;
 }
 
 /**
@@ -455,46 +456,50 @@ export interface HuntDraft {
  */
 export interface HuntDraftSave {
   /** Unique identifier for this draft save (UUID). */
-  draftId: string
+  draftId: string;
   /** Human-readable label – defaults to gameName or "Untitled Draft". */
-  label: string
+  label: string;
   /** ISO-8601 timestamp of when this snapshot was last written. */
-  savedAt: string
+  savedAt: string;
   /** The individual hunt clue cards in this draft. */
-  hunts: HuntDraft[]
+  hunts: HuntDraft[];
   /** Game-level metadata. */
   meta: {
-    gameName: string
-    startDate: string
-    endDate: string
-    rewardType: "XLM" | "NFT" | "Both"
-    sequential: boolean
-    isPrivate: boolean
-    timerEnabled: boolean
-    creatorEmail: string
-    emailNotifications: boolean
-  }
+    gameName: string;
+    startDate: string;
+    endDate: string;
+    rewardType: "XLM" | "NFT" | "Both";
+    sequential: boolean;
+    isPrivate: boolean;
+    timerEnabled: boolean;
+    creatorEmail: string;
+    emailNotifications: boolean;
+  };
   /** Reward buckets. */
-  rewards: Array<{ place: number; amount: number }>
+  rewards: Array<{ place: number; amount: number }>;
   /**
    * Whether the draft has been recovered into the editor.
    * Prevents the recovery prompt from showing again for the same draft.
    */
-  recovered?: boolean
+  recovered?: boolean;
 }
 
 export interface PlayerStats {
-  address: string
-  totalHuntsCompleted: number
-  totalPointsEarned: number
-  totalNftsReceived: number
-  totalCompletionTimeSeconds: number
-  completedHuntsTracked: number
-  averageCompletionTimeSeconds: number
-  lastUpdated: number
+  address: string;
+  totalHuntsCompleted: number;
+  totalPointsEarned: number;
+  totalNftsReceived: number;
+  totalCompletionTimeSeconds: number;
+  completedHuntsTracked: number;
+  averageCompletionTimeSeconds: number;
+  lastUpdated: number;
 }
 
-export type CoverImageUploadState = "idle" | "uploading" | "succeeded" | "failed"
+export type CoverImageUploadState =
+  | "idle"
+  | "uploading"
+  | "succeeded"
+  | "failed";
 
 // ─── Player Count ────────────────────────────────────────────────────────────
 
@@ -502,17 +507,17 @@ export type CoverImageUploadState = "idle" | "uploading" | "succeeded" | "failed
  * Player count above which a hunt is considered "Trending".
  * @deprecated Import from `@/lib/config/constants` instead: `PLAYER_COUNT.TRENDING_THRESHOLD`
  */
-export const TRENDING_PLAYER_THRESHOLD = 50
+export const TRENDING_PLAYER_THRESHOLD = 50;
 
 /**
  * How long a fetched player count is considered fresh (ms).
  * @deprecated Import from `@/lib/config/constants` instead: `PLAYER_COUNT.CACHE_TTL_MS`
  */
-export const PLAYER_COUNT_CACHE_TTL_MS = 60_000
+export const PLAYER_COUNT_CACHE_TTL_MS = 60_000;
 
 export interface PlayerCountResult {
-  huntId: string
-  count: number
+  huntId: string;
+  count: number;
   /**
    * `true` when `count >= TRENDING_PLAYER_THRESHOLD`.
    *
@@ -520,160 +525,160 @@ export interface PlayerCountResult {
    * reflects the same snapshot as the displayed number. Re-evaluated on
    * every cache miss (stale or absent entry).
    */
-  isTrending: boolean
-  fetchedAt: number   // Date.now() at time of fetch
-  isLoading: boolean
-  error: string | null
+  isTrending: boolean;
+  fetchedAt: number; // Date.now() at time of fetch
+  isLoading: boolean;
+  error: string | null;
 }
 
 // ─── Profile Dashboard Types ───────────────────────────────────────────────────
 // HuntProgressStatus and PlayerHuntProgress now live in @hunty/types.
 
 export interface NftAttribute {
-  trait_type: string
-  value: string | number
+  trait_type: string;
+  value: string | number;
 }
 
 export interface NftRewardDetail {
-  id: number
-  name: string
-  description?: string
-  imageUri: string
-  earnedAt: string
-  claimed: boolean
-  huntName?: string
-  attributes?: NftAttribute[]
+  id: number;
+  name: string;
+  description?: string;
+  imageUri: string;
+  earnedAt: string;
+  claimed: boolean;
+  huntName?: string;
+  attributes?: NftAttribute[];
   /** ipfs:// URI pointing to the SEP-0039 metadata JSON file for this NFT. */
-  metadataUri?: string
+  metadataUri?: string;
 }
 
 export interface ProfileSummary {
-  totalHunts: number
-  completedHunts: number
-  inProgressHunts: number
-  totalPoints: number
-  completionRate: number
-  totalNftRewards: number
-  claimedNftRewards: number
-  unclaimedNftRewards: number
+  totalHunts: number;
+  completedHunts: number;
+  inProgressHunts: number;
+  totalPoints: number;
+  completionRate: number;
+  totalNftRewards: number;
+  claimedNftRewards: number;
+  unclaimedNftRewards: number;
 }
 
 // ─── Seasonal Leaderboard ───────────────────────────────────────────────────
 
-export type SeasonStatus = "Upcoming" | "Active" | "Ended"
+export type SeasonStatus = "Upcoming" | "Active" | "Ended";
 
 export interface Season {
-  id: number
-  name: string
+  id: number;
+  name: string;
   /** Unix timestamp in seconds — when the season starts. */
-  startTime: number
+  startTime: number;
   /** Unix timestamp in seconds — when the season ends. */
-  endTime: number
-  status: SeasonStatus
+  endTime: number;
+  status: SeasonStatus;
   /** Reward amounts for the top N players, indexed by place (1st, 2nd, ...). */
-  rewards?: Reward[]
+  rewards?: Reward[];
 }
 
 export interface SeasonLeaderboardEntry {
-  address: string
-  name?: string
-  points: number
+  address: string;
+  name?: string;
+  points: number;
   /** Final rank for this player at season end (set once archived). */
-  rank?: number
+  rank?: number;
 }
 
 export interface ArchivedSeason {
-  season: Season
-  finalLeaderboard: SeasonLeaderboardEntry[]
-  archivedAt: number
+  season: Season;
+  finalLeaderboard: SeasonLeaderboardEntry[];
+  archivedAt: number;
 }
 
 export interface SeasonBadge {
-  seasonId: number
-  seasonName: string
+  seasonId: number;
+  seasonName: string;
   /** Final rank the player achieved, if the season has ended. */
-  rank?: number
-  earnedAt: number
+  rank?: number;
+  earnedAt: number;
 }
 
 // ─── Core Web Vitals ────────────────────────────────────────────────────────────
 
-export type WebVitalMetric = "LCP" | "FID" | "CLS" | "TTFB" | "INP" | "FCP"
+export type WebVitalMetric = "LCP" | "FID" | "CLS" | "TTFB" | "INP" | "FCP";
 
 export interface PerformanceMetric {
-  name: WebVitalMetric
-  value: number
-  rating: "good" | "needs-improvement" | "poor"
-  timestamp: number
-  url: string
+  name: WebVitalMetric;
+  value: number;
+  rating: "good" | "needs-improvement" | "poor";
+  timestamp: number;
+  url: string;
 }
 
 export interface PerformanceBudget {
-  name: WebVitalMetric
-  good: number
-  poor: number
+  name: WebVitalMetric;
+  good: number;
+  poor: number;
 }
 
 export interface PerformanceReportEntry {
-  id: string
-  metrics: PerformanceMetric[]
-  timestamp: number
-  url: string
-  userAgent: string
+  id: string;
+  metrics: PerformanceMetric[];
+  timestamp: number;
+  url: string;
+  userAgent: string;
 }
 
 export interface PerformanceAlert {
-  metric: WebVitalMetric
-  value: number
-  threshold: number
-  timestamp: number
-  url: string
+  metric: WebVitalMetric;
+  value: number;
+  threshold: number;
+  timestamp: number;
+  url: string;
 }
 
 // ─── Chat ────────────────────────────────────────────────────────────────────
 
 export interface ChatMessage {
-  id: string
-  huntId: number
-  senderAddress: string
-  senderName?: string
-  content: string
-  timestamp: number
-  isDeleted?: boolean
+  id: string;
+  huntId: number;
+  senderAddress: string;
+  senderName?: string;
+  content: string;
+  timestamp: number;
+  isDeleted?: boolean;
 }
 
 export interface ChatSettings {
-  huntId: number
-  isChatEnabled: boolean
-  creatorAddress?: string
-  mutedAddresses: string[]
+  huntId: number;
+  isChatEnabled: boolean;
+  creatorAddress?: string;
+  mutedAddresses: string[];
 }
 
 export interface ReportedMessage {
-  id: string
-  messageId: string
-  huntId: number
-  reportedBy: string
-  reason: string
-  timestamp: number
+  id: string;
+  messageId: string;
+  huntId: number;
+  reportedBy: string;
+  reason: string;
+  timestamp: number;
 }
 
 // ─── Waitlist ─────────────────────────────────────────────────────────────────
 
 export interface WaitlistEntry {
-  id: string
-  huntId: number
-  playerAddress: string
-  playerName?: string
-  timestamp: number
-  isNotified?: boolean
+  id: string;
+  huntId: number;
+  playerAddress: string;
+  playerName?: string;
+  timestamp: number;
+  isNotified?: boolean;
 }
 
 export interface HuntRegistrationStatus {
-  isRegistered: boolean
-  isWaitlisted: boolean
-  waitlistPosition?: number
-  progressData?: PlayerProgress
-  loading: boolean
-  error?: string
+  isRegistered: boolean;
+  isWaitlisted: boolean;
+  waitlistPosition?: number;
+  progressData?: PlayerProgress;
+  loading: boolean;
+  error?: string;
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,12 +21,22 @@
     "paths": {
       "@/*": ["./*"],
       "@shared/*": ["./shared/*"],
-      "@hunty/types": ["./packages/types/src/index.ts"],
-      "@hunty/types/*": ["./packages/types/src/*"]
+      "@hunty/types": ["../../packages/types/src/index.ts"],
+      "@hunty/types/*": ["../../packages/types/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "mobile/**/*", "shared/**/*", "stories/**/*", "**/*.stories.ts", "**/*.stories.tsx", "**/__tests__/**/*", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": [
+    "node_modules",
+    "mobile/**/*",
+    "shared/**/*",
+    "stories/**/*",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/__tests__/**/*",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
 }
-
-

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,11 +35,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@hunty/types/schemas": path.resolve(
-        __dirname,
-        "./packages/types/src/schemas.ts",
-      ),
-      "@hunty/types": path.resolve(__dirname, "./packages/types/src/index.ts"),
+      "@hunty/types/schemas": path.resolve(__dirname, "../../packages/types/src/schemas.ts"),
+      "@hunty/types": path.resolve(__dirname, "../../packages/types/src/index.ts"),
       "@": path.resolve(__dirname, "./"),
     },
   },

--- a/packages/types/src/hunt.ts
+++ b/packages/types/src/hunt.ts
@@ -2,79 +2,91 @@
  * Hunt domain types shared across web and mobile.
  */
 
-import type { Reward, RewardType } from "./reward"
+import type { Reward, RewardType } from "./reward";
 
-export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled"
+export type HuntStatus = "Active" | "Completed" | "Draft" | "Cancelled";
 
 /** Broad hunt category used in discovery filters. */
-export type HuntCategory = "Urban" | "Campus" | "Office" | "Museum" | "General"
+export type HuntCategory = "Urban" | "Campus" | "Office" | "Museum" | "General";
 
 /** Overall hunt difficulty tag used in discovery filters. */
-export type HuntDifficulty = "Easy" | "Medium" | "Hard"
+export type HuntDifficulty = "Easy" | "Medium" | "Hard";
+
+/** A revocable bearer token used to access a private hunt. */
+export interface HuntInvite {
+  /** Opaque UUID embedded in the private-hunt invite URL. */
+  token: string;
+  /** Unix timestamp in milliseconds when the invite was generated. */
+  createdAt: number;
+  /** Unix timestamp in milliseconds after which the invite is no longer accepted. */
+  expiresAt: number;
+}
 
 /** The canonical persisted shape of a hunt. */
 export interface StoredHunt {
-  id: number
-  title: string
-  description: string
-  cluesCount: number
+  id: number;
+  title: string;
+  description: string;
+  cluesCount: number;
   /** Broad hunt category used in discovery filters. */
-  category?: HuntCategory
+  category?: HuntCategory;
   /** Overall hunt difficulty tag used in discovery filters. */
-  difficulty?: HuntDifficulty
-  status: HuntStatus
-  rewardType: RewardType
+  difficulty?: HuntDifficulty;
+  status: HuntStatus;
+  rewardType: RewardType;
   /** When true, players must solve clues in order. */
-  sequential?: boolean
+  sequential?: boolean;
   /** Total reward pool value used for creator-side sorting. */
-  rewardPool?: number
+  rewardPool?: number;
   /** Per-place XLM reward buckets funded by the creator. */
-  rewards?: Reward[]
+  rewards?: Reward[];
   /** Escrow transaction hash proving the creator funded the XLM reward pool. */
-  rewardEscrowTxHash?: string
+  rewardEscrowTxHash?: string;
   /** Amount still available in the XLM escrow. */
-  rewardEscrowBalance?: number
+  rewardEscrowBalance?: number;
   /** Creator-side participant count snapshot for dashboard sorting. */
-  playerCount?: number
+  playerCount?: number;
   /** Max number of participants for limited spots */
-  maxCapacity?: number
+  maxCapacity?: number;
   /** Unix timestamp in seconds when the hunt draft was created locally. */
-  createdAt?: number
+  createdAt?: number;
   /** Unix timestamp in seconds — when the hunt starts. */
-  startTime?: number
+  startTime?: number;
   /** Unix timestamp in seconds — when the hunt ends. */
-  endTime?: number
-  creatorEmail?: string
-  emailNotifications?: boolean
+  endTime?: number;
+  creatorEmail?: string;
+  emailNotifications?: boolean;
   /** When true, the hunt is hidden from the public arcade grid. */
-  is_private?: boolean
+  is_private?: boolean;
+  /** The active private-hunt invite. Replaced on regeneration and removed on revoke. */
+  invite?: HuntInvite;
   /** Optional game cover CID/URL for hunt cards and sharing previews. */
-  coverImageCid?: string
+  coverImageCid?: string;
   /** Active editorial banner showcase at the top of the Arcade. */
-  isFeaturedOfWeek?: boolean
+  isFeaturedOfWeek?: boolean;
 }
 
 /** Lightweight hunt projection used by list/detail views. */
 export interface HuntInfo {
-  id: number
-  title: string
-  description: string
-  totalClues: number
-  status: string
-  sequential?: boolean
-  startTime?: number
-  endTime?: number
-  creatorEmail?: string
-  emailNotifications?: boolean
+  id: number;
+  title: string;
+  description: string;
+  totalClues: number;
+  status: string;
+  sequential?: boolean;
+  startTime?: number;
+  endTime?: number;
+  creatorEmail?: string;
+  emailNotifications?: boolean;
 }
 
 /** Editable draft clue used while building a hunt. */
 export interface HuntDraft {
-  id: number
-  title: string
-  description: string
-  link: string
-  code: string
-  image?: string
-  sequential?: boolean
+  id: number;
+  title: string;
+  description: string;
+  link: string;
+  code: string;
+  image?: string;
+  sequential?: boolean;
 }


### PR DESCRIPTION
PULL REQUEST TITLE

feat: add revocable invite links for private hunts

PULL REQUEST DESCRIPTION

SUMMARY

This pull request adds secure, expiring, and revocable invite links for private hunts. It also migrates the implementation to the updated Turborepo structure under apps/web and packages/types.

PROBLEM

Private hunts were hidden from the public arcade, but creators had no way to grant access to selected players.

Players could reach the registration flow without invite validation, and creators could not generate, copy, regenerate, or revoke private-hunt access links.

SOLUTION

Added cryptographically secure UUID v4 invite-token generation.

Added invite metadata containing:

Token
Creation timestamp
Expiration timestamp

Stored the active invite with its private hunt in huntStore.

Added the canonical invite URL format:

/hunt/[id]?invite=[token]

Added a default invite expiration period of seven days.

Made generating a new invite invalidate the previous invite.

Added creator dashboard controls to:

Generate an invite link
Copy a generated invite link
Copy an existing invite link
Regenerate an expired invite link
Revoke an invite link

Added private-hunt invite validation for:
Missing tokens
Invalid tokens
Expired tokens
Revoked tokens

Gated private-hunt registration and waitlisting behind successful invite validation.

Prevented the private-hunt play interface from rendering without valid invite access.

Revalidated invite access immediately before registration and waitlisting to prevent stale or recently revoked links from being used.

Added accessible access-denied messages describing why access was rejected.

Preserved existing public-hunt behavior. Public hunts continue to work without an invite token.

UPDATED REPOSITORY COMPATIBILITY

The implementation was migrated from the former root-level application structure to the updated monorepo structure.

Web application files now live under:

apps/web

Shared hunt and invite types now live under:

packages/types

The web TypeScript and Vitest aliases were updated to resolve the shared types package from its new monorepo location.

Duplicate imports and conflicting declarations introduced in invite-related files during the monorepo update were resolved.

The scheduled-hunt and rating behavior in getHuntById was preserved while removing unreachable return logic.

SECURITY AND ACCESS BEHAVIOR

Invite tokens are generated using the Web Crypto API.

Tokens are scoped to a specific hunt.

A random token cannot be used for another private hunt.

Invite expiration is validated before access is granted.

Revoking an invite removes it from the hunt record.

Regenerating an invite immediately invalidates the previous token.

Registration and waitlisting perform a final validation immediately before invoking their actions.

TESTING

Focused invite and hunt-store tests:

87 tests passed
0 tests failed

Covered behavior includes:

UUID token generation
Invite persistence
Correct URL generation
Valid invite access
Missing token rejection
Invalid token rejection
Expired token rejection
Invite replacement
Invite revocation
Public-hunt compatibility
Dashboard generation and copy actions
Dashboard revoke action
Accessible access-denied messages
Existing private-hunt behavior
Existing huntStore behavior

Focused ESLint validation:

Passed

Git diff validation:

Passed

Focused TypeScript validation:

No TypeScript diagnostics were reported in the invite-related implementation files.

KNOWN UPSTREAM REPOSITORY ISSUES

The updated main branch currently contains unrelated issues that prevent a complete repository build and installation.

These include:

A duplicated YAML mapping in pnpm-lock.yaml

An unavailable eas-cli version declared by the mobile workspace

Duplicate imports and identifiers in unrelated application files, including:

apps/web/app/admin/page.tsx
apps/web/app/creator/page.tsx
apps/web/app/dashboard/DashboardPageClient.tsx
apps/web/app/help/page.tsx
apps/web/app/hunty/page.tsx

These issues existed in the updated branch and are not caused by the private-hunt invite implementation.

MODIFIED FILES

apps/web/app/hunt/[id]/share.tsx

apps/web/components/HuntDashboard.tsx

apps/web/lib/huntStore.ts

apps/web/lib/types.ts

apps/web/tsconfig.json

apps/web/vitest.config.ts

packages/types/src/hunt.ts

NEW FILES

apps/web/components/HuntInviteControls.tsx

apps/web/components/PrivateHuntAccessGate.tsx

apps/web/components/tests/HuntInviteControls.test.tsx

apps/web/components/tests/PrivateHuntAccessGate.test.tsx

apps/web/lib/tests/huntInvite.test.ts

ACCEPTANCE CRITERIA

Creator can generate and copy an invite link:

Completed

Invite link allows registration on a private hunt:

Completed

Missing, invalid, revoked, or expired tokens show an access-denied message:

Completed

Creator can revoke an invite link:

Completed

CONFIDENCE

96 percent confidence in the scoped private-hunt invite implementation and its compatibility with the updated monorepo structure.

Closes #293 