### PR TITLE
fix(wallet): implement wallet disconnect and cleanup #571

### DIFF
--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -1,58 +1,45 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { useIsMounted } from "@/hooks/useIsMounted";
-import { useWallet } from "@/lib/context/WalletContext";
-import { WalletSelectionModal } from "./WalletSelectionModal";
-import { WalletBalance } from "./WalletBalance";
-import { ThemeToggle } from "./ThemeToggle";
-import { LanguageSelector } from "./LanguageSelector";
-import { NotificationPanel } from "@/components/NotificationPanel";
-import { WalletAddress } from "./WalletAddress";
-import { WalletIdenticon } from "./WalletIdenticon";
-import { getStellarAccountExplorerUrl } from "@/lib/walletAddress";
-import { toast } from "sonner";
 import {
   Bell,
-  Search,
-  X,
-  Menu,
-  Compass,
-  PlusCircle,
-  User,
   Check,
   ChevronDown,
   Compass,
   Copy,
+  ExternalLink,
   Gamepad2,
   HelpCircle,
-  ExternalLink,
   LogOut,
   Menu,
   PlusCircle,
   Search,
-  Trophy,
   User,
   X,
 } from "lucide-react";
 import Link from "next/link";
-import { useCallback,useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
+import { NotificationPanel } from "@/components/NotificationPanel";
 import { Button } from "@/components/ui/button";
 import { useIsMounted } from "@/hooks/useIsMounted";
 import { useWallet } from "@/lib/context/WalletContext";
-import { getUnreadNotificationCount } from "@/lib/notifications/rankTracker"
-import { createWeeklyDigestNotification, shouldSendWeeklyDigest } from "@/lib/notifications/weeklyDigest"
+import { getUnreadNotificationCount } from "@/lib/notifications/rankTracker";
+import {
+  createWeeklyDigestNotification,
+  shouldSendWeeklyDigest,
+} from "@/lib/notifications/weeklyDigest";
 import { cn } from "@/lib/utils";
+import { getStellarAccountExplorerUrl } from "@/lib/walletAddress";
 
-import Coin from "./icons/Coin";
+import { LanguageSelector } from "./LanguageSelector";
 import { ThemeToggle } from "./ThemeToggle";
-import { WalletBottomSheet } from "./WalletBottomSheet";
+import { WalletAddress } from "./WalletAddress";
+import { WalletBalance } from "./WalletBalance";
+import { WalletIdenticon } from "./WalletIdenticon";
+import { WalletSelectionModal } from "./WalletSelectionModal";
 
-// ÔöÇÔöÇÔöÇ Nav structure ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// ─── Nav structure ─────────────────────────────────────────────────────────────
 
 const NAV_ITEMS = [
   {
@@ -91,7 +78,6 @@ const NAV_ITEMS = [
   },
 ];
 
-
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
 function SearchBar({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -111,16 +97,23 @@ function SearchBar({ open, onClose }: { open: boolean; onClose: () => void }) {
           <input
             ref={inputRef}
             type="search"
-            placeholder="Search hunts, creators, rewardsÔÇª"
+            aria-label="Search hunts, creators, rewards"
+            placeholder="Search hunts, creators, rewards…"
             className="flex-1 bg-transparent text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none text-base"
             onKeyDown={(e) => e.key === "Escape" && onClose()}
           />
-          <button onClick={onClose} aria-label="Close search" className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+          <button
+            onClick={onClose}
+            aria-label="Close search"
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+          >
             <X className="w-4 h-4" />
           </button>
         </div>
         <div className="border-t border-slate-100 dark:border-white/5 px-4 py-3">
-          <p className="text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2">Quick links</p>
+          <p className="text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2">
+            Quick links
+          </p>
           <div className="flex flex-wrap gap-2">
             {["Active hunts", "XLM rewards", "NFT prizes", "Trending"].map((tag) => (
               <Link
@@ -184,7 +177,11 @@ function MobileMenu({
         <span className="text-2xl font-black bg-gradient-to-br from-[#2F2FFF] to-[#E87785] bg-clip-text text-transparent">
           Hunty
         </span>
-        <button onClick={onClose} aria-label="Close menu" className="p-2 rounded-xl hover:bg-slate-100 dark:hover:bg-white/5">
+        <button
+          onClick={onClose}
+          aria-label="Close menu"
+          className="p-2 rounded-xl hover:bg-slate-100 dark:hover:bg-white/5"
+        >
           <X className="w-6 h-6 text-slate-700 dark:text-slate-300" />
         </button>
       </div>
@@ -226,7 +223,10 @@ function MobileMenu({
             <div className="flex items-center justify-between px-4 py-3 bg-slate-50 dark:bg-slate-900">
               <WalletBalance variant="row" />
               <button
-                onClick={() => { onDisconnect(); onClose(); }}
+                onClick={() => {
+                  onDisconnect();
+                  onClose();
+                }}
                 className="flex items-center gap-1.5 text-sm text-red-500 hover:text-red-600 font-medium"
               >
                 <LogOut className="w-4 h-4" />
@@ -236,7 +236,10 @@ function MobileMenu({
           </div>
         ) : (
           <Button
-            onClick={() => { onConnectWallet(); onClose(); }}
+            onClick={() => {
+              onConnectWallet();
+              onClose();
+            }}
             className="w-full bg-gradient-to-r from-[#3737A4] to-[#0C0C4F] hover:opacity-90 text-white font-bold py-3 rounded-2xl text-base"
           >
             Connect Wallet
@@ -247,7 +250,7 @@ function MobileMenu({
   );
 }
 
-// ÔöÇÔöÇÔöÇ Main Header ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// ─── Main Header ───────────────────────────────────────────────────────────────
 
 export function Header() {
   const mounted = useIsMounted();
@@ -261,6 +264,7 @@ export function Header() {
   const [copied, setCopied] = useState(false);
   const [activeMega, setActiveMega] = useState<string | null>(null);
   const [scrolled, setScrolled] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(() => getUnreadNotificationCount());
 
   const dropdownRef = useRef<HTMLDivElement>(null);
   const notifRef = useRef<HTMLDivElement>(null);
@@ -273,21 +277,20 @@ export function Header() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  // Update unread notification count
+  // Poll unread notification count
   useEffect(() => {
-    setUnreadCount(getUnreadNotificationCount())
     const interval = setInterval(() => {
-      setUnreadCount(getUnreadNotificationCount())
-    }, 30000)
-    return () => clearInterval(interval)
-  }, [])
+      setUnreadCount(getUnreadNotificationCount());
+    }, 30000);
+    return () => clearInterval(interval);
+  }, []);
 
   // Weekly digest check on mount
   useEffect(() => {
     if (shouldSendWeeklyDigest()) {
-      createWeeklyDigestNotification()
+      createWeeklyDigestNotification();
     }
-  }, [])
+  }, []);
 
   // Close dropdowns on outside click
   useEffect(() => {
@@ -332,8 +335,6 @@ export function Header() {
     megaTimeoutRef.current = setTimeout(() => setActiveMega(null), 120);
   }, []);
 
-  const [unreadCount, setUnreadCount] = useState(0)
-
   return (
     <>
       <header
@@ -345,7 +346,6 @@ export function Header() {
         )}
       >
         <div className="relative max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8 flex items-center gap-4 h-16 md:h-18">
-
           {/* Logo */}
           <Link
             href="/"
@@ -383,10 +383,7 @@ export function Header() {
                   )}
                 </Link>
                 {mega && activeMega === label && (
-                  <div
-                    onMouseEnter={() => openMega(label)}
-                    onMouseLeave={() => closeMega()}
-                  >
+                  <div onMouseEnter={() => openMega(label)} onMouseLeave={() => closeMega()}>
                     <MegaMenu items={mega} />
                   </div>
                 )}
@@ -398,7 +395,10 @@ export function Header() {
           <div className="flex items-center gap-2 ml-auto">
             {/* Search */}
             <button
-              onClick={() => { setSearchOpen((v) => !v); setNotifOpen(false); }}
+              onClick={() => {
+                setSearchOpen((v) => !v);
+                setNotifOpen(false);
+              }}
               aria-label="Search"
               className="p-2 rounded-xl text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-white/5 hover:text-[#3737A4] dark:hover:text-indigo-400 transition-colors"
             >
@@ -408,13 +408,19 @@ export function Header() {
             {/* Notification bell */}
             <div className="relative" ref={notifRef}>
               <button
-                onClick={() => { setNotifOpen((v) => !v); setSearchOpen(false); }}
+                onClick={() => {
+                  setNotifOpen((v) => !v);
+                  setSearchOpen(false);
+                }}
                 aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ""}`}
                 className="relative p-2 rounded-xl text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-white/5 hover:text-[#3737A4] dark:hover:text-indigo-400 transition-colors"
               >
                 <Bell className="w-5 h-5" />
                 {unreadCount > 0 && (
-                  <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-[#E87785] ring-2 ring-white dark:ring-slate-950" aria-hidden="true" />
+                  <span
+                    className="absolute top-1 right-1 w-2 h-2 rounded-full bg-[#E87785] ring-2 ring-white dark:ring-slate-950"
+                    aria-hidden="true"
+                  />
                 )}
               </button>
               <NotificationPanel open={notifOpen} onClose={() => setNotifOpen(false)} />
@@ -468,7 +474,9 @@ export function Header() {
                           />
                         )}
                         <div className="min-w-0">
-                          <p className="text-xs text-blue-200 font-medium mb-0.5">Connected wallet</p>
+                          <p className="text-xs text-blue-200 font-medium mb-0.5">
+                            Connected wallet
+                          </p>
                           <p className="text-[11px] uppercase tracking-wide text-blue-200/80 mb-1">
                             {walletProvider ?? "freighter"}
                           </p>
@@ -504,8 +512,14 @@ export function Header() {
 
                         <button
                           onClick={() => {
-                            const type = window.location.pathname.includes("/creator") ? "creator" : "player";
-                            window.dispatchEvent(new CustomEvent("start-onboarding-tour", { detail: { tourType: type } }));
+                            const type = window.location.pathname.includes("/creator")
+                              ? "creator"
+                              : "player";
+                            window.dispatchEvent(
+                              new CustomEvent("start-onboarding-tour", {
+                                detail: { tourType: type },
+                              })
+                            );
                             setDropdownOpen(false);
                           }}
                           aria-label="Take onboarding tour"

--- a/apps/web/components/__tests__/Header.test.tsx
+++ b/apps/web/components/__tests__/Header.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach,describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Header } from "@/components/Header";
+import type { WalletProvider } from "@/lib/walletAdapter";
 
 const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
@@ -17,13 +18,39 @@ vi.mock("@/components/ThemeToggle", () => ({
   ThemeToggle: () => <div data-testid="theme-toggle" />,
 }));
 
+vi.mock("@/components/LanguageSelector", () => ({
+  LanguageSelector: () => <div data-testid="language-selector" />,
+}));
+
+vi.mock("@/components/NotificationPanel", () => ({
+  NotificationPanel: () => <div data-testid="notification-panel" />,
+}));
+
+vi.mock("@/lib/notifications/rankTracker", () => ({
+  getUnreadNotificationCount: () => 0,
+}));
+
+vi.mock("@/lib/notifications/weeklyDigest", () => ({
+  shouldSendWeeklyDigest: () => false,
+  createWeeklyDigestNotification: vi.fn(),
+}));
+
 vi.mock("@/components/WalletSelectionModal", () => ({
-  WalletSelectionModal: ({ isOpen, onClose, onConnect }: any) => (
-    isOpen ? <div data-testid="wallet-selection-modal" role="dialog" aria-label="Wallet selection modal">
-      <button onClick={() => onConnect("freighter")}>Connect Freighter</button>
-      <button onClick={onClose}>Close Sheet</button>
-    </div> : null
-  ),
+  WalletSelectionModal: ({
+    isOpen,
+    onClose,
+    onConnect,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConnect: (provider: WalletProvider) => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="wallet-selection-modal" role="dialog" aria-label="Wallet selection modal">
+        <button onClick={() => onConnect("freighter")}>Connect Freighter</button>
+        <button onClick={onClose}>Close Sheet</button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/components/WalletBalance", () => ({
@@ -36,17 +63,31 @@ Object.assign(navigator, {
   },
 });
 
+type WalletMock = {
+  connected: boolean;
+  displayKey: string;
+  publicKey: string;
+  connect: typeof mockConnect;
+  disconnect: typeof mockDisconnect;
+  walletProvider: WalletProvider | null;
+};
+
+function stubWallet(overrides: Partial<WalletMock> = {}) {
+  vi.mocked(useWallet).mockReturnValue({
+    connected: false,
+    displayKey: "",
+    publicKey: "",
+    connect: mockConnect,
+    disconnect: mockDisconnect,
+    walletProvider: null,
+    ...overrides,
+  });
+}
+
 describe("Header", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useWallet).mockReturnValue({
-      connected: false,
-      displayKey: null,
-      publicKey: null,
-      connect: mockConnect,
-      disconnect: mockDisconnect,
-      walletProvider: null,
-    } as any);
+    stubWallet();
   });
 
   function renderHeader(props?: Partial<React.ComponentProps<typeof Header>>) {
@@ -73,42 +114,36 @@ describe("Header", () => {
     });
 
     it("renders the live balance display when connected", () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       renderHeader();
       expect(screen.getAllByTestId("wallet-balance").length).toBeGreaterThan(0);
     });
 
     it("renders wallet dropdown trigger when connected", () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       renderHeader();
       expect(screen.getByText("GABC...DEF")).toBeInTheDocument();
     });
 
     it("does not render Connect Wallet button when connected", () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       renderHeader();
       expect(screen.queryByRole("button", { name: /connect wallet/i })).not.toBeInTheDocument();
@@ -133,14 +168,12 @@ describe("Header", () => {
     });
 
     it("toggles dropdown when wallet button is clicked", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       const walletBtn = screen.getByText("GABC...DEF").closest("button")!;
@@ -155,48 +188,42 @@ describe("Header", () => {
     });
 
     it("copies wallet address to clipboard", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       await user.click(screen.getByText("GABC...DEF").closest("button")!);
-      await user.click(screen.getByRole("button", { name: /copy address/i }));
+      await user.click(screen.getByRole("button", { name: /copy wallet address/i }));
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith("GABC123DEF456");
     });
 
     it("shows 'Copied!' feedback after copying", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       await user.click(screen.getByText("GABC...DEF").closest("button")!);
-      await user.click(screen.getByRole("button", { name: /copy address/i }));
+      await user.click(screen.getByRole("button", { name: /copy wallet address/i }));
 
       expect(screen.getByText(/copied!/i)).toBeInTheDocument();
     });
 
     it("calls disconnect when Disconnect button is clicked", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       await user.click(screen.getByText("GABC...DEF").closest("button")!);
@@ -206,14 +233,12 @@ describe("Header", () => {
     });
 
     it("closes dropdown when clicking outside", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       await user.click(screen.getByText("GABC...DEF").closest("button")!);
@@ -226,14 +251,12 @@ describe("Header", () => {
     });
 
     it("displays full public key in dropdown", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456GHI789",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       await user.click(screen.getByText("GABC...DEF").closest("button")!);
@@ -242,14 +265,12 @@ describe("Header", () => {
     });
 
     it("displays wallet provider name in dropdown", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "albedo",
-      } as any);
+      });
 
       const { user } = renderHeader();
       await user.click(screen.getByText("GABC...DEF").closest("button")!);
@@ -273,14 +294,12 @@ describe("Header", () => {
     });
 
     it("copy button has accessible aria-label", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       await user.click(screen.getByText("GABC...DEF").closest("button")!);
@@ -289,14 +308,12 @@ describe("Header", () => {
     });
 
     it("dropdown content is reachable via keyboard", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       const walletBtn = screen.getByText("GABC...DEF").closest("button")!;
@@ -307,14 +324,12 @@ describe("Header", () => {
     });
 
     it("wallet button chevron rotates when dropdown opens", async () => {
-      vi.mocked(useWallet).mockReturnValue({
+      stubWallet({
         connected: true,
         displayKey: "GABC...DEF",
         publicKey: "GABC123DEF456",
-        connect: mockConnect,
-        disconnect: mockDisconnect,
         walletProvider: "freighter",
-      } as any);
+      });
 
       const { user } = renderHeader();
       const walletBtn = screen.getByText("GABC...DEF").closest("button")!;

--- a/apps/web/e2e/profile-and-settings.spec.ts
+++ b/apps/web/e2e/profile-and-settings.spec.ts
@@ -1,4 +1,4 @@
-import { expect,test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { injectMockWallet, MOCK_PUBLIC_KEY, seedHuntData } from "./helpers/mock-wallet";
 
@@ -10,14 +10,14 @@ test.describe("Profile and Settings", () => {
 
   test("navigates to profile page from header", async ({ page }) => {
     await page.goto("/");
-    
+
     // Click on the wallet button to open dropdown
     const shortKey = `${MOCK_PUBLIC_KEY.slice(0, 6)}...${MOCK_PUBLIC_KEY.slice(-6)}`;
     await page.getByText(shortKey).click();
 
     // Look for a profile link or click the wallet address directly
     await page.getByRole("link", { name: /profile/i }).click();
-    
+
     await expect(page).toHaveURL(/\/profile/);
     await expect(page.getByRole("heading", { name: /profile|my profile/i })).toBeVisible();
   });
@@ -58,7 +58,7 @@ test.describe("Profile and Settings", () => {
 
     // The NFT gallery section should be visible (may be empty)
     const nftGallery = page.locator("text=/nft|gallery|digital assets/i").first();
-    
+
     // Check if gallery exists (even if empty)
     if (await nftGallery.isVisible().catch(() => false)) {
       await expect(nftGallery).toBeVisible();
@@ -70,10 +70,10 @@ test.describe("Profile and Settings", () => {
 
     // Find and click copy button
     const copyBtn = page.getByRole("button", { name: /copy|copy address/i });
-    
+
     if (await copyBtn.isVisible().catch(() => false)) {
       await copyBtn.click();
-      
+
       // Should show a success message or visual feedback
       // This depends on the implementation
       await page.waitForTimeout(500);
@@ -84,8 +84,10 @@ test.describe("Profile and Settings", () => {
     await page.goto("/profile");
 
     // Look for statistics like "Hunts Created", "Completed", etc.
-    const statsContainer = page.locator("text=/created|completed|in progress|stats|statistics/i").first();
-    
+    const statsContainer = page
+      .locator("text=/created|completed|in progress|stats|statistics/i")
+      .first();
+
     if (await statsContainer.isVisible().catch(() => false)) {
       await expect(statsContainer).toBeVisible();
     }
@@ -111,7 +113,7 @@ test.describe("Profile and Settings", () => {
 
     await page.getByRole("button", { name: /disconnect/i }).click();
 
-    // Should be redirected or show connect button
+    await expect(page).toHaveURL(/\/($|\?)/, { timeout: 5_000 });
     await expect(page.getByRole("button", { name: /connect wallet/i })).toBeVisible({
       timeout: 5_000,
     });
@@ -124,10 +126,8 @@ test.describe("Profile and Settings", () => {
     // Should either redirect to home or show connect wallet message
     const connectBtn = page.getByRole("button", { name: /connect wallet/i });
     const redirect = page.url().includes("/");
-    
-    await expect(
-      connectBtn.isVisible().catch(() => Promise.resolve(redirect))
-    ).toBeTruthy();
+
+    await expect(connectBtn.isVisible().catch(() => Promise.resolve(redirect))).toBeTruthy();
   });
 
   test("theme toggle persists user preference", async ({ page }) => {
@@ -135,18 +135,18 @@ test.describe("Profile and Settings", () => {
 
     // Find and click theme toggle
     const themeToggle = page.getByRole("button", { name: /dark|light|theme/i });
-    
+
     if (await themeToggle.isVisible().catch(() => false)) {
-      const initialState = await page.locator("html").evaluate((el) => 
-        el.getAttribute("class") || el.getAttribute("data-theme")
-      );
+      const initialState = await page
+        .locator("html")
+        .evaluate((el) => el.getAttribute("class") || el.getAttribute("data-theme"));
 
       await themeToggle.click();
 
       // Verify theme changed
-      const newState = await page.locator("html").evaluate((el) =>
-        el.getAttribute("class") || el.getAttribute("data-theme")
-      );
+      const newState = await page
+        .locator("html")
+        .evaluate((el) => el.getAttribute("class") || el.getAttribute("data-theme"));
 
       expect(initialState).not.toEqual(newState);
     }

--- a/apps/web/lib/__tests__/txToast.cancel.test.ts
+++ b/apps/web/lib/__tests__/txToast.cancel.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: {
+    loading: vi.fn(() => "toast-id"),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/SrAnnouncer", () => ({ announceSr: vi.fn() }));
+vi.mock("@/lib/contracts/errors", () => ({
+  mapContractError: (error: unknown) => ({
+    message: error instanceof Error ? error.message : "failed",
+    isUserRejection: false,
+  }),
+}));
+
+import { toast } from "sonner";
+
+import {
+  cancelPendingTransactions,
+  getDisconnectGeneration,
+  withTransactionToast,
+} from "@/lib/txToast";
+import {
+  resetWalletBalanceListeners,
+  subscribeToWalletBalanceEvents,
+} from "@/lib/wallet/balanceEvents";
+
+describe("cancelPendingTransactions", () => {
+  beforeEach(() => {
+    resetWalletBalanceListeners();
+    vi.clearAllMocks();
+  });
+
+  it("dismisses pending toasts and settles wallet balance", async () => {
+    const events: string[] = [];
+    subscribeToWalletBalanceEvents((event) => events.push(event.type));
+
+    let resolveTx!: (value: string) => void;
+    const txPromise = withTransactionToast(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveTx = resolve;
+        })
+    );
+
+    expect(toast.loading).toHaveBeenCalled();
+    const generationBefore = getDisconnectGeneration();
+
+    cancelPendingTransactions();
+
+    expect(toast.dismiss).toHaveBeenCalled();
+    expect(getDisconnectGeneration()).toBe(generationBefore + 1);
+    expect(events).toContain("settled");
+
+    resolveTx("ok");
+    await expect(txPromise).resolves.toBe("ok");
+
+    // Success toast must not fire after disconnect cancelled the pending stage.
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/__tests__/txToastBalance.test.ts
+++ b/apps/web/lib/__tests__/txToastBalance.test.ts
@@ -4,7 +4,7 @@
  * predicted spend can linger on screen for a payment that never landed.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -12,61 +12,62 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
     error: vi.fn(),
     warning: vi.fn(),
+    dismiss: vi.fn(),
   },
-}))
-vi.mock("@/components/SrAnnouncer", () => ({ announceSr: vi.fn() }))
+}));
+vi.mock("@/components/SrAnnouncer", () => ({ announceSr: vi.fn() }));
 vi.mock("@/lib/contracts/errors", () => ({
   mapContractError: (error: unknown) => ({
     message: error instanceof Error ? error.message : "failed",
     isUserRejection: false,
   }),
-}))
+}));
 
-import { withTransactionToast } from "@/lib/txToast"
+import { withTransactionToast } from "@/lib/txToast";
 import {
   resetWalletBalanceListeners,
   subscribeToWalletBalanceEvents,
-} from "@/lib/wallet/balanceEvents"
+} from "@/lib/wallet/balanceEvents";
 
-let events: string[]
+let events: string[];
 
 beforeEach(() => {
-  events = []
-  resetWalletBalanceListeners()
-  subscribeToWalletBalanceEvents((event) => events.push(event.type))
-})
+  events = [];
+  resetWalletBalanceListeners();
+  subscribeToWalletBalanceEvents((event) => events.push(event.type));
+});
 
 afterEach(() => {
-  resetWalletBalanceListeners()
-  vi.clearAllMocks()
-})
+  resetWalletBalanceListeners();
+  vi.clearAllMocks();
+});
 
 describe("withTransactionToast → wallet balance", () => {
   it("settles the balance after a confirmed transaction", async () => {
-    const result = await withTransactionToast(async () => "ok")
+    const result = await withTransactionToast(async () => "ok");
 
-    expect(result).toBe("ok")
-    expect(events).toEqual(["settled"])
-  })
+    expect(result).toBe("ok");
+    expect(events).toEqual(["settled"]);
+  });
 
   it("settles the balance after a failed transaction so a prediction is not left standing", async () => {
     await expect(
       withTransactionToast(async () => {
-        throw new Error("contract reverted")
-      }),
-    ).rejects.toThrow("contract reverted")
+        throw new Error("contract reverted");
+      })
+    ).rejects.toThrow("contract reverted");
 
-    expect(events).toEqual(["settled"])
-  })
+    expect(events).toEqual(["settled"]);
+  });
 
   it("still re-throws so callers can run their own cleanup", async () => {
-    const cleanup = vi.fn()
+    const cleanup = vi.fn();
 
     await withTransactionToast(async () => {
-      throw new Error("boom")
-    }).catch(cleanup)
+      throw new Error("boom");
+    }).catch(cleanup);
 
-    expect(cleanup).toHaveBeenCalledTimes(1)
-    expect(events).toEqual(["settled"])
-  })
-})
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["settled"]);
+  });
+});

--- a/apps/web/lib/context/WalletContext.tsx
+++ b/apps/web/lib/context/WalletContext.tsx
@@ -1,11 +1,7 @@
-"use client"
+"use client";
 
-import {
-  getAddress,
-  isConnected,
-  requestAccess,
-  WatchWalletChanges,
-} from "@stellar/freighter-api"
+import { getAddress, isConnected, requestAccess, WatchWalletChanges } from "@stellar/freighter-api";
+import { useRouter } from "next/navigation";
 import {
   createContext,
   type ReactNode,
@@ -14,20 +10,23 @@ import {
   useEffect,
   useMemo,
   useState,
-} from "react"
+} from "react";
 
-import { useIsMounted } from "@/hooks/useIsMounted"
+import { useIsMounted } from "@/hooks/useIsMounted";
+import { cancelPendingTransactions } from "@/lib/txToast";
 import {
   clearStoredWalletSession,
   connectWalletProvider,
   getStoredWalletSession,
   setStoredWalletSession,
   type WalletProvider,
-} from "@/lib/walletAdapter"
-import { useWalletStore } from "@/lib/wallets/walletStore"
-import { truncateAddress } from "@/lib/walletAddress"
+} from "@/lib/walletAdapter";
+import { truncateAddress } from "@/lib/walletAddress";
+import { disconnectWalletConnect } from "@/lib/walletConnect";
+import { useWalletStore } from "@/lib/wallets/walletStore";
+import { usePlayerStore, useWalletStore as useLegacyWalletStore } from "@/store/useStore";
 
-const STORAGE_KEY = "freighter_public_key"
+const STORAGE_KEY = "freighter_public_key";
 
 /**
  * Shortens a Stellar public key for display.
@@ -38,196 +37,202 @@ const STORAGE_KEY = "freighter_public_key"
  * 4 + 4 default used elsewhere.
  */
 export function shortenAddress(address: string, chars = 6): string {
-  if (!address) return address
-  return truncateAddress(address, { lead: chars, tail: chars })
+  if (!address) return address;
+  return truncateAddress(address, { lead: chars, tail: chars });
 }
 
 interface WalletContextValue {
   /** Whether a wallet is currently connected */
-  connected: boolean
+  connected: boolean;
   /** Full Stellar public key of connected account, or empty string */
-  publicKey: string
+  publicKey: string;
   /** Shortened public key suitable for display in header */
-  displayKey: string
+  displayKey: string;
   /** Call this when the user clicks "Connect Wallet" — triggers wallet popup */
-  connect: (provider?: WalletProvider) => Promise<{ error?: string }>
+  connect: (provider?: WalletProvider) => Promise<{ error?: string }>;
   /** Current selected wallet provider. */
-  walletProvider: WalletProvider | null
-  /** Disconnects and clears localStorage */
-  disconnect: () => void
+  walletProvider: WalletProvider | null;
+  /** Disconnects, clears all wallet/session state, and redirects home */
+  disconnect: () => void;
 }
 
-export const WalletContext = createContext<WalletContextValue | null>(null)
+export const WalletContext = createContext<WalletContextValue | null>(null);
 
 export function WalletProvider({ children }: { children: ReactNode }) {
-  const mounted = useIsMounted()
-  const [publicKey, setPublicKey] = useState<string>("")
-  const [connected, setConnected] = useState(false)
-  const [walletProvider, setWalletProvider] = useState<WalletProvider | null>(null)
+  const mounted = useIsMounted();
+  const router = useRouter();
+  const [publicKey, setPublicKey] = useState<string>("");
+  const [connected, setConnected] = useState(false);
+  const [walletProvider, setWalletProvider] = useState<WalletProvider | null>(null);
 
   const { setConnected: storeSetConnected, setDisconnected: storeSetDisconnected } =
-    useWalletStore()
+    useWalletStore();
+
+  /**
+   * Clears wallet React state, zustand stores, session keys, WalletConnect,
+   * and any pending transaction toasts — without navigating away.
+   * Used by explicit disconnect and by Freighter lock/disconnect watcher.
+   */
+  const clearWalletState = useCallback(() => {
+    clearStoredWalletSession();
+    localStorage.removeItem(STORAGE_KEY);
+    setPublicKey("");
+    setWalletProvider(null);
+    setConnected(false);
+    storeSetDisconnected();
+    useLegacyWalletStore.getState().clearWallet();
+    usePlayerStore.getState().clearProgress();
+    disconnectWalletConnect();
+    cancelPendingTransactions();
+  }, [storeSetDisconnected]);
 
   // On client mount: restore persisted session and verify it's still valid
   useEffect(() => {
-    if (!mounted) return
+    if (!mounted) return;
 
     const restoreSession = async () => {
-      const session = getStoredWalletSession()
+      const session = getStoredWalletSession();
       if (session) {
         try {
-          const address = await connectWalletProvider(session.provider)
-          setStoredWalletSession(session.provider, address)
-          localStorage.setItem(STORAGE_KEY, address)
-          setPublicKey(address)
-          setWalletProvider(session.provider)
-          setConnected(true)
-          return
+          const address = await connectWalletProvider(session.provider);
+          setStoredWalletSession(session.provider, address);
+          localStorage.setItem(STORAGE_KEY, address);
+          setPublicKey(address);
+          setWalletProvider(session.provider);
+          setConnected(true);
+          return;
         } catch {
-          clearStoredWalletSession()
+          clearStoredWalletSession();
         }
       }
 
-      const saved = localStorage.getItem(STORAGE_KEY)
-      if (!saved) return
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (!saved) return;
 
       try {
         // Check extension is present before calling getAddress
-        const connResult = await isConnected()
+        const connResult = await isConnected();
         if (!connResult.isConnected) {
           // Extension removed or disabled — clear stale session
-          localStorage.removeItem(STORAGE_KEY)
-          return
+          localStorage.removeItem(STORAGE_KEY);
+          return;
         }
 
         // getAddress() returns the active address without prompting the user.
         // Returns empty string (not an error) if the app isn't on the allow list.
-        const addrResult = await getAddress()
+        const addrResult = await getAddress();
         if (addrResult.error || !addrResult.address) {
-          localStorage.removeItem(STORAGE_KEY)
-          return
+          localStorage.removeItem(STORAGE_KEY);
+          return;
         }
 
         // Restore session (update if user switched accounts in Freighter)
-        const resolvedKey = addrResult.address
+        const resolvedKey = addrResult.address;
         if (resolvedKey !== saved) {
-          localStorage.setItem(STORAGE_KEY, resolvedKey)
+          localStorage.setItem(STORAGE_KEY, resolvedKey);
         }
-        setPublicKey(resolvedKey)
-        setWalletProvider("freighter")
-        setConnected(true)
+        setPublicKey(resolvedKey);
+        setWalletProvider("freighter");
+        setConnected(true);
       } catch {
-        localStorage.removeItem(STORAGE_KEY)
+        localStorage.removeItem(STORAGE_KEY);
       }
-    }
+    };
 
-    restoreSession()
-  }, [mounted])
+    restoreSession();
+  }, [mounted]);
 
   // Watch for live account/network changes (e.g. user switches accounts in Freighter)
   // Runs once on client mount — watcher polls internally every 3s
   useEffect(() => {
-    if (!mounted) return
+    if (!mounted) return;
 
-    let watcher: InstanceType<typeof WatchWalletChanges> | null = null
+    let watcher: InstanceType<typeof WatchWalletChanges> | null = null;
 
     try {
-      watcher = new WatchWalletChanges(3000)
+      watcher = new WatchWalletChanges(3000);
       watcher.watch(
-        ({
-          address,
-        }: {
-          address: string
-          network: string
-          networkPassphrase: string
-        }) => {
+        ({ address }: { address: string; network: string; networkPassphrase: string }) => {
           if (address) {
             // Account changed or connected
-            setPublicKey(address)
-            setConnected(true)
-            localStorage.setItem(STORAGE_KEY, address)
-            setStoredWalletSession("freighter", address)
+            setPublicKey(address);
+            setConnected(true);
+            localStorage.setItem(STORAGE_KEY, address);
+            setStoredWalletSession("freighter", address);
           } else {
             // Empty address = user locked or disconnected Freighter
-            setPublicKey("")
-            setConnected(false)
-            localStorage.removeItem(STORAGE_KEY)
+            clearWalletState();
           }
-        },
-      )
+        }
+      );
     } catch {
       // Freighter not installed — watcher silently skipped
     }
 
     return () => {
-      watcher?.stop()
-    }
-  }, [mounted])
+      watcher?.stop();
+    };
+  }, [mounted, clearWalletState]);
 
   /**
    * Trigger wallet popup to request wallet access.
    * requestAccess() prompts if not yet on the allow list,
    * or returns immediately if the user already approved this app.
    */
-  const connect = useCallback(async (provider: WalletProvider = "freighter"): Promise<{ error?: string }> => {
-    try {
-      if (provider === "freighter") {
-        const connResult = await isConnected()
-        if (!connResult.isConnected) {
-          return {
-            error:
-              "Freighter extension not found. Please install it from freighter.app",
+  const connect = useCallback(
+    async (provider: WalletProvider = "freighter"): Promise<{ error?: string }> => {
+      try {
+        if (provider === "freighter") {
+          const connResult = await isConnected();
+          if (!connResult.isConnected) {
+            return {
+              error: "Freighter extension not found. Please install it from freighter.app",
+            };
           }
+
+          // requestAccess() returns { address: string, error?: string }
+          // error is a plain string per the Freighter API docs
+          const accessResult = await requestAccess();
+
+          if (accessResult.error) {
+            return { error: String(accessResult.error) };
+          }
+
+          const address = accessResult.address;
+          if (!address) {
+            return { error: "No public key returned. Please try again." };
+          }
+
+          setStoredWalletSession("freighter", address);
+          localStorage.setItem(STORAGE_KEY, address);
+          setPublicKey(address);
+          setWalletProvider("freighter");
+          setConnected(true);
+          storeSetConnected(address, "freighter");
+          return {};
         }
 
-        // requestAccess() returns { address: string, error?: string }
-        // error is a plain string per the Freighter API docs
-        const accessResult = await requestAccess()
-
-        if (accessResult.error) {
-          return { error: String(accessResult.error) }
-        }
-
-        const address = accessResult.address
-        if (!address) {
-          return { error: "No public key returned. Please try again." }
-        }
-
-        setStoredWalletSession("freighter", address)
-        localStorage.setItem(STORAGE_KEY, address)
-        setPublicKey(address)
-        setWalletProvider("freighter")
-        setConnected(true)
-        storeSetConnected(address, "freighter")
-        return {}
+        const address = await connectWalletProvider(provider);
+        setStoredWalletSession(provider, address);
+        localStorage.setItem(STORAGE_KEY, address);
+        setPublicKey(address);
+        setWalletProvider(provider);
+        setConnected(true);
+        storeSetConnected(address, provider);
+        return {};
+      } catch (err) {
+        return {
+          error: err instanceof Error ? err.message : "Unexpected error during connection.",
+        };
       }
-
-      const address = await connectWalletProvider(provider)
-      setStoredWalletSession(provider, address)
-      localStorage.setItem(STORAGE_KEY, address)
-      setPublicKey(address)
-      setWalletProvider(provider)
-      setConnected(true)
-      storeSetConnected(address, provider)
-      return {}
-    } catch (err) {
-      return {
-        error:
-          err instanceof Error
-            ? err.message
-            : "Unexpected error during connection.",
-      }
-    }
-  }, [storeSetConnected])
+    },
+    [storeSetConnected]
+  );
 
   const disconnect = useCallback(() => {
-    clearStoredWalletSession()
-    localStorage.removeItem(STORAGE_KEY)
-    setPublicKey("")
-    setWalletProvider(null)
-    setConnected(false)
-    storeSetDisconnected()
-  }, [storeSetDisconnected])
+    clearWalletState();
+    router.push("/");
+  }, [clearWalletState, router]);
 
   const value = useMemo<WalletContextValue>(
     () => ({
@@ -238,12 +243,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       walletProvider,
       disconnect,
     }),
-    [connected, publicKey, connect, walletProvider, disconnect],
-  )
+    [connected, publicKey, connect, walletProvider, disconnect]
+  );
 
-  return (
-    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
-  )
+  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
 }
 
 /**
@@ -251,9 +254,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
  * Must be used within a WalletProvider.
  */
 export function useWallet(): WalletContextValue {
-  const ctx = useContext(WalletContext)
+  const ctx = useContext(WalletContext);
   if (ctx == null) {
-    throw new Error("useWallet must be used within a WalletProvider")
+    throw new Error("useWallet must be used within a WalletProvider");
   }
-  return ctx
+  return ctx;
 }

--- a/apps/web/lib/context/__tests__/WalletContext.disconnect.test.tsx
+++ b/apps/web/lib/context/__tests__/WalletContext.disconnect.test.tsx
@@ -1,0 +1,149 @@
+import * as freighterApi from "@stellar/freighter-api";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWallet, WalletProvider } from "@/lib/context/WalletContext";
+import * as walletAdapter from "@/lib/walletAdapter";
+import { useWalletStore } from "@/lib/wallets/walletStore";
+import { usePlayerStore, useWalletStore as useLegacyWalletStore } from "@/store/useStore";
+
+const mockPush = vi.fn();
+const mockCancelPendingTransactions = vi.fn();
+const mockDisconnectWalletConnect = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/lib/txToast", () => ({
+  cancelPendingTransactions: () => mockCancelPendingTransactions(),
+}));
+
+vi.mock("@/lib/walletConnect", () => ({
+  disconnectWalletConnect: () => mockDisconnectWalletConnect(),
+}));
+
+vi.mock("@/lib/walletAdapter", () => ({
+  connectWalletProvider: vi.fn(),
+  getStoredWalletSession: vi.fn(() => null),
+  setStoredWalletSession: vi.fn(),
+  clearStoredWalletSession: vi.fn(),
+}));
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn(),
+  getAddress: vi.fn(),
+  requestAccess: vi.fn(),
+  WatchWalletChanges: vi.fn().mockImplementation(function (this: {
+    watch: (cb: unknown) => void;
+    stop: () => void;
+  }) {
+    this.watch = () => {};
+    this.stop = () => {};
+  }),
+}));
+
+vi.mock("@/hooks/useIsMounted", () => ({
+  useIsMounted: () => true,
+}));
+
+const storage: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => storage[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    storage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete storage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(storage).forEach((key) => delete storage[key]);
+  }),
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(WalletProvider, null, children);
+}
+
+describe("WalletContext disconnect cleanup", () => {
+  beforeEach(() => {
+    Object.keys(storage).forEach((key) => delete storage[key]);
+    vi.stubGlobal("localStorage", localStorageMock);
+    mockPush.mockClear();
+    mockCancelPendingTransactions.mockClear();
+    mockDisconnectWalletConnect.mockClear();
+    vi.mocked(walletAdapter.clearStoredWalletSession).mockClear();
+    vi.mocked(walletAdapter.getStoredWalletSession).mockReturnValue(null);
+
+    useWalletStore.setState({
+      connected: false,
+      publicKey: "",
+      provider: null,
+      lastUsedProvider: null,
+      connecting: false,
+      error: null,
+    });
+    useLegacyWalletStore.setState({
+      walletAddress: "",
+      walletBalance: null,
+      isConnected: false,
+    });
+    usePlayerStore.setState({ currentProgress: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("clears all wallet/session state, cancels pending txs, and redirects home", async () => {
+    vi.mocked(freighterApi.isConnected).mockResolvedValue({
+      isConnected: true,
+    } as Awaited<ReturnType<typeof freighterApi.isConnected>>);
+    vi.mocked(freighterApi.requestAccess).mockResolvedValue({
+      address: "GTESTDISCONNECT123",
+    } as Awaited<ReturnType<typeof freighterApi.requestAccess>>);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      await result.current.connect("freighter");
+    });
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    useLegacyWalletStore.getState().setWallet("GTESTDISCONNECT123");
+    useLegacyWalletStore.getState().setBalance("10.0");
+    usePlayerStore.getState().setProgress({
+      hunt_id: 1,
+      player: "GTESTDISCONNECT123",
+      current_clue_index: 1,
+      completed: false,
+      reward_claimed: false,
+    });
+
+    act(() => {
+      result.current.disconnect();
+    });
+
+    expect(result.current.connected).toBe(false);
+    expect(result.current.publicKey).toBe("");
+    expect(walletAdapter.clearStoredWalletSession).toHaveBeenCalled();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith("freighter_public_key");
+
+    const canonical = useWalletStore.getState();
+    expect(canonical.connected).toBe(false);
+    expect(canonical.publicKey).toBe("");
+
+    const legacy = useLegacyWalletStore.getState();
+    expect(legacy.walletAddress).toBe("");
+    expect(legacy.walletBalance).toBeNull();
+    expect(legacy.isConnected).toBe(false);
+
+    expect(usePlayerStore.getState().currentProgress).toBeNull();
+    expect(mockDisconnectWalletConnect).toHaveBeenCalled();
+    expect(mockCancelPendingTransactions).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+});

--- a/apps/web/lib/txToast.ts
+++ b/apps/web/lib/txToast.ts
@@ -1,8 +1,8 @@
-import { toast } from "sonner"
+import { toast } from "sonner";
 
-import { announceSr } from "@/components/SrAnnouncer"
-import { settleWalletBalance } from "@/lib/wallet/balanceEvents"
-import { mapContractError } from "@/lib/contracts/errors"
+import { announceSr } from "@/components/SrAnnouncer";
+import { mapContractError } from "@/lib/contracts/errors";
+import { settleWalletBalance } from "@/lib/wallet/balanceEvents";
 
 // ─── Stage type ───────────────────────────────────────────────────────────────
 
@@ -14,26 +14,57 @@ import { mapContractError } from "@/lib/contracts/errors"
  *   confirmed → transaction landed on-chain
  *   failed    → transaction rejected or errored
  */
-export type TxStage = "pending" | "approving" | "confirmed" | "failed"
+export type TxStage = "pending" | "approving" | "confirmed" | "failed";
 
 /** Call this inside your transaction function to advance the visible stage. */
-export type SetStageFn = (stage: Extract<TxStage, "pending" | "approving">) => void
+export type SetStageFn = (stage: Extract<TxStage, "pending" | "approving">) => void;
 
 // ─── Message config ───────────────────────────────────────────────────────────
 
 export type TxToastMessages = {
   /** Shown immediately — "Pending" state. Default: "Waiting for wallet…" */
-  pending?: string
+  pending?: string;
   /** Shown after setStage("approving") — wallet popup is open. Default: "Approve in your wallet…" */
-  approving?: string
+  approving?: string;
   /** Shown on success — "Confirmed" state. Default: "Transaction confirmed!" */
-  confirmed?: string
-}
+  confirmed?: string;
+};
 
 const DEFAULTS: Required<TxToastMessages> = {
-  pending:   "Pending — waiting for wallet…",
+  pending: "Pending — waiting for wallet…",
   approving: "Approving — sign in your wallet…",
   confirmed: "Confirmed!",
+};
+
+/** Toast ids for in-flight transaction stages that should be cleared on disconnect. */
+const pendingToastIds = new Set<string | number>();
+
+/**
+ * Generation counter bumped on disconnect so in-flight `withTransactionToast`
+ * calls can detect that the wallet session was torn down mid-flight.
+ */
+let disconnectGeneration = 0;
+
+/**
+ * Cancel any pending / approving transaction toasts and reconcile optimistic
+ * balance state. Called when the user disconnects their wallet.
+ */
+export function cancelPendingTransactions(): void {
+  disconnectGeneration += 1;
+
+  for (const id of pendingToastIds) {
+    toast.dismiss(id);
+  }
+  pendingToastIds.clear();
+
+  // Also dismiss any other sonner toasts so the UI never hangs after disconnect.
+  toast.dismiss();
+  settleWalletBalance();
+}
+
+/** @internal Exposed for tests */
+export function getDisconnectGeneration(): number {
+  return disconnectGeneration;
 }
 
 // ─── Main function ────────────────────────────────────────────────────────────
@@ -68,50 +99,70 @@ export async function withTransactionToast<T>(
   fn: (setStage: SetStageFn) => Promise<T>,
   messages: TxToastMessages = {}
 ): Promise<T> {
-  const msgs: Required<TxToastMessages> = { ...DEFAULTS, ...messages }
+  const msgs: Required<TxToastMessages> = { ...DEFAULTS, ...messages };
+  const startedAtGeneration = disconnectGeneration;
 
   // Stage 1 — Pending
-  announceSr(msgs.pending)
-  const toastId = toast.loading(msgs.pending)
+  announceSr(msgs.pending);
+  const toastId = toast.loading(msgs.pending);
+  pendingToastIds.add(toastId);
 
   const setStage: SetStageFn = (stage) => {
     if (stage === "approving") {
-      announceSr(msgs.approving)
+      announceSr(msgs.approving);
       // Update the same toast in-place so it doesn't flicker
-      toast.loading(msgs.approving, { id: toastId })
+      toast.loading(msgs.approving, { id: toastId });
     }
-  }
+  };
+
+  const releaseToast = () => {
+    pendingToastIds.delete(toastId);
+  };
 
   try {
-    const result = await fn(setStage)
+    const result = await fn(setStage);
+
+    // Wallet was disconnected while this tx was in flight — skip success UI.
+    if (startedAtGeneration !== disconnectGeneration) {
+      releaseToast();
+      return result;
+    }
 
     // Stage 3 — Confirmed
-    announceSr(msgs.confirmed)
-    toast.success(msgs.confirmed, { id: toastId })
+    announceSr(msgs.confirmed);
+    toast.success(msgs.confirmed, { id: toastId });
+    releaseToast();
 
     // The transaction landed, so any optimistic balance shown while it was in
     // flight is now reconciled against chain state.
-    settleWalletBalance()
+    settleWalletBalance();
 
-    return result
+    return result;
   } catch (err) {
-    const mapped = mapContractError(err)
+    releaseToast();
+
+    // Disconnect already dismissed toasts and settled balance — don't re-toast.
+    if (startedAtGeneration !== disconnectGeneration) {
+      throw err;
+    }
+
+    const mapped = mapContractError(err);
 
     // A failed or rejected transaction also has to clear an optimistic value —
     // otherwise a predicted spend stays on screen for a payment that never
     // happened, until the next poll tick.
-    settleWalletBalance()
+    settleWalletBalance();
 
     if (mapped.isUserRejection) {
       // Yellow warning — user intentionally cancelled, not an error.
-      announceSr("Transaction cancelled")
-      toast.warning(mapped.message, { id: toastId })
+      announceSr("Transaction cancelled");
+      toast.warning(mapped.message, { id: toastId });
     } else {
-      announceSr("Failed: " + mapped.message)
-      toast.error(mapped.message, { id: toastId })
+      announceSr("Failed: " + mapped.message);
+      toast.error(mapped.message, { id: toastId });
     }
 
     // Re-throw so callers can run their own cleanup (e.g. reset isPublishing).
-    throw err
+    throw err;
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,6 +5,13 @@ import { defineConfig } from "vitest/config";
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   plugins: [react()],
+  // Vite 8 defaults to oxc, which skips the React plugin's esbuild JSX transform.
+  // Force automatic JSX runtime so .tsx sources parse under import analysis.
+  oxc: {
+    jsx: {
+      runtime: "automatic",
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,
@@ -35,10 +42,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@hunty/types/schemas": path.resolve(
-        __dirname,
-        "./packages/types/src/schemas.ts",
-      ),
+      "@hunty/types/schemas": path.resolve(__dirname, "./packages/types/src/schemas.ts"),
       "@hunty/types": path.resolve(__dirname, "./packages/types/src/index.ts"),
       "@": path.resolve(__dirname, "./"),
     },


### PR DESCRIPTION
## Overview

This PR implements a proper **wallet disconnect and cleanup** flow so disconnecting clears all related wallet/session state, cancels pending transaction UI, and returns the user to home.

## Related Issue

Closes #571

## Changes

### 🔌 Wallet Disconnect Cleanup

* **[MODIFY]** `apps/web/lib/context/WalletContext.tsx`
  * Full disconnect cleanup: Freighter/session keys, canonical + legacy zustand wallet stores, player progress, WalletConnect session.
  * Cancels pending transaction toasts on disconnect.
  * Redirects to `/` after an explicit disconnect.
  * Freighter lock/empty-address watcher now uses the same cleanup path (without redirect).

* **[MODIFY]** `apps/web/lib/txToast.ts`
  * Adds `cancelPendingTransactions()` to dismiss in-flight pending/approving toasts and settle optimistic balance state.

* **[MODIFY]** `apps/web/components/Header.tsx`
  * Fixes broken duplicate imports so the disconnect control in the profile/header dropdown is usable again.
  * Minor a11y/lint fixes for search input + unread count polling.

* **[ADD]** Tests
  * `WalletContext.disconnect.test.tsx` — store/session cleanup, pending-tx cancel, home redirect.
  * `txToast.cancel.test.ts` — pending toast dismissal on cancel.
  * Header + e2e disconnect coverage updates.

## Verification Results

```
npm test -- lib/context/__tests__/WalletContext.disconnect.test.tsx lib/__tests__/txToast.cancel.test.ts
✅ 2/2 passed

Header disconnect interaction:
✅ Disconnect button calls disconnect()
```

| Acceptance Criteria | Status |
| --- | --- |
| Disconnect button in profile/header dropdown | ✅ Present in header wallet dropdown + mobile menu |
| Clear wallet state from zustand store | ✅ Canonical + legacy wallet stores cleared |
| Remove session data | ✅ Freighter key, stellar session, WalletConnect session cleared |
| Cancel any pending transactions | ✅ Pending tx toasts dismissed + balance settled |
| Redirect to home page after disconnect | ✅ `router.push("/")` on explicit disconnect |