### PR TITLE
docs: update root README to describe Turborepo monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,49 @@ Hunty is a cross-platform scavenger-hunt platform and dApp that combines web, mo
 
 ## Repository Structure
 
-- `app/` — Next.js app router routes and pages for the web UI
-- `components/` — Reusable React components and UI patterns
-- `lib/` — Core utilities, blockchain adapters, stores, and helpers
-- `mobile/` — Expo React Native mobile app and mobile-specific assets
-- `public/` — Static assets served by the web app
-- `e2e/` — End-to-end Playwright tests
-- `components/__tests__/`, `lib/__tests__/` — Unit tests
+This is a [Turborepo](https://turbo.build/) monorepo. Shared code lives in `packages/`, deployable apps live in `apps/`.
+
+```
+hunty/
+├── apps/
+│   ├── web/          # Next.js 15 App Router web application
+│   └── mobile/       # Expo React Native mobile app
+├── packages/
+│   ├── types/        # Shared TypeScript domain types and Zod schemas
+│   ├── ui/           # Shared UI component library (web + native)
+│   └── config/       # Shared ESLint, TypeScript, and Tailwind configs
+├── turbo.json        # Turborepo task pipeline
+└── package.json      # Root workspace config and scripts
+```
+
+### Workspaces
+
+| Package | Name | Description |
+|---------|------|-------------|
+| [`apps/web`](./apps/web) | `@hunty/web` | Web app — Next.js 15 App Router with creator dashboard, hunt play, NFT minting, leaderboards, and Stellar wallet integration. |
+| [`apps/mobile`](./apps/mobile) | `mobile` | Mobile app — Expo React Native with camera, location, notifications, maps, and WalletConnect support. |
+| [`packages/types`](./packages/types) | `@hunty/types` | Shared domain types, Zod validation schemas, and TypeScript type guards used by both apps. |
+| [`packages/ui`](./packages/ui) | `@hunty/ui` | Cross-platform component library exporting `web`, `native`, and shared `tokens` entry points. |
+| [`packages/config`](./packages/config) | `@hunty/config` | Centralized ESLint, TypeScript, and Tailwind CSS configurations consumed by all workspaces. |
+
+### Dependency direction
+
+```
+types  ←  ui  ←  web
+types           ←  mobile
+config  ←  (all workspaces)
+```
+
+- `@hunty/types` is the leaf — no internal dependencies.
+- `@hunty/ui` depends on `@hunty/types`.
+- `@hunty/web` depends on `@hunty/types`, `@hunty/ui`, and `@hunty/config`.
+- `@hunty/config` is consumed as a devDependency by all workspaces for shared tooling config.
 
 ## Getting Started
 
 ### Prerequisites
 
-- Node.js 18+ and pnpm
+- **Node.js 18+** and **pnpm 9+** (this repo uses pnpm workspaces)
 - Git
 - For blockchain features: Stellar wallet (e.g., Freighter)
 - For file uploads: Pinata account ([Get API key](https://pinata.cloud))
@@ -61,7 +91,7 @@ git clone https://github.com/Samuel1-ona/hunty.git
 cd hunty
 ```
 
-2. Install dependencies at the root:
+2. Install all workspace dependencies from the root:
 
 ```bash
 pnpm install
@@ -70,58 +100,39 @@ pnpm install
 3. Set up environment variables:
 
 ```bash
-# Copy the example environment file
 cp .env.example .env.local
 ```
 
 Open `.env.local` and configure your environment variables. See `.env.example` for detailed documentation of all available options. Key variables include:
 
-- **PINATA_JWT** - Required for IPFS file uploads
-- **RESEND_API_KEY** - Required for email notifications  
-- **NEXT_PUBLIC_WC_PROJECT_ID** - Required for WalletConnect support
-- **DATABASE_URL** - PostgreSQL connection string
-- **Contract addresses** - Your deployed Soroban smart contract addresses
+- **PINATA_JWT** — Required for IPFS file uploads
+- **RESEND_API_KEY** — Required for email notifications
+- **NEXT_PUBLIC_WC_PROJECT_ID** — Required for WalletConnect support
+- **DATABASE_URL** — PostgreSQL connection string
+- **Contract addresses** — Your deployed Soroban smart contract addresses
 
 For detailed setup instructions, see [DEVELOPMENT.md](./DEVELOPMENT.md).
 
-4. Run the web app in development:
+4. Run all apps in development:
 
 ```bash
 pnpm dev
 ```
 
-The app will be available at `http://localhost:3000`.
+This uses Turborepo to run `dev` in every workspace concurrently. The web app is available at `http://localhost:3000`.
 
-5. Start the mobile app from `mobile/`:
-
-```bash
-cd mobile
-pnpm install
-expo start
-```
-
-6. Mobile EAS Build & OTA setup:
+5. Start only the mobile app:
 
 ```bash
-cd mobile
-pnpm run build:android:dev
-pnpm run build:ios:preview
-pnpm run update:preview
-```
-
-5. Configure reminder emails (optional but recommended for scheduled start reminders):
-
-```bash
-export RESEND_API_KEY=your_api_key
+pnpm --filter mobile start
 ```
 
 6. Run tests:
-7. Run tests:
 
 ```bash
-pnpm test
+pnpm test            # unit tests across all workspaces
 pnpm run test:coverage
-pnpm run e2e
+pnpm run e2e          # Playwright E2E (web only)
 ```
 
 The local coverage command writes an HTML report to `coverage/index.html`.
@@ -132,7 +143,7 @@ Creators can now define a hunt start and end time in their local timezone. The a
 
 ## Docker development
 
-This repository includes a local Docker development environment for the web app and a PostgreSQL database container.
+The web app includes a local Docker development environment with a PostgreSQL database container.
 
 1. Build and start the development stack:
 
@@ -140,11 +151,7 @@ This repository includes a local Docker development environment for the web app 
 docker compose up --build
 ```
 
-2. Open the web app at:
-
-```bash
-http://localhost:3000
-```
+2. Open the web app at `http://localhost:3000`.
 
 3. PostgreSQL is available at `localhost:5432` with:
 
@@ -160,11 +167,35 @@ http://localhost:3000
 docker compose down
 ```
 
+## Root scripts
+
+All root scripts delegate to [Turborepo](https://turbo.build/) and run across every workspace:
+
+| Command | Description |
+|---------|-------------|
+| `pnpm dev` | Start all apps in development mode (no cache, persistent) |
+| `pnpm build` | Production build of all workspaces (respects `^build` dependency graph) |
+| `pnpm start` | Start built apps |
+| `pnpm lint` | Lint all workspaces |
+| `pnpm typecheck` | Run TypeScript type-checking across all workspaces |
+| `pnpm test` | Run unit tests across all workspaces |
+| `pnpm run test:coverage` | Run tests with coverage output |
+| `pnpm clean` | Remove build artifacts (`.next/`, `dist/`, etc.) |
+
+Run a command in a single workspace with `--filter`:
+
+```bash
+pnpm --filter @hunty/web build
+pnpm --filter mobile test
+```
+
+See [turbo.json](./turbo.json) for the full task pipeline configuration.
+
 ## Notes
 
-- This project prefers `pnpm`; a `pnpm-lock.yaml` is included.
+- This project is managed with **pnpm workspaces** and **Turborepo**; the lockfile is `pnpm-lock.yaml`.
 - On-chain reward flows require wallet integrations and a local or testnet Stellar environment.
-- See `lib/walletAdapter.ts` and `lib/stellarErrors.ts` for wallet helpers and common error handling.
+- The `@hunty/types` and `@hunty/ui` packages use `workspace:*` protocol so local changes propagate immediately during development.
 
 ## Roadmap
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,60 @@
+# mobile
+
+The **Hunty** React Native / Expo mobile app. It uses Expo SDK 55, Expo Router
+for file-based navigation, and connects to the Stellar blockchain via
+`@stellar/stellar-sdk` and WalletConnect.
+
+## Scripts
+
+### Development
+
+| Script | Description |
+| --- | --- |
+| `start` | Start the Expo dev server |
+| `android` | Start and open on Android emulator |
+| `ios` | Start and open on iOS simulator |
+| `web` | Start and open in a web browser |
+
+### Code quality
+
+| Script | Description |
+| --- | --- |
+| `lint` | ESLint for `.js/.jsx/.ts/.tsx` |
+| `lint:fix` | ESLint with auto-fix |
+| `format` | Prettier write |
+| `format:check` | Prettier check (CI) |
+| `test` | Jest (passes with no tests) |
+
+### Store & assets
+
+| Script | Description |
+| --- | --- |
+| `store:validate` | Validate App Store / Play Store metadata |
+| `store:generate` | Generate store listing assets |
+
+### E2E
+
+| Script | Description |
+| --- | --- |
+| `test:e2e` | Run Maestro E2E flows |
+| `test:e2e:validate` | Validate Maestro baseline screenshots |
+
+### EAS Build / Submit / Update
+
+| Script | Description |
+| --- | --- |
+| `build:android` / `build:ios` / `build:all` | EAS production builds |
+| `build:*:dev` / `build:*:preview` | Development & preview builds |
+| `submit:*` | Submit builds to app stores |
+| `update:development` / `update:preview` / `update:production` | OTA updates |
+
+## Key dependencies
+
+- **`expo` ~55** — Expo SDK (camera, location, notifications, secure-store, …)
+- **`expo-router`** — file-based routing
+- **`@stellar/stellar-sdk`** — Stellar blockchain client
+- **`@walletconnect/*`** — WalletConnect v2 for mobile wallet connection
+- **`@tanstack/react-query`** — server-state caching
+- **`zustand`** — lightweight state management
+- **`nativewind`** — Tailwind CSS for React Native
+- **`@sentry/react-native`** — error tracking

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,37 @@
+# @hunty/web
+
+The **Hunty** web application — a Next.js 15 App Router app built with React 19,
+Tailwind CSS v4, and Zustand for client state. It connects to the Stellar
+blockchain via the Stellar SDK and Freighter wallet extension.
+
+## Scripts
+
+| Script | Description |
+| --- | --- |
+| `dev` | Start the Next.js dev server |
+| `build` | Production build |
+| `analyze` | Build with `ANALYZE=true` for bundle analysis |
+| `bundle:check` | Check bundle sizes against budgets |
+| `start` | Start the production server |
+| `lint` | Run Next.js ESLint |
+| `typecheck` | Run TypeScript in `--noEmit` mode |
+| `test` | Run Vitest (single run) |
+| `test:watch` | Run Vitest in watch mode |
+| `test:coverage` | Run Vitest with v8 coverage |
+| `e2e` | Run Playwright end-to-end tests |
+| `smoke` | Run Playwright smoke suite |
+| `test:e2e:ui` | Open Playwright interactive UI |
+| `perf:budget` | Check performance budgets |
+| `clean` | Remove `.next` build cache |
+
+## Key dependencies
+
+- **`@hunty/types`** / **`@hunty/ui`** — shared workspace packages for domain
+  types and UI components.
+- **`@stellar/stellar-sdk`** / **`@stellar/freighter-api`** — Stellar blockchain
+  integration and browser wallet connection.
+- **`@tanstack/react-query`** — server-state caching and data fetching.
+- **`next-intl`** — internationalization.
+- **`next-themes`** — dark/light theme switching.
+- **`zod`** — runtime schema validation.
+- **`zustand`** — lightweight client-side state management.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,49 @@
+# @hunty/config
+
+Shared ESLint, TypeScript, and Tailwind CSS configurations for the Hunty
+monorepo. Each workspace imports only the configs it needs via the seven export
+paths below.
+
+## Export paths
+
+### ESLint
+
+| Import | File | Description |
+| --- | --- | --- |
+| `@hunty/config/eslint/base` | `eslint/base.mjs` | Base ESLint rules for all packages |
+| `@hunty/config/eslint/next` | `eslint/next.mjs` | Next.js-specific rules (apps/web) |
+| `@hunty/config/eslint/react-native` | `eslint/react-native.mjs` | React Native rules (apps/mobile) |
+
+### TypeScript
+
+| Import | File | Description |
+| --- | --- | --- |
+| `@hunty/config/tsconfig/base.json` | `tsconfig/base.json` | Base TS config for all packages |
+| `@hunty/config/tsconfig/nextjs.json` | `tsconfig/nextjs.json` | Next.js TS config (apps/web) |
+| `@hunty/config/tsconfig/react-native.json` | `tsconfig/react-native.json` | React Native TS config (apps/mobile) |
+
+### Tailwind
+
+| Import | File | Description |
+| --- | --- | --- |
+| `@hunty/config/tailwind` | `tailwind/index.js` | Shared Tailwind CSS preset |
+
+## Usage
+
+Each workspace extends the configs it needs:
+
+```jsonc
+// tsconfig.json
+{ "extends": "@hunty/config/tsconfig/nextjs.json" }
+```
+
+```js
+// eslint.config.mjs
+import base from "@hunty/config/eslint/next"
+export default base
+```
+
+## Scripts
+
+This package has no scripts — it is a configuration-only package consumed by
+other workspaces.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,62 @@
+# @hunty/ui
+
+Shared UI component library for the Hunty monorepo. Provides **platform-agnostic
+design tokens**, **web (React / Next.js) components**, and **native (React Native
+/ Expo) type exports** — all from one package.
+
+## Export paths
+
+| Import | Source | Description |
+| --- | --- | --- |
+| `@hunty/ui` | `src/index.ts` | Design tokens + web components (default) |
+| `@hunty/ui/tokens` | `src/tokens/index.ts` | Colors, typography, spacing (platform-agnostic) |
+| `@hunty/ui/web` | `src/web/index.ts` | React / Next.js components |
+| `@hunty/ui/native` | `src/native/index.ts` | React Native type exports only |
+
+### `@hunty/ui/tokens`
+
+Design tokens shared between web and native, kept in sync with the CSS custom
+properties in `apps/web/app/globals.css`:
+
+- **colors** — palette, semantic colors
+- **typography** — font families, sizes, weights
+- **spacing** — spacing scale
+
+### `@hunty/ui/web`
+
+React components imported directly or from the root:
+
+```tsx
+import { Button, Card, Badge, EmptyState } from "@hunty/ui/web"
+// or
+import { Button } from "@hunty/ui"
+```
+
+Components: `Button`, `Card` (plus `CardHeader`, `CardTitle`, `CardDescription`,
+`CardContent`, `CardFooter`), `Badge`, `EmptyState`.
+
+### `@hunty/ui/native`
+
+Exports **types only** (`ButtonProps`, `CardProps`, `BadgeProps`,
+`EmptyStateProps`) so consumers can type-check without pulling React Native
+dependencies into web builds. Actual native component implementations live in
+`apps/mobile/components`.
+
+```ts
+import type { ButtonProps } from "@hunty/ui/native"
+```
+
+## Scripts
+
+| Script | Description |
+| --- | --- |
+| `typecheck` | Run TypeScript in `--noEmit` mode |
+| `lint` | ESLint (zero warnings) |
+| `test` | Run Vitest |
+
+## Dependencies
+
+- **`@hunty/types`** — shared domain types consumed by native type re-exports
+- **`react`** / **`react-dom`** — peer dependencies (≥18)
+- **`class-variance-authority`** / **`clsx`** / **`tailwind-merge`** — utility
+  classes for component styling


### PR DESCRIPTION
## Summary

Updates the root  to document the Turborepo monorepo structure, replacing the old flat-layout description.

### Changes

- **Repository Structure** — Added tree diagram showing  and  layout, workspace table with descriptions, and dependency direction diagram
- **Getting Started** — Updated prerequisites to specify pnpm 9+, simplified install steps to reflect monorepo commands (Scope: all 6 workspace projects
[WARN] Ignoring broken lockfile at /private/tmp/hunty: The lockfile at "/private/tmp/hunty/pnpm-lock.yaml" is broken: duplicated mapping key (147:9)

 144 |       '@storybook/addon-docs':
 145 |         specifier: ^10.4.6
 146 |         version: 10.4.6(@types/react-do ...
 147 |         version: 10.4.6(@types/react-do ...
---------------^
 148 |       '@storybook/addon-mcp':
 149 |         specifier: ^0.6.0
Progress: resolved 1, reused 0, downloaded 0, added 0
[WARN] deprecated @testing-library/jest-dom@6.10.0: Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.
[WARN] GET https://registry.npmjs.org/@radix-ui%2Freact-tooltip error (ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC). Will retry in 10 seconds. 2 retries left.
Progress: resolved 27, reused 5, downloaded 0, added 0
[WARN] deprecated next@15.3.4: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
[WARN] deprecated supertest@6.3.4: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
Progress: resolved 55, reused 8, downloaded 18, added 0
apps/mobile                              | [WARN] deprecated @testing-library/react-native@12.9.0
[WARN] deprecated soroban-client@0.11.2: ⚠️ This package is now deprecated: transition to @stellar/stellar-sdk@latest, instead! 🚚 All future updates and bug fixes will happen there. Please refer to the migration guide for details on porting your codebase: https://github.com/stellar/js-soroban-client/tree/main/docs/migration.md
Progress: resolved 84, reused 13, downloaded 32, added 0
[WARN] GET https://registry.npmjs.org/@types/serviceworker/-/serviceworker-0.0.197.tgz error (UND_ERR_SOCKET). Will retry in 10 seconds. 2 retries left.
Progress: resolved 90, reused 13, downloaded 45, added 0
Progress: resolved 97, reused 14, downloaded 50, added 0
/private/tmp/hunty/apps/mobile:
[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for eas-cli@^3.74.0 while fetching it from https://registry.npmjs.org/

This error happened while installing a direct dependency of /private/tmp/hunty/apps/mobile

The latest release of eas-cli is "21.2.0".

Other releases are:
  * alpha: 0.16.1-alpha.0
  * next: 7.1.0
  * latest-eas-build: 21.2.0
  * latest-eas-build-staging: 21.2.0

If you need the full list of all 415 published versions run "pnpm view eas-cli versions".
apps/mobile                              | [WARN] deprecated expo-random@14.0.1
[ERROR] Command failed with exit code 1: pnpm install

pnpm: Command failed with exit code 1: pnpm install
    at getFinalError (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:88085:14)
    at makeError (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:90392:21)
    at getSyncResult (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:92236:10)
    at spawnSubprocessSync (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:92196:14)
    at execaCoreSync (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:92126:23)
    at callBoundExeca (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:94654:23)
    at boundExeca (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:94631:49)
    at sync2 (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:94786:14)
    at runPnpmCli (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:248219:5)
    at runDepsStatusCheck (file:///usr/local/lib/node_modules/pnpm/dist/pnpm.mjs:249983:7) runs all workspaces via Turborepo)
- **Root scripts** — New section documenting all turbo-delegated commands (, , , , , ) with  examples
- **Notes** — Updated to mention pnpm workspaces and  protocol

Closes #925