### PR TITLE
feat: add registration status check to RegistrationButton and documen…

### DIFF
--- a/apps/web/components/RegistrationButton.tsx
+++ b/apps/web/components/RegistrationButton.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import { AnimatedCheckmark } from "@/components/AnimatedCheckmark";
 import { Skeleton } from "@/components/ui/skeleton";
+import { checkRegistrationStatus } from "@/lib/contracts/player-registration";
 import type { HuntRegistrationStatus } from "@/lib/types";
 
 interface RegistrationButtonProps {
@@ -31,6 +32,7 @@ export function RegistrationButton({
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
+  const [isAlreadyRegistered, setIsAlreadyRegistered] = useState(false);
 
   const isHuntFull = maxCapacity !== undefined && currentPlayers !== undefined && currentPlayers >= maxCapacity;
   const capacityCopy =
@@ -44,6 +46,12 @@ export function RegistrationButton({
     setSuccessMessage(null);
 
     try {
+      const status = await checkRegistrationStatus(huntId, playerAddress);
+      if (status.isRegistered) {
+        setIsAlreadyRegistered(true);
+        return;
+      }
+
       await onRegister();
       setSuccessMessage("Successfully registered for the hunt!");
       setRetryCount(0); // Reset retry count on success
@@ -102,14 +110,11 @@ export function RegistrationButton({
   return (
     <div className="space-y-3">
       {/* Registration button */}
-      {registrationStatus.isRegistered ? (
-        <button
-          className="w-full flex items-center justify-center gap-2 bg-green-600 hover:bg-green-500 active:scale-95 transition-all duration-150 text-white font-semibold text-base px-8 py-4 rounded-2xl shadow-lg shadow-green-900/40"
-          disabled={isRegistering}
-        >
-          <AnimatedCheckmark asCircle className="text-green-600" size={20} />
-          Continue Hunt
-        </button>
+      {registrationStatus.isRegistered || isAlreadyRegistered ? (
+        <div className="w-full flex items-center justify-center gap-2 bg-green-100 dark:bg-green-900/30 text-green-900 dark:text-green-200 font-semibold text-base px-8 py-4 rounded-2xl border border-green-200 dark:border-green-800">
+          <AnimatedCheckmark asCircle className="text-green-600 dark:text-green-400" size={20} />
+          You're already registered
+        </div>
       ) : registrationStatus.isWaitlisted ? (
         <div className="w-full flex items-center justify-center gap-2 bg-amber-100 dark:bg-amber-900/30 text-amber-900 dark:text-amber-200 font-semibold text-base px-8 py-4 rounded-2xl border border-amber-200 dark:border-amber-800">
           <div className="animate-pulse w-2 h-2 bg-amber-600 dark:bg-amber-500 rounded-full" />


### PR DESCRIPTION
closed #312 

## Description
This PR addresses issue #312 where a player who has already registered for a hunt could potentially click the "Join Hunt" button again (e.g. after a page refresh resulting in a stale UI state). Previously, this triggered a redundant transaction that was rejected by the smart contract, surfacing a raw and confusing contract error. This update intercepts duplicate registration attempts client-side and gracefully updates the UI.

## Acceptance Criteria Met
- [x] **Pre-flight Status Check**: Verifies if the wallet address is already in the hunt's player list before calling the `registerPlayer` contract function.
- [x] **Improved UX Badge**: Replaces the "Join Hunt" (or previously generic "Continue Hunt") element with a clear, friendly "You're already registered" badge for registered players.

## Changes
- **`components/RegistrationButton.tsx`**:
  - Imported the `checkRegistrationStatus` utility.
  - Added a localized `isAlreadyRegistered` state to track real-time registration verification during the registration click handler.
  - Modified the UI logic to render a styled green badge (`You're already registered`) when either the component prop or the active pre-flight check confirms registration.

## Testing Instructions
1. Pull the branch locally and start the development server (`pnpm dev`).
2. Navigate to a hunt and register using a connected Soroban-compatible wallet (e.g., Freighter).
3. Confirm that upon successful registration, the button changes to a green "You're already registered" badge.
4. Refresh the page or manipulate local state to trick the "Join Hunt" button into appearing again.
5. Click "Join Hunt" and observe that no transaction is submitted. Instead, the UI recognizes the existing registration and switches immediately to the "You're already registered" badge without showing any raw contract errors.
