### PR TITLE
Type Soroban and NFT SDK boundaries

### DIFF
--- a/apps/web/lib/nft/__tests__/minter.test.ts
+++ b/apps/web/lib/nft/__tests__/minter.test.ts
@@ -1,0 +1,96 @@
+import { Account, rpc, type Transaction } from "@stellar/stellar-sdk"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const sdk = vi.hoisted(() => ({
+  publicKey: "",
+  getAccount: vi.fn(),
+  simulateTransaction: vi.fn(),
+  prepareTransaction: vi.fn(),
+  sendTransaction: vi.fn(),
+  signTransaction: vi.fn(),
+}))
+
+vi.mock("@/lib/contracts/config", () => ({
+  getRequiredAddress: () => "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+}))
+vi.mock("@/lib/huntStore", () => ({ getHunt: () => ({ title: "Typed Hunt" }) }))
+vi.mock("@/lib/logger", () => ({ logger: { warn: vi.fn() } }))
+vi.mock("@/lib/nft/metadataBuilder", () => ({
+  buildNftMetadata: () => ({ name: "Typed Hunt", description: "Reward", image: "ipfs://image" }),
+}))
+vi.mock("@/lib/nft/metadataUploader", () => ({
+  uploadNftMetadata: () => Promise.resolve({ cid: "metadata-cid", metadataUri: "ipfs://metadata-cid" }),
+}))
+vi.mock("@/lib/soroban/client", () => ({
+  createSorobanServer: () =>
+    ({
+      getAccount: sdk.getAccount,
+      simulateTransaction: sdk.simulateTransaction,
+      prepareTransaction: sdk.prepareTransaction,
+      sendTransaction: sdk.sendTransaction,
+    }) as unknown as rpc.Server,
+}))
+vi.mock("@/lib/walletAdapter", () => ({
+  getActiveWalletAdapter: () => ({
+    provider: "freighter",
+    getPublicKey: () => Promise.resolve(sdk.publicKey),
+    signTransaction: sdk.signTransaction,
+  }),
+}))
+
+import { estimateMintFee, mintHuntRewardNft } from "../minter"
+
+describe("typed Stellar NFT minting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sdk.publicKey = "GB2UW33KNO3EGTASKYAJOFPYZJ3RT7C3IG6BOJSKOBXW3PEYNXC5XCCN"
+    sdk.getAccount.mockResolvedValue(new Account(sdk.publicKey, "1"))
+  })
+
+  it("uses the SDK simulation response to estimate the resource fee", async () => {
+    const simulation: rpc.Api.SimulateTransactionSuccessResponse = {
+      id: "simulation-1",
+      latestLedger: 123,
+      events: [],
+      _parsed: true,
+      transactionData: {} as rpc.Api.SimulateTransactionSuccessResponse["transactionData"],
+      minResourceFee: "250000",
+    }
+    sdk.simulateTransaction.mockResolvedValue(simulation)
+
+    await expect(estimateMintFee(7)).resolves.toEqual({
+      feeStroops: 250000,
+      feeXlm: 0.025,
+      simulated: true,
+    })
+    expect(sdk.simulateTransaction).toHaveBeenCalledOnce()
+  })
+
+  it("prepares, signs, parses, and sends a real SDK transaction", async () => {
+    sdk.simulateTransaction.mockResolvedValue({
+      id: "simulation-2",
+      latestLedger: 124,
+      events: [],
+      _parsed: true,
+      error: "not a contract invocation",
+    } satisfies rpc.Api.SimulateTransactionErrorResponse)
+    sdk.prepareTransaction.mockImplementation((tx: Transaction) => Promise.resolve(tx))
+    sdk.signTransaction.mockImplementation((xdr: string) => Promise.resolve(xdr))
+    sdk.sendTransaction.mockResolvedValue({
+      status: "PENDING",
+      hash: "abc123",
+      latestLedger: 125,
+      latestLedgerCloseTime: 1,
+    } satisfies rpc.Api.SendTransactionResponse)
+
+    const result = await mintHuntRewardNft({ huntId: 7 })
+
+    expect(result.txHash).toBe("abc123")
+    expect(sdk.prepareTransaction).toHaveBeenCalledOnce()
+    const sent = sdk.sendTransaction.mock.calls[0]?.[0]
+    expect(sent).toBeDefined()
+    expect(typeof sent.toXDR()).toBe("string")
+  })
+})
+

--- a/apps/web/lib/nft/minter.ts
+++ b/apps/web/lib/nft/minter.ts
@@ -14,17 +14,15 @@
 import {
   type Account,
   Operation,
+  rpc,
   type Transaction,
   TransactionBuilder,
 } from "@stellar/stellar-sdk"
 
-import {
-  getRequiredAddress,
-  NETWORK_PASSPHRASE,
-} from "@/lib/contracts/config"
+import { NETWORK_PASSPHRASE } from "@/lib/contracts/config"
 import { getHunt } from "@/lib/huntStore"
 import { logger } from "@/lib/logger"
-import { IpfsUploadError,MetadataValidationError } from "@/lib/nft/errors"
+import { IpfsUploadError, MetadataValidationError } from "@/lib/nft/errors"
 import { buildNftMetadata } from "@/lib/nft/metadataBuilder"
 import { uploadNftMetadata } from "@/lib/nft/metadataUploader"
 import type { NftMetadata } from "@/lib/nft/types"
@@ -102,10 +100,8 @@ export async function estimateMintFee(
   const wallet = getActiveWalletAdapter()
   const publicKey = await wallet.getPublicKey()
   const recipient = recipientAddress || publicKey
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const server = createSorobanServer() as any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const account = (await server.getAccount(publicKey)) as any
+  const server = createSorobanServer()
+  const account = await server.getAccount(publicKey)
 
   const tx = buildMintTransaction({
     account,
@@ -116,14 +112,13 @@ export async function estimateMintFee(
 
   try {
     const sim = await server.simulateTransaction(tx)
-    const simCost = (sim as { cost?: { cpuInsns?: number } }).cost
-    const cpu = Number(simCost?.cpuInsns ?? 0)
-    const resourceFee =
-      cpu > 0 ? Math.max(DEFAULT_FEE_STROOPS, Math.ceil(cpu / 100)) : DEFAULT_FEE_STROOPS
+    const resourceFee = rpc.Api.isSimulationSuccess(sim)
+      ? Math.max(DEFAULT_FEE_STROOPS, Number(sim.minResourceFee))
+      : DEFAULT_FEE_STROOPS
     return {
       feeStroops: resourceFee,
       feeXlm: resourceFee / 1e7,
-      simulated: Boolean(simCost),
+      simulated: rpc.Api.isSimulationSuccess(sim),
     }
   } catch (err) {
     logger.warn("estimateMintFee: simulation failed, using default", err)
@@ -178,7 +173,7 @@ async function mintHuntRewardNftInternal(input: NftMintInput): Promise<MintResul
   // Stage 1: Build metadata
   onStage?.("building_metadata")
   const metadata: NftMetadata = buildNftMetadata({
-    name: `Hunty Trophy — ${huntName} · Rank ${rank}`,
+    name: `Hunty Trophy â€” ${huntName} Â· Rank ${rank}`,
     description: `Reward NFT for completing ${huntName} on Hunty.`,
     imageCid: input.imageCid || PLACEHOLDER_IMAGE_CID,
     difficulty: "Unrated",
@@ -211,10 +206,8 @@ async function mintHuntRewardNftInternal(input: NftMintInput): Promise<MintResul
 
   // Stage 4: Build + sign the mint transaction
   onStage?.("signing")
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const server = createSorobanServer() as any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const account = (await server.getAccount(publicKey)) as any
+  const server = createSorobanServer()
+  const account = await server.getAccount(publicKey)
 
   let tx = buildMintTransaction({
     account,
@@ -227,11 +220,7 @@ async function mintHuntRewardNftInternal(input: NftMintInput): Promise<MintResul
   // Inject Soroban resource data from a fresh simulation when available so the
   // transaction carries valid Soroban auth/resources at submission time.
   try {
-    const sim = await server.simulateTransaction(tx)
-    if (sim && typeof server.prepareTransaction === "function") {
-      const prepared = await server.prepareTransaction(tx, sim)
-      if (prepared) tx = prepared
-    }
+    tx = await server.prepareTransaction(tx)
   } catch (err) {
     logger.warn("mintHuntRewardNft: simulate/prepare failed, submitting as-is", err)
   }
@@ -243,8 +232,12 @@ async function mintHuntRewardNftInternal(input: NftMintInput): Promise<MintResul
   onStage?.("submitting")
   let txHash: string
   try {
-    const result = await server.submitTransaction(signedXdr)
-    txHash = result?.hash ?? ""
+    const signedTransaction = TransactionBuilder.fromXDR(
+      signedXdr,
+      NETWORK_PASSPHRASE
+    )
+    const result = await server.sendTransaction(signedTransaction)
+    txHash = result.hash
   } catch (err) {
     // Fall back to a deterministic local tx id so the flow is still demoable
     // when the NFT contract is not yet deployed. Matches transfer.ts pattern.
@@ -278,7 +271,6 @@ function buildMintTransaction(opts: {
   metadataUri: string
   feeStroops?: number
 }): Transaction {
-  const nftContractAddress = getRequiredAddress("NFT_REWARD")
   const fee = String(opts.feeStroops ?? 100_000)
 
   return new TransactionBuilder(opts.account, {
@@ -288,13 +280,9 @@ function buildMintTransaction(opts: {
     .addOperation(
       Operation.manageData({
         name: `mint_nft:${opts.huntId}:${Date.now()}`,
-        value: JSON.stringify({
-          action: "mint_nft",
-          nft_contract: nftContractAddress,
-          recipient: opts.recipient,
-          hunt_id: opts.huntId,
-          metadata_uri: opts.metadataUri,
-        }),
+        // Stellar manage-data values are capped at 64 bytes. The previous JSON
+        // payload always exceeded that limit and failed before simulation.
+        value: opts.metadataUri.slice(0, 64),
       })
     )
     .setTimeout(180)
@@ -332,3 +320,4 @@ export function getMintReceipt(
     return null
   }
 }
+

--- a/apps/web/lib/soroban/SorobanContext.tsx
+++ b/apps/web/lib/soroban/SorobanContext.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { rpc } from "@stellar/stellar-sdk"
 import {
   createContext,
   type ReactNode,
@@ -25,8 +26,7 @@ export type SorobanConnectionStatus =
 
 export type SorobanContextValue = {
   /** Valid Server instance for Soroban RPC (same API as soroban-client). */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  server: any | null
+  server: rpc.Server | null
   /** Network passphrase (e.g. Futurenet / Testnet). */
   networkPassphrase: string
   /** RPC URL in use. */
@@ -42,8 +42,7 @@ export type SorobanContextValue = {
 const SorobanContext = createContext<SorobanContextValue | null>(null)
 
 export function SorobanProvider({ children }: { children: ReactNode }) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [server, setServer] = useState<any | null>(null)
+  const [server, setServer] = useState<rpc.Server | null>(null)
   const [networkPassphrase] = useState(() => getSorobanNetworkPassphrase())
   const [rpcUrl] = useState(() => getSorobanRpcUrl())
   const [connectionStatus, setConnectionStatus] =
@@ -116,3 +115,4 @@ export function useSoroban(): SorobanContextValue {
   }
   return ctx
 }
+

--- a/apps/web/lib/soroban/__tests__/client.test.ts
+++ b/apps/web/lib/soroban/__tests__/client.test.ts
@@ -1,0 +1,24 @@
+import { rpc } from "@stellar/stellar-sdk"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }))
+
+import { createSorobanServer } from "../client"
+
+describe("createSorobanServer", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("creates and reuses the typed Stellar RPC server", () => {
+    vi.stubEnv("NEXT_PUBLIC_SOROBAN_RPC_URL", "https://soroban-testnet.stellar.org")
+
+    const first = createSorobanServer()
+    const second = createSorobanServer()
+
+    expect(first).toBeInstanceOf(rpc.Server)
+    expect(second).toBe(first)
+    expect(first.serverURL.toString()).toContain("soroban-testnet.stellar.org")
+  })
+})
+

--- a/apps/web/lib/soroban/client.ts
+++ b/apps/web/lib/soroban/client.ts
@@ -1,10 +1,7 @@
 import * as Sentry from "@sentry/nextjs"
-import Server from "@stellar/stellar-sdk"
+import { rpc } from "@stellar/stellar-sdk"
 
 import { createSorobanRpcOptimizer } from "./rpcOptimization"
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SorobanServer = Server as any;
 
 /**
  * Testnet network configuration
@@ -74,18 +71,16 @@ export function getSorobanNetworkType(): "testnet" | "mainnet" {
  * Creates a Soroban Server instance for the configured RPC URL.
  * Uses the same Server API as soroban-client (stellar-sdk is the maintained package).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let sharedServer: any | null = null;
+let sharedServer: rpc.Server | null = null;
 let sharedServerRpcUrl: string | null = null;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createSorobanServer(): any {
+export function createSorobanServer(): rpc.Server {
   const rpcUrl = getRpcUrl();
   if (sharedServer && sharedServerRpcUrl === rpcUrl) {
     return sharedServer;
   }
 
-  sharedServer = new SorobanServer(rpcUrl);
+  sharedServer = new rpc.Server(rpcUrl);
   sharedServerRpcUrl = rpcUrl;
   return sharedServer;
 }
@@ -138,3 +133,4 @@ export async function readSorobanContractState<T>(request: {
     throw err
   }
 }
+


### PR DESCRIPTION
## Summary

- replace all nine `no-explicit-any` suppressions in the Soroban context, RPC client, and NFT minter with Stellar SDK types
- use the maintained `rpc.Server` API for simulation, preparation, signed-XDR parsing, and transaction submission
- keep manage-data payloads within Stellar's 64-byte protocol limit
- add focused tests for the typed RPC server, fee simulation, and end-to-end prepare/sign/parse/send flow

## Root cause

The code imported the SDK's intentionally untyped default export and cast the RPC server boundary to `any`. That hid API drift: the current SDK exposes `rpc.Server`, `minResourceFee`, `prepareTransaction(transaction)`, and `sendTransaction(transaction)`. It also concealed an oversized `manageData` payload that failed before simulation.

## Validation

- `vitest --run lib/nft/__tests__/minter.test.ts lib/soroban/__tests__/client.test.ts` — 3 tests passed
- `git diff --check` — passed
- repository-wide `tsc --noEmit` remains blocked by pre-existing syntax errors in `app/creator/page.tsx`, `components/ClueSortList.tsx`, and `lib/contracts/hunt.ts`

Closes #905
