### PR TITLE
feat: add real-time game progress tracking

### DIFF
--- a/apps/web/app/api/v1/hunts/[id]/leaderboard/route.ts
+++ b/apps/web/app/api/v1/hunts/[id]/leaderboard/route.ts
@@ -1,16 +1,13 @@
 import { NextResponse } from "next/server";
 
-import { get_hunt_leaderboard } from "@/lib/contracts/hunt";
-import { rateLimit, getIP, rateLimitResponse } from "@/lib/rate-limit";
 import { ValidationError } from "@/lib/api/errors";
 import { withErrorHandling } from "@/lib/api/withErrorHandling";
 import { getIP, rateLimit, rateLimitResponse } from "@/lib/rate-limit";
+import { getAllProgressForHunt } from "@/lib/progressData";
 
-/**
- * GET /api/v1/hunts/[id]/leaderboard
- * Get hunt leaderboard with cursor pagination.
- */
-export const GET = withErrorHandling<{ params: Promise<{ id: string }> }>(async (req, { params }) => {
+export const GET = withErrorHandling<{
+  params: Promise<{ id: string }>
+}>(async (req, { params }) => {
   const ip = getIP(req);
   const { success, reset } = rateLimit(ip, { limit: 100, windowMs: 60 * 1000 });
 
@@ -34,15 +31,21 @@ export const GET = withErrorHandling<{ params: Promise<{ id: string }> }>(async 
     throw new ValidationError("Invalid cursor", { cursor: cursorParam });
   }
 
-  const leaderboard = await get_hunt_leaderboard(huntId);
+  const entries = getAllProgressForHunt(huntId);
 
-  // get_hunt_leaderboard might return unsorted or current-player augmented data.
-  // We sort by points descending to ensure a consistent leaderboard order.
-  const sorted = [...leaderboard].sort((a, b) => b.points - a.points);
+  const leaderboard = entries
+    .filter((e) => e.totalPoints > 0)
+    .map((e) => ({
+      address: e.wallet,
+      points: e.totalPoints,
+      completionCount: e.completed ? 1 : 0,
+      completedAt: e.completedAt ?? undefined,
+    }))
+    .sort((a, b) => b.points - a.points);
 
-  const total = sorted.length;
+  const total = leaderboard.length;
   const pageStart = cursor == null ? 0 : Math.max(0, cursor);
-  const paginated = sorted.slice(pageStart, pageStart + limit);
+  const paginated = leaderboard.slice(pageStart, pageStart + limit);
   const nextCursor = paginated.length === limit ? pageStart + paginated.length : null;
 
   return NextResponse.json({

--- a/apps/web/app/api/v1/hunts/[id]/players/route.ts
+++ b/apps/web/app/api/v1/hunts/[id]/players/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server"
+
+import { ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
+import { getIP, rateLimit, rateLimitResponse } from "@/lib/rate-limit"
+import {
+  getAllProgressForHunt,
+  getActivePlayersForHunt,
+  getCompletedPlayersForHunt,
+  StoredProgressEntry,
+} from "@/lib/progressData"
+
+export const GET = withErrorHandling<{
+  params: Promise<{ id: string }>
+}>(async (req, { params }) => {
+  const ip = getIP(req)
+  const { success, reset } = rateLimit(ip, {
+    limit: 60,
+    windowMs: 60 * 1000,
+  })
+  if (!success) {
+    return rateLimitResponse(reset)
+  }
+
+  const { id } = await params
+  const huntId = parseInt(id, 10)
+  if (isNaN(huntId)) {
+    throw new ValidationError("Invalid hunt ID", { id })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const filter = searchParams.get("filter")
+
+  let entries: StoredProgressEntry[]
+  if (filter === "active") {
+    entries = getActivePlayersForHunt(huntId)
+  } else if (filter === "completed") {
+    entries = getCompletedPlayersForHunt(huntId)
+  } else {
+    entries = getAllProgressForHunt(huntId)
+  }
+
+  entries.sort((a, b) => b.totalPoints - a.totalPoints)
+
+  return NextResponse.json({
+    data: entries,
+    total: entries.length,
+  })
+})

--- a/apps/web/app/api/v1/hunts/[id]/progress/route.ts
+++ b/apps/web/app/api/v1/hunts/[id]/progress/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server"
+
+import { NotFoundError, ValidationError } from "@/lib/api/errors"
+import { withErrorHandling } from "@/lib/api/withErrorHandling"
+import { getIP, rateLimit, rateLimitResponse } from "@/lib/rate-limit"
+import {
+  getPlayerProgress,
+  savePlayerProgress,
+} from "@/lib/progressData"
+
+export const GET = withErrorHandling<{
+  params: Promise<{ id: string }>
+}>(async (req, { params }) => {
+  const ip = getIP(req)
+  const { success, reset } = rateLimit(ip, {
+    limit: 100,
+    windowMs: 60 * 1000,
+  })
+  if (!success) {
+    return rateLimitResponse(reset)
+  }
+
+  const { id } = await params
+  const huntId = parseInt(id, 10)
+  if (isNaN(huntId)) {
+    throw new ValidationError("Invalid hunt ID", { id })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const wallet = searchParams.get("wallet")
+  if (!wallet) {
+    throw new ValidationError("wallet query parameter is required")
+  }
+
+  const progress = getPlayerProgress(huntId, wallet)
+  if (!progress) {
+    return NextResponse.json({ data: null })
+  }
+
+  return NextResponse.json({ data: progress })
+})
+
+export const POST = withErrorHandling<{
+  params: Promise<{ id: string }>
+}>(async (req, { params }) => {
+  const ip = getIP(req)
+  const { success, reset } = rateLimit(ip, {
+    limit: 60,
+    windowMs: 60 * 1000,
+  })
+  if (!success) {
+    return rateLimitResponse(reset)
+  }
+
+  const { id } = await params
+  const huntId = parseInt(id, 10)
+  if (isNaN(huntId)) {
+    throw new ValidationError("Invalid hunt ID", { id })
+  }
+
+  let body: {
+    wallet?: string
+    currentClueIndex?: number
+    totalClues?: number
+    totalPoints?: number
+    completedClueIds?: number[]
+    completed?: boolean
+  }
+  try {
+    body = await req.json()
+  } catch {
+    throw new ValidationError("Invalid request body")
+  }
+
+  if (!body.wallet || typeof body.wallet !== "string") {
+    throw new ValidationError("wallet is required")
+  }
+  if (
+    body.currentClueIndex === undefined ||
+    typeof body.currentClueIndex !== "number"
+  ) {
+    throw new ValidationError("currentClueIndex is required")
+  }
+  if (body.totalClues === undefined || typeof body.totalClues !== "number") {
+    throw new ValidationError("totalClues is required")
+  }
+
+  const entry = savePlayerProgress(
+    huntId,
+    body.wallet,
+    body.currentClueIndex,
+    body.totalClues,
+    body.totalPoints ?? 0,
+    body.completedClueIds ?? [],
+    body.completed ?? false,
+  )
+
+  return NextResponse.json({ data: entry })
+})

--- a/apps/web/components/HuntCards.tsx
+++ b/apps/web/components/HuntCards.tsx
@@ -216,7 +216,7 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
 
     try {
       if (huntId != null) {
-        const result = await submitAnswer(huntId, Number(hunt.id), input);
+        const result = await submitAnswer(huntId, Number(hunt.id), input, playerAddress);
         if (result?.txHash) await pollTransaction(result.txHash);
 
         setSuccess(true);
@@ -263,9 +263,8 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
         onScoreUpdate?.(updatedActualPoints);
         setTimeout(() => {
           setSuccess(false);
-          onUnlock?.(actualPoints);
+          onUnlock?.(updatedActualPoints);
         }, 1200);
-        setTimeout(() => { setSuccess(false); onUnlock?.(); }, 1200);
       } else {
         // Local / preview fallback
         if (input.trim().toLowerCase() === (hunt.code || "").trim().toLowerCase()) {
@@ -288,9 +287,8 @@ export const HuntCards: React.FC<HuntCardsProps> = ({
           onScoreUpdate?.(breakdown.totalPoints);
           setTimeout(() => {
             setSuccess(false);
-            onUnlock?.(actualPoints);
+            onUnlock?.(breakdown.totalPoints);
           }, 1200);
-          setTimeout(() => { setSuccess(false); onUnlock?.(); }, 1200);
         } else {
           setError("Try Again");
           setSuccess(false);

--- a/apps/web/lib/contracts/hunt.ts
+++ b/apps/web/lib/contracts/hunt.ts
@@ -11,6 +11,7 @@ import { SOROBAN_RPC_URL, NETWORK_PASSPHRASE } from "./config"
 import { getActiveWalletAdapter } from "@/lib/walletAdapter"
 import { sha256Hex } from "@/lib/crypto"
 import { logger } from "@/lib/logger"
+import { isOnline, queueProgressUpdate } from "@/lib/offlineSync"
 
 import type {
   ClueDifficulty,
@@ -328,26 +329,38 @@ export async function extendEndTime(
 
 /**
  * Retrieves the hunt leaderboard.
- * Attempts to fetch "live" data from the contract account's data attributes
- * (leveraging the manageData pattern) with a robust mock data fallback.
+ * Fetches real progress data from the server API, with localStorage fallback.
  */
 export async function get_hunt_leaderboard(
   huntId: number,
 ): Promise<LeaderboardEntry[]> {
-  // Simulate network latency
-  await new Promise((resolve) => setTimeout(resolve, 800));
-
   const now = Math.floor(Date.now() / 1000)
-  const DAY = 86400
 
-  const mockData: LeaderboardEntry[] = [
-    { address: "GDD...9X2", name: "StellarQuest", points: 45, completionCount: 12, completedAt: now - DAY * 0.5, category: "Trivia", difficulty: "Medium" },
-    { address: "GBX...A1B", points: 30, completionCount: 7, completedAt: now - DAY * 3, category: "Outdoor", difficulty: "Hard" },
-    { address: "GCT...Z9Y", name: "AliceCrypto", points: 58, completionCount: 18, completedAt: now - DAY * 1, category: "Campus", difficulty: "Easy" },
-    { address: "GDE...123", points: 15, completionCount: 4, completedAt: now - DAY * 20, category: "Indoor", difficulty: "Easy" },
-    { address: "GFA...789", name: "BobHunts", points: 41, completionCount: 10, completedAt: now - DAY * 6, category: "Onboarding", difficulty: "Medium" },
-    { address: "GCA...HB2", points: 28, completionCount: 6, completedAt: now - DAY * 45, category: "Community", difficulty: "Hard" },
-  ]
+  // Try fetching from server API when online
+  if (typeof window !== "undefined") {
+    try {
+      const baseUrl = window.location.origin;
+      const res = await fetch(
+        `${baseUrl}/api/v1/hunts/${huntId}/leaderboard?limit=100`,
+      );
+      if (res.ok) {
+        const body = await res.json();
+        if (Array.isArray(body?.data) && body.data.length > 0) {
+          return body.data.map((entry: { address?: string; points?: number; completionCount?: number; completedAt?: number }) => ({
+            address: entry.address ?? "unknown",
+            points: entry.points ?? 0,
+            completionCount: entry.completionCount ?? 0,
+            completedAt: entry.completedAt,
+          }));
+        }
+      }
+    } catch {
+      // Fall back to localStorage
+    }
+  }
+
+  // Fallback: build from localStorage
+  const entries: LeaderboardEntry[] = []
 
   if (typeof window !== "undefined") {
     try {
@@ -355,7 +368,13 @@ export async function get_hunt_leaderboard(
       if (myPointsStr) {
         const myPoints = parseInt(myPointsStr, 10);
         if (myPoints > 0) {
-          mockData.push({ address: "YOU...PLYR", name: "You (Current Player)", points: myPoints, completionCount: 1, completedAt: now - DAY * 0.1 })
+          entries.push({
+            address: "YOU...PLYR",
+            name: "You (Current Player)",
+            points: myPoints,
+            completionCount: 1,
+            completedAt: now - 86400 * 0.1,
+          })
         }
       }
     } catch (e) {
@@ -363,7 +382,7 @@ export async function get_hunt_leaderboard(
     }
   }
 
-  return mockData;
+  return entries;
 }
 
 export async function get_hunt_leaderboard_paginated(
@@ -593,6 +612,78 @@ export async function pollTransaction(txHash: string): Promise<boolean> {
   throw new Error("Transaction polling timed out after 30 seconds");
 }
 
+async function saveProgressToServer(
+  huntId: number,
+  clueId: number,
+  wallet?: string,
+): Promise<void> {
+  if (!wallet) return
+
+  const clues = getHuntClues(huntId)
+  const progress = getHuntProgress(huntId)
+  const userPointsKey = `hunt_${huntId}_my_points`
+  const totalPoints = parseInt(
+    typeof window !== "undefined"
+      ? localStorage.getItem(userPointsKey) || "0"
+      : "0",
+    10,
+  )
+
+  const solvedClueIds: number[] = []
+  for (const clue of clues) {
+    const solvedKey = `hunt_clue_solved_${huntId}_${clue.id}`
+    if (
+      typeof window !== "undefined" &&
+      localStorage.getItem(solvedKey) === "true"
+    ) {
+      solvedClueIds.push(clue.id)
+    }
+  }
+
+  const payload = {
+    wallet,
+    currentClueIndex: progress.currentClueIndex,
+    totalClues: clues.length,
+    totalPoints,
+    completedClueIds: solvedClueIds,
+    completed: progress.completed,
+  }
+
+  if (isOnline()) {
+    try {
+      const baseUrl =
+        typeof window !== "undefined"
+          ? window.location.origin
+          : process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+      await fetch(`${baseUrl}/api/v1/hunts/${huntId}/progress`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+    } catch {
+      queueProgressUpdate(
+        huntId,
+        wallet,
+        payload.currentClueIndex,
+        payload.totalClues,
+        payload.totalPoints,
+        payload.completedClueIds,
+        payload.completed,
+      )
+    }
+  } else {
+    queueProgressUpdate(
+      huntId,
+      wallet,
+      payload.currentClueIndex,
+      payload.totalClues,
+      payload.totalPoints,
+      payload.completedClueIds,
+      payload.completed,
+    )
+  }
+}
+
 /**
  * Submits an answer for a specific clue. Throws AnswerIncorrectError on mismatch.
  * Mock implementation that checks against localStorage clue data.
@@ -601,6 +692,7 @@ export async function submitAnswer(
   huntId: number,
   clueId: number,
   answer: string,
+  wallet?: string,
 ): Promise<SubmitAnswerResult> {
   await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -674,6 +766,8 @@ export async function submitAnswer(
   }
 
   advanceHuntProgress(huntId, clueIndex + 1, clues.length)
+
+  saveProgressToServer(huntId, clue.id, wallet)
 
   return {
     txHash: `mock_tx_${Date.now()}`,

--- a/apps/web/lib/contracts/player-registration.ts
+++ b/apps/web/lib/contracts/player-registration.ts
@@ -1,11 +1,13 @@
 import Server, { Operation,TransactionBuilder } from "@stellar/stellar-sdk"
 
 import { RegistrationError } from "@/lib/contracts/errors"
-import { getHuntProgress } from "@/lib/huntStore"
+import { advanceHuntProgress, getHuntProgress } from "@/lib/huntStore"
 import type { PlayerProgress, RegistrationResult,RegistrationStatus } from "@/lib/types"
 
 import { withSorobanRpcRetry } from "../soroban/rpcRetry"
 import { NETWORK_PASSPHRASE,SOROBAN_RPC_URL } from "./config"
+import { isOnline } from "@/lib/offlineSync"
+import { logger } from "@/lib/logger"
 
 export type { PlayerProgress, RegistrationResult,RegistrationStatus }
 
@@ -276,8 +278,59 @@ export async function getPlayerProgress(
 
   return withRetry(async () => {
     try {
-      // In a real implementation, this would query the contract's get_player_progress function
-      // For now, we simulate the contract call using the manageData pattern
+      // Try fetching from server progress API first (when online)
+      if (isOnline() && typeof window !== "undefined") {
+        try {
+          const baseUrl = window.location.origin;
+          const res = await fetch(
+            `${baseUrl}/api/v1/hunts/${huntId}/progress?wallet=${encodeURIComponent(playerAddress)}`,
+          );
+          if (res.ok) {
+            const body = await res.json();
+            if (body?.data) {
+              const serverProgress = body.data;
+              
+              // Sync server progress to localStorage for offline use
+              try {
+                const progress = getHuntProgress(huntId);
+                const { savePlayerProgress } = await import("@/lib/progressData");
+                
+                if (serverProgress.currentClueIndex > progress.currentClueIndex) {
+                  advanceHuntProgress(huntId, serverProgress.currentClueIndex, serverProgress.totalClues);
+                }
+                
+                const userPointsKey = `hunt_${huntId}_my_points`;
+                const currentPoints = parseInt(localStorage.getItem(userPointsKey) || "0", 10);
+                if (serverProgress.totalPoints > currentPoints) {
+                  localStorage.setItem(userPointsKey, serverProgress.totalPoints.toString());
+                }
+                
+                if (serverProgress.completed) {
+                  localStorage.setItem(`hunt_completed_${huntId}`, "true");
+                }
+                
+                for (const clueId of serverProgress.completedClueIds || []) {
+                  localStorage.setItem(`hunt_clue_solved_${huntId}_${clueId}`, "true");
+                }
+              } catch {
+                // Non-critical, best-effort sync
+              }
+
+              return {
+                hunt_id: huntId,
+                player: playerAddress,
+                current_clue_index: serverProgress.currentClueIndex,
+                completed: serverProgress.completed,
+                reward_claimed: false,
+              };
+            }
+          }
+        } catch {
+          // Fall back to localStorage if server fetch fails
+        }
+      }
+
+      // Fallback to localStorage for offline or if server fetch failed
       if (typeof window !== "undefined") {
         const userPointsKey = `hunt_${huntId}_my_points`;
         const hasPoints = localStorage.getItem(userPointsKey) !== null;

--- a/apps/web/lib/offlineSync.ts
+++ b/apps/web/lib/offlineSync.ts
@@ -1,0 +1,152 @@
+import { logger } from "@/lib/logger"
+
+const QUEUE_KEY = "hunty_offline_progress_queue"
+
+export interface QueuedProgressUpdate {
+  id: string
+  huntId: number
+  wallet: string
+  currentClueIndex: number
+  totalClues: number
+  totalPoints: number
+  completedClueIds: number[]
+  completed: boolean
+  queuedAt: number
+}
+
+function readQueue(): QueuedProgressUpdate[] {
+  if (typeof window === "undefined") return []
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+function writeQueue(queue: QueuedProgressUpdate[]): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(queue))
+  } catch {
+    // ignore
+  }
+}
+
+export function isOnline(): boolean {
+  return typeof navigator !== "undefined" ? navigator.onLine : true
+}
+
+export function queueProgressUpdate(
+  huntId: number,
+  wallet: string,
+  currentClueIndex: number,
+  totalClues: number,
+  totalPoints: number,
+  completedClueIds: number[],
+  completed: boolean,
+): void {
+  const queue = readQueue()
+  const existingIdx = queue.findIndex(
+    (item) => item.huntId === huntId && item.wallet === wallet,
+  )
+
+  const update: QueuedProgressUpdate = {
+    id: `${huntId}_${wallet}_${Date.now()}`,
+    huntId,
+    wallet,
+    currentClueIndex,
+    totalClues,
+    totalPoints,
+    completedClueIds,
+    completed,
+    queuedAt: Date.now(),
+  }
+
+  if (existingIdx >= 0) {
+    queue[existingIdx] = update
+  } else {
+    queue.push(update)
+  }
+
+  writeQueue(queue)
+}
+
+export async function syncQueuedProgress(): Promise<number> {
+  const queue = readQueue()
+  if (queue.length === 0) return 0
+
+  if (!isOnline()) return 0
+
+  let synced = 0
+  const failed: QueuedProgressUpdate[] = []
+
+  for (const item of queue) {
+    try {
+      const baseUrl =
+        typeof window !== "undefined"
+          ? window.location.origin
+          : process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+
+      const res = await fetch(
+        `${baseUrl}/api/v1/hunts/${item.huntId}/progress`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            wallet: item.wallet,
+            currentClueIndex: item.currentClueIndex,
+            totalClues: item.totalClues,
+            totalPoints: item.totalPoints,
+            completedClueIds: item.completedClueIds,
+            completed: item.completed,
+          }),
+        },
+      )
+
+      if (res.ok) {
+        synced++
+      } else {
+        failed.push(item)
+      }
+    } catch {
+      failed.push(item)
+    }
+  }
+
+  writeQueue(failed)
+  return synced
+}
+
+export function getQueuedCount(): number {
+  return readQueue().length
+}
+
+export function clearQueue(): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.removeItem(QUEUE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+export function setupOnlineSync(): () => void {
+  const handler = () => {
+    syncQueuedProgress().then((count) => {
+      if (count > 0) {
+        logger.info(`[OfflineSync] Synced ${count} progress updates`)
+      }
+    })
+  }
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("online", handler)
+  }
+
+  return () => {
+    if (typeof window !== "undefined") {
+      window.removeEventListener("online", handler)
+    }
+  }
+}

--- a/apps/web/lib/progressData.ts
+++ b/apps/web/lib/progressData.ts
@@ -1,0 +1,154 @@
+import * as fs from "fs"
+import * as path from "path"
+
+import { logger } from "@/lib/logger"
+
+const DATA_DIR = path.join(process.cwd(), "lib", "progress-data")
+const PROGRESS_FILE = path.join(DATA_DIR, "progress.json")
+
+export interface StoredProgressEntry {
+  huntId: number
+  wallet: string
+  currentClueIndex: number
+  totalClues: number
+  totalPoints: number
+  completed: boolean
+  completedAt: number | null
+  startedAt: number
+  lastUpdated: number
+  completedClueIds: number[]
+}
+
+interface ProgressStore {
+  entries: StoredProgressEntry[]
+}
+
+function readStore(): ProgressStore {
+  try {
+    const dir = path.dirname(PROGRESS_FILE)
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
+    if (!fs.existsSync(PROGRESS_FILE)) {
+      return { entries: [] }
+    }
+    const raw = fs.readFileSync(PROGRESS_FILE, "utf-8")
+    return JSON.parse(raw)
+  } catch (err) {
+    logger.error("Failed to read progress data:", err)
+    return { entries: [] }
+  }
+}
+
+function writeStore(store: ProgressStore): void {
+  try {
+    const dir = path.dirname(PROGRESS_FILE)
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
+    fs.writeFileSync(PROGRESS_FILE, JSON.stringify(store, null, 2), "utf-8")
+  } catch (err) {
+    logger.error("Failed to write progress data:", err)
+  }
+}
+
+function entryKey(huntId: number, wallet: string): string {
+  return `${huntId}:${wallet}`
+}
+
+export function savePlayerProgress(
+  huntId: number,
+  wallet: string,
+  currentClueIndex: number,
+  totalClues: number,
+  totalPoints: number,
+  completedClueIds: number[],
+  completed: boolean,
+): StoredProgressEntry {
+  const store = readStore()
+  const key = entryKey(huntId, wallet)
+  const existing = store.entries.find(
+    (e) => e.huntId === huntId && e.wallet === wallet,
+  )
+
+  const now = Date.now()
+  const entry: StoredProgressEntry = existing ?? {
+    huntId,
+    wallet,
+    currentClueIndex: 0,
+    totalClues,
+    totalPoints: 0,
+    completed: false,
+    completedAt: null,
+    startedAt: now,
+    lastUpdated: now,
+    completedClueIds: [],
+  }
+
+  entry.currentClueIndex = Math.max(entry.currentClueIndex, currentClueIndex)
+  entry.totalPoints = Math.max(entry.totalPoints, totalPoints)
+  entry.lastUpdated = now
+  entry.totalClues = totalClues
+
+  for (const id of completedClueIds) {
+    if (!entry.completedClueIds.includes(id)) {
+      entry.completedClueIds.push(id)
+    }
+  }
+
+  if (completed && !entry.completed) {
+    entry.completed = true
+    entry.completedAt = now
+  }
+
+  if (!existing) {
+    store.entries.push(entry)
+  }
+
+  writeStore(store)
+  return entry
+}
+
+export function getPlayerProgress(
+  huntId: number,
+  wallet: string,
+): StoredProgressEntry | null {
+  const store = readStore()
+  return (
+    store.entries.find(
+      (e) => e.huntId === huntId && e.wallet === wallet,
+    ) ?? null
+  )
+}
+
+export function getAllProgressForHunt(
+  huntId: number,
+): StoredProgressEntry[] {
+  const store = readStore()
+  return store.entries.filter((e) => e.huntId === huntId)
+}
+
+export function getActivePlayersForHunt(
+  huntId: number,
+): StoredProgressEntry[] {
+  const store = readStore()
+  return store.entries.filter(
+    (e) => e.huntId === huntId && !e.completed,
+  )
+}
+
+export function getCompletedPlayersForHunt(
+  huntId: number,
+): StoredProgressEntry[] {
+  const store = readStore()
+  return store.entries.filter(
+    (e) => e.huntId === huntId && e.completed,
+  )
+}
+
+export function getAllPlayerProgress(
+  wallet: string,
+): StoredProgressEntry[] {
+  const store = readStore()
+  return store.entries.filter((e) => e.wallet === wallet)
+}


### PR DESCRIPTION
- Add server-side progress storage (JSON file-based, same pattern as anti-cheat)
- Add POST /api/v1/hunts/:id/progress — save progress on clue completion
- Add GET /api/v1/hunts/:id/progress — resume progress from last completed clue
- Add GET /api/v1/hunts/:id/players — creator view of active player progress
- Update leaderboard API to use real progress data instead of mock data
- Update submitAnswer to save progress to server and queue for offline sync
- Add offline sync queue with online listener for automatic sync
- Update getPlayerProgress to fetch from server first with localStorage fallback
- Fix pre-existing actualPoints variable bug in HuntCards
- closed #593