### PR TITLE
docs: add READMEs to apps/web, apps/mobile, packages/ui, packages/config

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,60 @@
+# mobile
+
+The **Hunty** React Native / Expo mobile app. It uses Expo SDK 55, Expo Router
+for file-based navigation, and connects to the Stellar blockchain via
+`@stellar/stellar-sdk` and WalletConnect.
+
+## Scripts
+
+### Development
+
+| Script | Description |
+| --- | --- |
+| `start` | Start the Expo dev server |
+| `android` | Start and open on Android emulator |
+| `ios` | Start and open on iOS simulator |
+| `web` | Start and open in a web browser |
+
+### Code quality
+
+| Script | Description |
+| --- | --- |
+| `lint` | ESLint for `.js/.jsx/.ts/.tsx` |
+| `lint:fix` | ESLint with auto-fix |
+| `format` | Prettier write |
+| `format:check` | Prettier check (CI) |
+| `test` | Jest (passes with no tests) |
+
+### Store & assets
+
+| Script | Description |
+| --- | --- |
+| `store:validate` | Validate App Store / Play Store metadata |
+| `store:generate` | Generate store listing assets |
+
+### E2E
+
+| Script | Description |
+| --- | --- |
+| `test:e2e` | Run Maestro E2E flows |
+| `test:e2e:validate` | Validate Maestro baseline screenshots |
+
+### EAS Build / Submit / Update
+
+| Script | Description |
+| --- | --- |
+| `build:android` / `build:ios` / `build:all` | EAS production builds |
+| `build:*:dev` / `build:*:preview` | Development & preview builds |
+| `submit:*` | Submit builds to app stores |
+| `update:development` / `update:preview` / `update:production` | OTA updates |
+
+## Key dependencies
+
+- **`expo` ~55** — Expo SDK (camera, location, notifications, secure-store, …)
+- **`expo-router`** — file-based routing
+- **`@stellar/stellar-sdk`** — Stellar blockchain client
+- **`@walletconnect/*`** — WalletConnect v2 for mobile wallet connection
+- **`@tanstack/react-query`** — server-state caching
+- **`zustand`** — lightweight state management
+- **`nativewind`** — Tailwind CSS for React Native
+- **`@sentry/react-native`** — error tracking

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,37 @@
+# @hunty/web
+
+The **Hunty** web application — a Next.js 15 App Router app built with React 19,
+Tailwind CSS v4, and Zustand for client state. It connects to the Stellar
+blockchain via the Stellar SDK and Freighter wallet extension.
+
+## Scripts
+
+| Script | Description |
+| --- | --- |
+| `dev` | Start the Next.js dev server |
+| `build` | Production build |
+| `analyze` | Build with `ANALYZE=true` for bundle analysis |
+| `bundle:check` | Check bundle sizes against budgets |
+| `start` | Start the production server |
+| `lint` | Run Next.js ESLint |
+| `typecheck` | Run TypeScript in `--noEmit` mode |
+| `test` | Run Vitest (single run) |
+| `test:watch` | Run Vitest in watch mode |
+| `test:coverage` | Run Vitest with v8 coverage |
+| `e2e` | Run Playwright end-to-end tests |
+| `smoke` | Run Playwright smoke suite |
+| `test:e2e:ui` | Open Playwright interactive UI |
+| `perf:budget` | Check performance budgets |
+| `clean` | Remove `.next` build cache |
+
+## Key dependencies
+
+- **`@hunty/types`** / **`@hunty/ui`** — shared workspace packages for domain
+  types and UI components.
+- **`@stellar/stellar-sdk`** / **`@stellar/freighter-api`** — Stellar blockchain
+  integration and browser wallet connection.
+- **`@tanstack/react-query`** — server-state caching and data fetching.
+- **`next-intl`** — internationalization.
+- **`next-themes`** — dark/light theme switching.
+- **`zod`** — runtime schema validation.
+- **`zustand`** — lightweight client-side state management.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,49 @@
+# @hunty/config
+
+Shared ESLint, TypeScript, and Tailwind CSS configurations for the Hunty
+monorepo. Each workspace imports only the configs it needs via the seven export
+paths below.
+
+## Export paths
+
+### ESLint
+
+| Import | File | Description |
+| --- | --- | --- |
+| `@hunty/config/eslint/base` | `eslint/base.mjs` | Base ESLint rules for all packages |
+| `@hunty/config/eslint/next` | `eslint/next.mjs` | Next.js-specific rules (apps/web) |
+| `@hunty/config/eslint/react-native` | `eslint/react-native.mjs` | React Native rules (apps/mobile) |
+
+### TypeScript
+
+| Import | File | Description |
+| --- | --- | --- |
+| `@hunty/config/tsconfig/base.json` | `tsconfig/base.json` | Base TS config for all packages |
+| `@hunty/config/tsconfig/nextjs.json` | `tsconfig/nextjs.json` | Next.js TS config (apps/web) |
+| `@hunty/config/tsconfig/react-native.json` | `tsconfig/react-native.json` | React Native TS config (apps/mobile) |
+
+### Tailwind
+
+| Import | File | Description |
+| --- | --- | --- |
+| `@hunty/config/tailwind` | `tailwind/index.js` | Shared Tailwind CSS preset |
+
+## Usage
+
+Each workspace extends the configs it needs:
+
+```jsonc
+// tsconfig.json
+{ "extends": "@hunty/config/tsconfig/nextjs.json" }
+```
+
+```js
+// eslint.config.mjs
+import base from "@hunty/config/eslint/next"
+export default base
+```
+
+## Scripts
+
+This package has no scripts — it is a configuration-only package consumed by
+other workspaces.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,62 @@
+# @hunty/ui
+
+Shared UI component library for the Hunty monorepo. Provides **platform-agnostic
+design tokens**, **web (React / Next.js) components**, and **native (React Native
+/ Expo) type exports** — all from one package.
+
+## Export paths
+
+| Import | Source | Description |
+| --- | --- | --- |
+| `@hunty/ui` | `src/index.ts` | Design tokens + web components (default) |
+| `@hunty/ui/tokens` | `src/tokens/index.ts` | Colors, typography, spacing (platform-agnostic) |
+| `@hunty/ui/web` | `src/web/index.ts` | React / Next.js components |
+| `@hunty/ui/native` | `src/native/index.ts` | React Native type exports only |
+
+### `@hunty/ui/tokens`
+
+Design tokens shared between web and native, kept in sync with the CSS custom
+properties in `apps/web/app/globals.css`:
+
+- **colors** — palette, semantic colors
+- **typography** — font families, sizes, weights
+- **spacing** — spacing scale
+
+### `@hunty/ui/web`
+
+React components imported directly or from the root:
+
+```tsx
+import { Button, Card, Badge, EmptyState } from "@hunty/ui/web"
+// or
+import { Button } from "@hunty/ui"
+```
+
+Components: `Button`, `Card` (plus `CardHeader`, `CardTitle`, `CardDescription`,
+`CardContent`, `CardFooter`), `Badge`, `EmptyState`.
+
+### `@hunty/ui/native`
+
+Exports **types only** (`ButtonProps`, `CardProps`, `BadgeProps`,
+`EmptyStateProps`) so consumers can type-check without pulling React Native
+dependencies into web builds. Actual native component implementations live in
+`apps/mobile/components`.
+
+```ts
+import type { ButtonProps } from "@hunty/ui/native"
+```
+
+## Scripts
+
+| Script | Description |
+| --- | --- |
+| `typecheck` | Run TypeScript in `--noEmit` mode |
+| `lint` | ESLint (zero warnings) |
+| `test` | Run Vitest |
+
+## Dependencies
+
+- **`@hunty/types`** — shared domain types consumed by native type re-exports
+- **`react`** / **`react-dom`** — peer dependencies (≥18)
+- **`class-variance-authority`** / **`clsx`** / **`tailwind-merge`** — utility
+  classes for component styling


### PR DESCRIPTION
Adds README documentation for the four remaining workspaces.

- apps/web: Next.js 15 App Router app (scripts, key deps)
- apps/mobile: Expo/React Native app (dev, EAS, store scripts)
- packages/ui: shared component library (tokens/web/native split, 4 export paths)
- packages/config: shared ESLint/TS/Tailwind configs (all 7 export paths)

Closes #924