### PR TITLE
feat: add hunt participant caps

### DIFF
--- a/apps/web/app/hunt/[id]/share.tsx
+++ b/apps/web/app/hunt/[id]/share.tsx
@@ -40,6 +40,7 @@ import {
   updateHuntStatus,
   validateHuntInvite,
 } from "@/lib/huntStore";
+import { getHuntCapacity, getRemainingSpots } from "@/lib/huntStore";
 import { REGISTRATION_STATUS_DEBOUNCE_MS } from "@/lib/soroban/queryConfig";
 import { withTransactionToast } from "@/lib/txToast";
 import type {
@@ -75,7 +76,8 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
 
   // Get current players (using stored hunt's playerCount, defaulting to 0)
   const currentPlayers = hunt.playerCount ?? 0;
-  const maxCapacity = hunt.maxCapacity;
+  const maxCapacity = getHuntCapacity(hunt);
+  const remainingSpots = getRemainingSpots(hunt);
 
   useEffect(() => {
     if (searchParams.get("reattempt") !== "1" || !connectedPublicKey) return;
@@ -298,13 +300,18 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
                 currentPlayers={currentPlayers}
               />
               {/* Waitlist/Spot Display */}
-              {maxCapacity && (
+              {maxCapacity !== undefined && (
                 <WaitlistDisplay
                   huntId={hunt.id}
                   currentPlayers={currentPlayers}
                   maxCapacity={maxCapacity}
                   playerAddress={connectedPublicKey}
                 />
+              )}
+              {maxCapacity !== undefined && remainingSpots !== undefined && (
+                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                  {remainingSpots} of {maxCapacity} spots left
+                </div>
               )}
             </div>
           ) : (
@@ -491,7 +498,6 @@ export default function HuntShare({ hunt }: HuntDetailProps) {
     </div>
   );
 }
-
 
 
 

--- a/apps/web/app/hunty/page.tsx
+++ b/apps/web/app/hunty/page.tsx
@@ -392,7 +392,7 @@ const huntItemSchema = z.object({
     setRewards(rewards.filter((reward) => reward.place !== place));
   };
 
-  const updateHunt = (id: number, field: string, value: string) => {
+  const updateHunt = (id: number, field: string, value: string | number | undefined) => {
     setHunts(
       hunts.map((hunt) =>
         hunt.id === id ? { ...hunt, [field]: value } : hunt,
@@ -510,6 +510,7 @@ const huntItemSchema = z.object({
         emailNotifications: formValues.emailNotifications,
         is_private: formValues.isPrivate,
         sequential: formValues.sequential,
+        maxParticipants: formValues.hunts[0]?.maxParticipants,
         coverImageCid,
         category,
         tags,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -17,6 +17,7 @@ import { HuntCardSkeletonGrid } from "@/components/LoadingSkeletons"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Header } from "@/components/Header"
 import { getAllHunts, getHunt, type StoredHunt } from "@/lib/huntStore"
+import { getHuntCapacity, getRemainingSpots } from "@/lib/huntStore"
 import { LeaderboardTable } from "@/components/LeaderBoardTable"
 import { EmptyState } from "@/components/EmptyState"
 import { HuntOfTheWeekBanner } from "@/components/HuntOfTheWeekBanner"
@@ -162,6 +163,11 @@ function ActiveHuntCard({
                 aria-label={`${playerCount.count} player${playerCount.count !== 1 ? "s" : ""} registered`}
               >
                 {playerCount.count} player{playerCount.count !== 1 ? "s" : ""}
+              </span>
+            )}
+            {getHuntCapacity(hunt) !== undefined && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-medium text-indigo-700">
+                {getRemainingSpots(hunt)} of {getHuntCapacity(hunt)} spots left
               </span>
             )}
           </div>

--- a/apps/web/components/HuntForm.tsx
+++ b/apps/web/components/HuntForm.tsx
@@ -35,7 +35,7 @@ import ToggleSwitch from "./ToggleButton"
 
 interface HuntFormProps {
   hunt: HuntDraft
-  onUpdate: (field: string, value: string) => void
+  onUpdate: (field: string, value: string | number | undefined) => void
   onRemove: () => void
   huntId?: number
   onCluesSaved?: (count: number) => void
@@ -289,6 +289,18 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
           aria-label="Hunt Description"
           value={hunt.description}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onUpdate("description", e.target.value)}
+          className="w-full pl-6 py-3"
+        />
+        <Input
+          type="number"
+          min={1}
+          placeholder="Optional participant cap"
+          aria-label="Participant cap"
+          value={hunt.maxParticipants ?? ""}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            const raw = e.target.value.trim()
+            onUpdate("maxParticipants", raw === "" ? undefined : Number(raw))
+          }}
           className="w-full pl-6 py-3"
         />
         <div className="relative">
@@ -559,4 +571,3 @@ export function HuntForm({ hunt, onUpdate, onRemove, huntId, onCluesSaved, onIma
     </div>
   )
 }
-

--- a/apps/web/components/RegistrationButton.tsx
+++ b/apps/web/components/RegistrationButton.tsx
@@ -33,6 +33,10 @@ export function RegistrationButton({
   const [retryCount, setRetryCount] = useState(0);
 
   const isHuntFull = maxCapacity !== undefined && currentPlayers !== undefined && currentPlayers >= maxCapacity;
+  const capacityCopy =
+    maxCapacity !== undefined && currentPlayers !== undefined
+      ? `${Math.max(0, maxCapacity - currentPlayers)} of ${maxCapacity} spots left`
+      : null;
 
   const handleRegister = async () => {
     setIsRegistering(true);
@@ -151,6 +155,9 @@ export function RegistrationButton({
             </>
           )}
         </button>
+      )}
+      {capacityCopy && (
+        <p className="text-center text-xs text-slate-500 dark:text-slate-400">{capacityCopy}</p>
       )}
 
       {/* Success message */}

--- a/apps/web/lib/contracts/errors.ts
+++ b/apps/web/lib/contracts/errors.ts
@@ -121,6 +121,7 @@ const ERROR_MESSAGE_MAP: Record<string, string> = {
     "This clue is locked. Solve the previous clue first.",
   CONTRACT_HUNT_NOT_ACTIVE: "This hunt is not currently active.",
   CONTRACT_HUNT_EXPIRED: "This hunt has expired.",
+  CONTRACT_HUNT_FULL: "This hunt has reached its participant cap.",
 
   // Registration-specific errors
   INVALID_HUNT_ID: "Invalid hunt ID. Please check the hunt and try again.",

--- a/apps/web/lib/contracts/hunt.ts
+++ b/apps/web/lib/contracts/hunt.ts
@@ -73,7 +73,8 @@ export async function createHunt(
   emailNotifications?: boolean,
   /** When true, the hunt is hidden from the public arcade. */
   is_private?: boolean,
-  sequential?: boolean
+  sequential?: boolean,
+  maxParticipants?: number
 ): Promise<CreateHuntResult> {
   if (typeof window === "undefined")
     throw new Error("Browser environment required");
@@ -96,6 +97,7 @@ export async function createHunt(
       : {}),
     ...(is_private ? { is_private: true } : {}),
     ...(sequential ? { sequential: true } : {}),
+    ...(maxParticipants !== undefined ? { max_participants: maxParticipants } : {}),
   })
 
   const publicKey = await wallet.getPublicKey();

--- a/apps/web/lib/contracts/player-registration.ts
+++ b/apps/web/lib/contracts/player-registration.ts
@@ -1,7 +1,7 @@
 import Server, { Operation,TransactionBuilder } from "@stellar/stellar-sdk"
 
 import { RegistrationError } from "@/lib/contracts/errors"
-import { advanceHuntProgress, getHuntProgress } from "@/lib/huntStore"
+import { advanceHuntProgress, getHuntById, getHuntCapacity, getHuntProgress, getRegisteredWallets } from "@/lib/huntStore"
 import type { PlayerProgress, RegistrationResult,RegistrationStatus } from "@/lib/types"
 
 import { withSorobanRpcRetry } from "../soroban/rpcRetry"
@@ -33,6 +33,7 @@ const NON_RETRYABLE_ERROR_CODES = [
   "WALLET_NOT_CONNECTED",
   "WALLET_SIGNING_FAILED",
   "ADDRESS_MISMATCH",
+  "CONTRACT_HUNT_FULL",
 ]
 
 class NonRetryableRegistrationError extends Error {
@@ -512,6 +513,21 @@ export async function registerPlayer(
     // Validate inputs first
     validateHuntId(huntId)
     validatePlayerAddress(playerAddress)
+
+    const hunt = getHuntById(huntId)
+    const capacity = getHuntCapacity(hunt)
+    if (capacity !== undefined) {
+      const registered = new Set(getRegisteredWallets(huntId))
+      if (!registered.has(playerAddress)) {
+        const currentPlayers = hunt?.playerCount ?? registered.size
+        if (currentPlayers >= capacity) {
+          throw new RegistrationError(
+            `This hunt is full. ${capacity} participant${capacity === 1 ? "" : "s"} max.`,
+            "CONTRACT_HUNT_FULL",
+          )
+        }
+      }
+    }
 
     // Check wallet availability
     if (!isWalletAvailable()) {

--- a/apps/web/lib/huntStore.ts
+++ b/apps/web/lib/huntStore.ts
@@ -291,6 +291,21 @@ function getExistingClueCount(huntId: number): number {
   return getHuntClues(huntId).length;
 }
 
+export function getHuntCapacity(
+  hunt: Pick<StoredHunt, "maxParticipants" | "maxCapacity"> | undefined,
+): number | undefined {
+  if (!hunt) return undefined;
+  return hunt.maxParticipants ?? hunt.maxCapacity;
+}
+
+export function getRemainingSpots(
+  hunt: Pick<StoredHunt, "playerCount" | "maxParticipants" | "maxCapacity"> | undefined,
+): number | undefined {
+  const capacity = getHuntCapacity(hunt);
+  if (capacity === undefined) return undefined;
+  return Math.max(0, capacity - (hunt?.playerCount ?? 0));
+}
+
 /** All hunts (for Game Arcade: filter by status === "Active"). Private, archived, and soft-deleted hunts are excluded. */
 export function getAllHunts(): StoredHunt[] {
   return getHuntsWithRatings(readHunts().filter((h) => !h.is_private));
@@ -667,6 +682,7 @@ export function addHunt(hunt: StoredHunt): void {
   if (hunts.some((h) => h.id === hunt.id)) return;
   const normalized = {
     ...hunt,
+    maxParticipants: hunt.maxParticipants ?? hunt.maxCapacity,
     status: normalizeHuntStatus(hunt.status) as StoredHunt["status"],
   };
   writeHunts([...hunts, normalized]);
@@ -905,7 +921,7 @@ export function duplicateHunt(huntId: number): StoredHunt | undefined {
     rewardEscrowTxHash: undefined,
     rewardEscrowBalance: undefined,
     playerCount: 0,
-    maxCapacity: original.maxCapacity,
+    maxParticipants: original.maxParticipants ?? original.maxCapacity,
     createdAt: nowSeconds,
     startTime: undefined,
     endTime: undefined,

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -85,6 +85,8 @@ export interface StoredHunt {
   /** Creator-side participant count snapshot for dashboard sorting. */
   playerCount?: number;
   /** Max number of participants for limited spots. */
+  maxParticipants?: number;
+  /** @deprecated Use `maxParticipants`. Kept for older stored hunts. */
   maxCapacity?: number;
   /** Unix timestamp in seconds when the hunt draft was created locally. */
   createdAt?: number;
@@ -447,6 +449,7 @@ export interface HuntDraft {
   code: string;
   image?: string;
   sequential?: boolean;
+  maxParticipants?: number;
 }
 
 /**

--- a/apps/web/lib/waitlist/service.ts
+++ b/apps/web/lib/waitlist/service.ts
@@ -1,4 +1,4 @@
-import { getHuntById } from "@/lib/huntStore"
+import { getHuntById, getHuntCapacity } from "@/lib/huntStore"
 import type { WaitlistEntry } from "@/lib/types"
 
 const WAITLIST_STORAGE_KEY = "hunty_waitlist"
@@ -70,8 +70,9 @@ export function popFromWaitlist(huntId: number): WaitlistEntry | null {
 
 export function isHuntFull(huntId: number, currentPlayers: number): boolean {
   const hunt = getHuntById(huntId)
-  if (!hunt || !hunt.maxCapacity) return false
-  return currentPlayers >= hunt.maxCapacity
+  const capacity = getHuntCapacity(hunt)
+  if (!hunt || capacity === undefined) return false
+  return currentPlayers >= capacity
 }
 
 export function markWaitlistEntryNotified(entryId: string): void {

--- a/packages/types/src/hunt.ts
+++ b/packages/types/src/hunt.ts
@@ -46,7 +46,9 @@ export interface StoredHunt {
   rewardEscrowBalance?: number;
   /** Creator-side participant count snapshot for dashboard sorting. */
   playerCount?: number;
-  /** Max number of participants for limited spots */
+  /** Max number of participants for limited spots. */
+  maxParticipants?: number;
+  /** @deprecated Use `maxParticipants`. */
   maxCapacity?: number;
   /** Unix timestamp in seconds when the hunt draft was created locally. */
   createdAt?: number;
@@ -89,4 +91,5 @@ export interface HuntDraft {
   code: string;
   image?: string;
   sequential?: boolean;
+  maxParticipants?: number;
 }

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -56,6 +56,7 @@ export const storedHuntSchema = z.object({
   rewardEscrowTxHash: z.string().optional(),
   rewardEscrowBalance: z.number().optional(),
   playerCount: z.number().optional(),
+  maxParticipants: z.number().optional(),
   maxCapacity: z.number().optional(),
   createdAt: z.number().optional(),
   startTime: z.number().optional(),


### PR DESCRIPTION
## Summary #292 

This PR adds support for an optional participant cap on hunts so creators can limit registration to a fixed number of players.

I implemented the feature across the web app and shared hunt types, with backward-compatible support for existing hunts that still use `maxCapacity`.

## What changed

- Added `maxParticipants` to the shared hunt model in `packages/types`
- Kept `maxCapacity` as a deprecated compatibility alias for older stored hunts
- Added a participant cap field to `HuntForm`
- Persisted the cap when publishing a hunt
- Passed the cap through the hunt creation contract payload
- Displayed remaining spots on hunt cards in the public arcade
- Displayed remaining spots on the hunt play page
- Blocked new registrations once the cap is reached
- Added a dedicated full-capacity error message
- Updated waitlist logic to respect the new cap field

## Behavior

- Creators can now set an optional participant cap when creating a hunt
- Players see remaining spots as a badge/copy like `3 of 20 spots left`
- When the cap is reached, the registration flow stops the user from joining normally and routes them to the waitlist UI
- Existing hunts that only have `maxCapacity` continue to work

## Important limitation

I could not make the on-chain Soroban contract change in this workspace because the contract source is not present here.

That means:
- The frontend and shared types are updated
- Registration is blocked in the app layer
- True contract-level enforcement still needs to be added in the actual contract repo/source

## Files touched

- `packages/types/src/hunt.ts`
- `packages/types/src/schemas.ts`
- `apps/web/lib/types.ts`
- `apps/web/lib/huntStore.ts`
- `apps/web/lib/contracts/hunt.ts`
- `apps/web/lib/contracts/player-registration.ts`
- `apps/web/lib/contracts/errors.ts`
- `apps/web/lib/waitlist/service.ts`
- `apps/web/components/HuntForm.tsx`
- `apps/web/components/RegistrationButton.tsx`
- `apps/web/app/hunty/page.tsx`
- `apps/web/app/page.tsx`
- `apps/web/app/hunt/[id]/share.tsx`

## Testing

I attempted to run TypeScript verification, but the workspace is currently blocked by local environment/package resolution issues, so I could not complete a clean typecheck in this environment.

## Follow-up needed

To make this fully match the original issue, the Soroban contract repo needs a matching `maxParticipants` field and on-chain enforcement in the registration/create flow.