### PR TITLE
feat: add paymaster service for fee abstraction

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -124,6 +124,19 @@ PINATA_JWT=your_pinata_jwt_token_here
 RESEND_API_KEY=your_resend_api_key_here
 
 # ============================================================================
+# PAYMASTER SERVICE (FEE ABSTRACTION)
+# ============================================================================
+# REQUIRED: Secret seed for the Stellar keypair that signs fee-bump transactions.
+# Generate with:
+#   node -e "const {Keypair}=require('@stellar/stellar-sdk'); const kp=Keypair.random(); console.log('Secret:', kp.secret()); console.log('Public:', kp.publicKey())"
+# Fund the account on testnet: https://laboratory.stellar.org/#account-creator?network=testnet
+# On mainnet, send XLM from an exchange or another wallet.
+PAYMASTER_SECRET=
+
+# Public G-address of the paymaster keypair (used by the client to show status)
+NEXT_PUBLIC_PAYMASTER_PUBLIC_KEY=
+
+# ============================================================================
 # WALLET INTEGRATION
 # ============================================================================
 # WalletConnect Project ID

--- a/apps/web/app/api/paymaster/admin/config/route.ts
+++ b/apps/web/app/api/paymaster/admin/config/route.ts
@@ -1,0 +1,157 @@
+/**
+ * GET/POST /api/paymaster/admin/config
+ *
+ * Admin controls for global paymaster sponsorship limits.
+ *
+ * GET  — Returns the current effective configuration (defaults + overrides).
+ * POST — Updates one or more configuration values.
+ *
+ * Both endpoints require an `Authorization: Bearer <ADMIN_API_SECRET>` header.
+ *
+ * POST body (JSON):
+ *   { "maxSponsoredTx": 5, "maxBudgetPerUserStroops": 20000000 }
+ *
+ * Only provided keys are updated; omitted keys keep their current value.
+ * Set a key to `null` to delete the override and revert to the default.
+ */
+
+import { NextResponse } from "next/server";
+
+import { AuthError, ValidationError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
+import { getPaymasterConfig } from "@/lib/paymaster/config";
+import {
+  deleteConfigValue,
+  getConfigValue,
+  listUsers,
+  setConfigValue,
+} from "@/lib/paymaster/db";
+import {
+  CONFIG_KEYS,
+  type AdminConfigUpdate,
+  type PaymasterConfig,
+  type PaymasterUserRecord,
+} from "@/lib/paymaster/types";
+
+export const dynamic = "force-dynamic";
+
+// ─── Auth check helper ─────────────────────────────────────────────────────
+
+function requireAdmin(request: Request): void {
+  const auth = request.headers.get("authorization");
+  const secret = process.env.ADMIN_API_SECRET;
+
+  if (!secret) {
+    throw new AuthError(
+      "Paymaster admin is not configured (ADMIN_API_SECRET is not set).",
+    );
+  }
+
+  if (!auth || !auth.startsWith("Bearer ") || auth.slice(7) !== secret) {
+    throw new AuthError("Invalid or missing admin authorization token.");
+  }
+}
+
+// ─── GET ───────────────────────────────────────────────────────────────────
+
+export const GET = withErrorHandling(async (request: Request) => {
+  requireAdmin(request);
+
+  const baseConfig = getPaymasterConfig();
+
+  // Load any DB overrides
+  const maxSponsoredTx = await getConfigValue(CONFIG_KEYS.MAX_SPONSORED_TX);
+  const maxBudgetPerUser = await getConfigValue(CONFIG_KEYS.MAX_BUDGET_PER_USER);
+  const maxFeePerTx = await getConfigValue(CONFIG_KEYS.MAX_FEE_PER_TX);
+
+  const effectiveConfig: PaymasterConfig = {
+    maxSponsoredTx: Number(maxSponsoredTx ?? baseConfig.maxSponsoredTx),
+    maxBudgetPerUserStroops: Number(maxBudgetPerUser ?? baseConfig.maxBudgetPerUserStroops),
+    maxFeePerTxStroops: Number(maxFeePerTx ?? baseConfig.maxFeePerTxStroops),
+    paymasterPublicKey: baseConfig.paymasterPublicKey,
+  };
+
+  // Also return user summary stats
+  const users: PaymasterUserRecord[] = await listUsers();
+
+  const stats = {
+    totalTrackedUsers: users.length,
+    totalSponsoredTx: users.reduce((sum, u) => sum + u.sponsored_tx_count, 0),
+    totalBudgetUsed: users.reduce((sum, u) => sum + Number(u.total_budget_sponsored), 0),
+  };
+
+  return NextResponse.json({
+    config: effectiveConfig,
+    stats,
+    users: users.map((u) => ({
+      walletAddress: u.wallet_address,
+      sponsoredTxCount: u.sponsored_tx_count,
+      totalBudgetSponsored: Number(u.total_budget_sponsored),
+      updatedAt: u.updated_at,
+    })),
+  });
+});
+
+// ─── POST ──────────────────────────────────────────────────────────────────
+
+export const POST = withErrorHandling(async (request: Request) => {
+  requireAdmin(request);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw new ValidationError("Invalid JSON body");
+  }
+
+  const update = body as AdminConfigUpdate;
+  const updated: string[] = [];
+
+  // Update max sponsored transactions
+  if (update.maxSponsoredTx !== undefined) {
+    if (update.maxSponsoredTx === null) {
+      await deleteConfigValue(CONFIG_KEYS.MAX_SPONSORED_TX);
+      updated.push("maxSponsoredTx reverted to default");
+    } else if (Number.isFinite(update.maxSponsoredTx) && update.maxSponsoredTx >= 0) {
+      await setConfigValue(CONFIG_KEYS.MAX_SPONSORED_TX, String(update.maxSponsoredTx));
+      updated.push(`maxSponsoredTx → ${update.maxSponsoredTx}`);
+    } else {
+      throw new ValidationError("maxSponsoredTx must be a non-negative integer");
+    }
+  }
+
+  // Update max budget per user (stroops)
+  if (update.maxBudgetPerUserStroops !== undefined) {
+    if (update.maxBudgetPerUserStroops === null) {
+      await deleteConfigValue(CONFIG_KEYS.MAX_BUDGET_PER_USER);
+      updated.push("maxBudgetPerUserStroops reverted to default");
+    } else if (Number.isFinite(update.maxBudgetPerUserStroops) && update.maxBudgetPerUserStroops >= 0) {
+      await setConfigValue(
+        CONFIG_KEYS.MAX_BUDGET_PER_USER,
+        String(update.maxBudgetPerUserStroops),
+      );
+      updated.push(`maxBudgetPerUserStroops → ${update.maxBudgetPerUserStroops}`);
+    } else {
+      throw new ValidationError("maxBudgetPerUserStroops must be a non-negative integer");
+    }
+  }
+
+  // Update max fee per transaction (stroops)
+  if (update.maxFeePerTxStroops !== undefined) {
+    if (update.maxFeePerTxStroops === null) {
+      await deleteConfigValue(CONFIG_KEYS.MAX_FEE_PER_TX);
+      updated.push("maxFeePerTxStroops reverted to default");
+    } else if (Number.isFinite(update.maxFeePerTxStroops) && update.maxFeePerTxStroops >= 0) {
+      await setConfigValue(CONFIG_KEYS.MAX_FEE_PER_TX, String(update.maxFeePerTxStroops));
+      updated.push(`maxFeePerTxStroops → ${update.maxFeePerTxStroops}`);
+    } else {
+      throw new ValidationError("maxFeePerTxStroops must be a non-negative integer");
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    updated,
+    config: getPaymasterConfig(),
+  });
+});

--- a/apps/web/app/api/paymaster/budget/[wallet]/route.ts
+++ b/apps/web/app/api/paymaster/budget/[wallet]/route.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/paymaster/budget/[wallet]
+ *
+ * Returns the sponsorship budget status for a given wallet address.
+ * Useful for the client to check eligibility before attempting to submit
+ * a transaction for sponsorship.
+ *
+ * Response (200):
+ *   {
+ *     "walletAddress": "G-...",
+ *     "usedTx": 1,
+ *     "maxTx": 3,
+ *     "usedBudget": 100000,
+ *     "maxBudget": 10000000,
+ *     "eligible": true
+ *   }
+ */
+
+import { NextResponse } from "next/server";
+
+import { NotFoundError } from "@/lib/api/errors";
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
+import { getPaymasterConfig } from "@/lib/paymaster/config";
+import { ensureUser, getConfigValue } from "@/lib/paymaster/db";
+import {
+  CONFIG_KEYS,
+  type BudgetInfo,
+} from "@/lib/paymaster/types";
+import { parseNumericConfig } from "@/lib/paymaster/config";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withErrorHandling(
+  async (_request: Request, { params }: { params: Promise<{ wallet: string }> }) => {
+    const { wallet } = await params;
+
+    if (!wallet.startsWith("G") || wallet.length !== 56) {
+      throw new NotFoundError("Invalid wallet address");
+    }
+
+    // Ensure the user is tracked (creates row with defaults if new).
+    const user = await ensureUser(wallet);
+
+    // Get effective limits (respecting any DB overrides).
+    const maxTxOverride = await getConfigValue(CONFIG_KEYS.MAX_SPONSORED_TX);
+    const maxBudgetOverride = await getConfigValue(CONFIG_KEYS.MAX_BUDGET_PER_USER);
+    const defaults = getPaymasterConfig();
+
+    const maxTx = parseNumericConfig(maxTxOverride, defaults.maxSponsoredTx);
+    const maxBudget = parseNumericConfig(maxBudgetOverride, defaults.maxBudgetPerUserStroops);
+
+    const eligible =
+      user.sponsored_tx_count < maxTx &&
+      user.total_budget_sponsored < maxBudget;
+
+    const info: BudgetInfo = {
+      walletAddress: wallet,
+      usedTx: user.sponsored_tx_count,
+      maxTx,
+      usedBudget: user.total_budget_sponsored,
+      maxBudget,
+      eligible,
+    };
+
+    return NextResponse.json(info);
+  },
+);

--- a/apps/web/app/api/paymaster/sponsor/route.ts
+++ b/apps/web/app/api/paymaster/sponsor/route.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /api/paymaster/sponsor
+ *
+ * Submit a transaction for the paymaster to sponsor. The paymaster will
+ * check the user's quota and budget, and if eligible, return a signed
+ * fee-bump XDR the client can submit to the network.
+ *
+ * Request body (JSON):
+ *   { "txXdr": "<base64 transaction XDR>", "walletAddress": "G-..." }
+ *
+ * Success (200):
+ *   { "sponsored": true, "feeBumpTxXdr": "...", "remainingTx": 2, "remainingBudget": 5000000 }
+ *
+ * Fallback (200 — not sponsored):
+ *   { "sponsored": false, "reason": "...", "remainingTx": 0, "remainingBudget": 0 }
+ *
+ * Errors (4xx/5xx):
+ *   { "error": "...", "code": "VALIDATION_ERROR" }
+ */
+
+import { NextResponse } from "next/server";
+
+import { withErrorHandling } from "@/lib/api/withErrorHandling";
+import { ValidationError } from "@/lib/api/errors";
+import { getPaymaster } from "@/lib/paymaster";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withErrorHandling(async (request: Request) => {
+  // ── 1. Parse & validate body ───────────────────────────────────────
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw new ValidationError("Invalid JSON body");
+  }
+
+  const { txXdr, walletAddress } = body as Record<string, unknown>;
+
+  if (typeof txXdr !== "string" || txXdr.length === 0) {
+    throw new ValidationError("txXdr is required and must be a non-empty string");
+  }
+
+  if (typeof walletAddress !== "string" || !walletAddress.startsWith("G") || walletAddress.length !== 56) {
+    throw new ValidationError("walletAddress is required and must be a valid Stellar G-address");
+  }
+
+  // ── 2. Check sponsorship eligibility & build fee-bump ──────────────
+  const paymaster = getPaymaster();
+  const result = await paymaster.sponsorTransaction(txXdr, walletAddress);
+
+  return NextResponse.json(result);
+});

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -52,6 +52,15 @@ const serverSchema = z.object({
   /** Resend API key for transactional email */
   RESEND_API_KEY: z.string().min(1, "RESEND_API_KEY is required"),
 
+  // -- Paymaster --
+  /**
+   * Secret seed for the Stellar keypair that signs fee-bump transactions.
+   * Generate with: node -e "const {Keypair}=require('@stellar/stellar-sdk'); console.log(Keypair.random().secret())"
+   * The corresponding public key should be set as NEXT_PUBLIC_PAYMASTER_PUBLIC_KEY.
+   * Fund the account on testnet via https://laboratory.stellar.org/#account-creator?network=testnet
+   */
+  PAYMASTER_SECRET: z.string().min(1, "PAYMASTER_SECRET is required"),
+
   // -- Web Push (VAPID) --
   VAPID_PUBLIC_KEY: z.string().min(1, "VAPID_PUBLIC_KEY is required"),
   VAPID_PRIVATE_KEY: z.string().min(1, "VAPID_PRIVATE_KEY is required"),
@@ -140,6 +149,10 @@ const clientSchema = z.object({
   NEXT_PUBLIC_HUNTY_CORE_ADDRESS: z.string().optional(),
   NEXT_PUBLIC_REWARD_MANAGER_ADDRESS: z.string().optional(),
   NEXT_PUBLIC_NFT_REWARD_ADDRESS: z.string().optional(),
+
+  // -- Paymaster --
+  /** Public G-address of the paymaster keypair. Shown in UIs and explorer links. */
+  NEXT_PUBLIC_PAYMASTER_PUBLIC_KEY: z.string().optional(),
 
   // -- WalletConnect --
   NEXT_PUBLIC_WC_PROJECT_ID: z.string().optional(),

--- a/apps/web/lib/paymaster.ts
+++ b/apps/web/lib/paymaster.ts
@@ -1,34 +1,249 @@
-import { FeeBumpTransaction, Keypair, Networks, TransactionBuilder } from "soroban-client"
+/**
+ * Paymaster service — sponsors transaction fees for new users.
+ *
+ * The paymaster wraps a Stellar keypair that signs fee-bump transactions,
+ * covering the network fee so users don't need XLM for their first few
+ * interactions. Quotas and budgets are tracked per wallet via PostgreSQL.
+ *
+ * @module paymaster
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import {
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+
+import { getPaymasterConfig, parseNumericConfig } from "./paymaster/config";
+import {
+  ensureUser,
+  getConfigValue,
+  incrementSponsorship,
+} from "./paymaster/db";
+import { CONFIG_KEYS, type SponsorResponse } from "./paymaster/types";
+
+// ─── Singleton instance ────────────────────────────────────────────────────
+
+let _instance: StellarPaymaster | null = null;
 
 /**
- * Utility for creating fee-bump (gasless) transactions.
- * The paymaster signs the fee-bump transaction, covering the fee for the user.
+ * Returns the singleton StellarPaymaster instance, initialising it from
+ * environment variables on first call.
+ *
+ * The paymaster secret must be set in `PAYMASTER_SECRET` (server-side env).
  */
-export class StellarPaymaster {
-  private readonly paymasterKey: Keypair
-  private readonly network: string
+export function getPaymaster(): StellarPaymaster {
+  if (!_instance) {
+    const secret = process.env.PAYMASTER_SECRET;
+    if (!secret) {
+      throw new Error(
+        "PAYMASTER_SECRET environment variable is not set. " +
+          "The paymaster service cannot start without a funded Stellar keypair.",
+      );
+    }
+    _instance = new StellarPaymaster(
+      secret,
+      process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE ?? Networks.TESTNET,
+    );
+  }
+  return _instance;
+}
 
-  constructor(paymasterSecret: string, network: string = Networks.TESTNET) {
-    this.paymasterKey = Keypair.fromSecret(paymasterSecret)
-    this.network = network
+/**
+ * Resets the singleton (useful in tests).
+ */
+export function resetPaymaster(): void {
+  _instance = null;
+}
+
+// ─── Paymaster class ───────────────────────────────────────────────────────
+
+export class StellarPaymaster {
+  readonly paymasterKey: Keypair;
+  private readonly network: string;
+
+  constructor(paymasterSecret: string, network?: string) {
+    this.paymasterKey = Keypair.fromSecret(paymasterSecret);
+    this.network = network ?? Networks.TESTNET;
   }
 
-  async createFeeBump(userTxXdr: string, maxFee = 100): Promise<string> {
-    const userTx = TransactionBuilder.fromXDR(userTxXdr, this.network)
+  /**
+   * The Stellar G-address of this paymaster.
+   */
+  get publicKey(): string {
+    return this.paymasterKey.publicKey();
+  }
 
-    if (userTx instanceof FeeBumpTransaction) {
-      throw new Error("Expected a standard transaction XDR, received a fee-bump transaction.")
+  /**
+   * Check whether a user is eligible for sponsorship and, if so, create a
+   * fee-bump transaction signed by the paymaster.
+   *
+   * Eligibility rules:
+   * 1. User must not have exceeded their per-user sponsored tx count.
+   * 2. User must not have exceeded their per-user sponsored budget.
+   * 3. The requested fee must not exceed the per-transaction max fee.
+   *
+   * @param txXdr        - Standard transaction XDR (not a fee-bump).
+   * @param walletAddress - Stellar G-address of the user.
+   * @returns A {@link SponsorResponse} indicating whether the tx was sponsored.
+   */
+  async sponsorTransaction(
+    txXdr: string,
+    walletAddress: string,
+  ): Promise<SponsorResponse> {
+    // ── 1. Determine effective limits ────────────────────────────────
+    const maxSponsoredTx = await this._getEffectiveMaxTx();
+    const maxBudgetPerUser = await this._getEffectiveMaxBudget();
+    const maxFeePerTx = await this._getEffectiveMaxFee();
+
+    // ── 2. Ensure user is tracked & check quota ──────────────────────
+    const user = await ensureUser(walletAddress);
+    const { sponsored_tx_count, total_budget_sponsored } = user;
+
+    if (sponsored_tx_count >= maxSponsoredTx) {
+      return {
+        sponsored: false,
+        reason: `Sponsorship quota exhausted: used ${sponsored_tx_count}/${maxSponsoredTx} sponsored transactions.`,
+        remainingTx: 0,
+        remainingBudget: Math.max(0, maxBudgetPerUser - total_budget_sponsored),
+      };
     }
 
+    if (total_budget_sponsored >= maxBudgetPerUser) {
+      return {
+        sponsored: false,
+        reason: `Sponsorship budget exhausted: used ${total_budget_sponsored}/${maxBudgetPerUser} stroops.`,
+        remainingTx: maxSponsoredTx - sponsored_tx_count,
+        remainingBudget: 0,
+      };
+    }
+
+    // ── 3. Parse and validate the user's transaction ─────────────────
+    let userTx: Transaction;
+    try {
+      const parsed = TransactionBuilder.fromXDR(txXdr, this.network);
+      if (parsed instanceof FeeBumpTransaction) {
+        return {
+          sponsored: false,
+          reason: "Expected a standard transaction XDR, not a fee-bump.",
+          remainingTx: maxSponsoredTx - sponsored_tx_count,
+          remainingBudget: Math.max(0, maxBudgetPerUser - total_budget_sponsored),
+        };
+      }
+      userTx = parsed;
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { source: "paymaster" },
+        extra: { walletAddress },
+      });
+      return {
+        sponsored: false,
+        reason: "Invalid transaction XDR.",
+        remainingTx: maxSponsoredTx - sponsored_tx_count,
+        remainingBudget: Math.max(0, maxBudgetPerUser - total_budget_sponsored),
+      };
+    }
+
+    // ── 4. Determine the fee — use the user's declared base fee ──────
+    const declaredFee = userTx.fee;
+    const feeStroops = Math.min(declaredFee, maxFeePerTx);
+
+    // Check remaining budget with this fee taken into account
+    const estimatedBudgetAfter = total_budget_sponsored + feeStroops;
+    if (estimatedBudgetAfter > maxBudgetPerUser) {
+      return {
+        sponsored: false,
+        reason: `Sponsored fee (${feeStroops} stroops) would exceed remaining budget (${maxBudgetPerUser - total_budget_sponsored} stroops).`,
+        remainingTx: maxSponsoredTx - sponsored_tx_count,
+        remainingBudget: Math.max(0, maxBudgetPerUser - total_budget_sponsored),
+      };
+    }
+
+    // ── 5. Build and sign the fee-bump transaction ───────────────────
+    try {
+      const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+        this.paymasterKey,
+        String(feeStroops),
+        userTx,
+        this.network,
+      );
+
+      feeBumpTx.sign(this.paymasterKey);
+      const feeBumpXdr = feeBumpTx.toXDR();
+
+      // ── 6. Persist the sponsorship increment ───────────────────────
+      // The inner tx hash is available before submission; the outer
+      // (fee-bump) hash can be provided later via a confirmation call.
+      const innerHash = userTx.hash().toString("hex");
+      await incrementSponsorship(walletAddress, feeStroops, innerHash);
+
+      return {
+        sponsored: true,
+        feeBumpTxXdr: feeBumpXdr,
+        remainingTx: maxSponsoredTx - (sponsored_tx_count + 1),
+        remainingBudget: maxBudgetPerUser - estimatedBudgetAfter,
+      };
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { source: "paymaster" },
+        extra: { walletAddress, feeStroops },
+      });
+      return {
+        sponsored: false,
+        reason: "Failed to create fee-bump transaction. Please try again.",
+        remainingTx: maxSponsoredTx - sponsored_tx_count,
+        remainingBudget: Math.max(0, maxBudgetPerUser - total_budget_sponsored),
+      };
+    }
+  }
+
+  /**
+   * Create a raw fee-bump XDR without quota/budget checks.
+   * Useful for admin-initiated or off-chain operations.
+   */
+  async createFeeBump(userTxXdr: string, maxFee?: number): Promise<string> {
+    const userTx = TransactionBuilder.fromXDR(userTxXdr, this.network);
+
+    if (userTx instanceof FeeBumpTransaction) {
+      throw new Error("Expected a standard transaction XDR, received a fee-bump transaction.");
+    }
+
+    const fee = maxFee ?? 100_000; // default 0.01 XLM
     const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
       this.paymasterKey,
-      String(maxFee),
+      String(fee),
       userTx,
-      this.network
-    )
+      this.network,
+    );
 
-    feeBumpTx.sign(this.paymasterKey)
+    feeBumpTx.sign(this.paymasterKey);
+    return feeBumpTx.toXDR();
+  }
 
-    return feeBumpTx.toXDR()
+  /**
+   * Retrieve the effective max sponsored tx count from DB config or default.
+   */
+  private async _getEffectiveMaxTx(): Promise<number> {
+    const override = await getConfigValue(CONFIG_KEYS.MAX_SPONSORED_TX);
+    return parseNumericConfig(override, getPaymasterConfig().maxSponsoredTx);
+  }
+
+  /**
+   * Retrieve the effective max budget per user from DB config or default.
+   */
+  private async _getEffectiveMaxBudget(): Promise<number> {
+    const override = await getConfigValue(CONFIG_KEYS.MAX_BUDGET_PER_USER);
+    return parseNumericConfig(override, getPaymasterConfig().maxBudgetPerUserStroops);
+  }
+
+  /**
+   * Retrieve the effective max fee per tx from DB config or default.
+   */
+  private async _getEffectiveMaxFee(): Promise<number> {
+    const override = await getConfigValue(CONFIG_KEYS.MAX_FEE_PER_TX);
+    return parseNumericConfig(override, getPaymasterConfig().maxFeePerTxStroops);
   }
 }

--- a/apps/web/lib/paymaster/config.ts
+++ b/apps/web/lib/paymaster/config.ts
@@ -1,0 +1,41 @@
+/**
+ * Paymaster configuration defaults and helpers.
+ *
+ * Global overrides can be stored in the `paymaster_config` database table.
+ * These defaults are used when no DB override exists.
+ */
+
+import {
+  DEFAULT_MAX_BUDGET_PER_USER,
+  DEFAULT_MAX_FEE_PER_TX,
+  DEFAULT_MAX_SPONSORED_TX,
+  type PaymasterConfig,
+} from "./types";
+
+/**
+ * Returns the effective paymaster configuration.
+ *
+ * In the current implementation these are static defaults. In the future
+ * they can be loaded from the `paymaster_config` DB table and cached with
+ * a short TTL so admin updates take effect quickly without a restart.
+ */
+export function getPaymasterConfig(): PaymasterConfig {
+  return {
+    maxSponsoredTx: DEFAULT_MAX_SPONSORED_TX,
+    maxBudgetPerUserStroops: DEFAULT_MAX_BUDGET_PER_USER,
+    maxFeePerTxStroops: DEFAULT_MAX_FEE_PER_TX,
+    paymasterPublicKey: process.env.NEXT_PUBLIC_PAYMASTER_PUBLIC_KEY,
+  };
+}
+
+/**
+ * Utility to parse a numeric config value from the DB or env with a fallback.
+ */
+export function parseNumericConfig(
+  raw: string | undefined | null,
+  fallback: number,
+): number {
+  if (raw === undefined || raw === null) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/apps/web/lib/paymaster/db.ts
+++ b/apps/web/lib/paymaster/db.ts
@@ -1,0 +1,189 @@
+/**
+ * Paymaster database operations.
+ *
+ * Uses the shared PostgreSQL client from `@/lib/db` to read/write
+ * sponsorship quotas, budgets, and transaction logs.
+ *
+ * All server-side only — never import in client components.
+ */
+
+import { getDb } from "@/lib/db";
+
+import type {
+  PaymasterConfigRecord,
+  PaymasterTxRecord,
+  PaymasterUserRecord,
+} from "./types";
+
+// ─── Users (quota / budget) ────────────────────────────────────────────────
+
+/**
+ * Ensure a user row exists in `paymaster_users`. If it doesn't, insert it
+ * with the default sponsorship limits. Returns the current record.
+ */
+export async function ensureUser(walletAddress: string): Promise<PaymasterUserRecord> {
+  const sql = getDb();
+
+  // Try an upsert: if the row exists this is a no-op; otherwise insert defaults.
+  const [row] = await sql`
+    INSERT INTO paymaster_users (wallet_address)
+    VALUES (${walletAddress})
+    ON CONFLICT (wallet_address) DO NOTHING
+    RETURNING *
+  `;
+
+  if (row) return row as unknown as PaymasterUserRecord;
+
+  // Row already existed — fetch it.
+  return getUser(walletAddress);
+}
+
+/**
+ * Fetch a single user record by wallet address.
+ * @throws if the user does not exist.
+ */
+export async function getUser(walletAddress: string): Promise<PaymasterUserRecord> {
+  const sql = getDb();
+  const [row] = await sql`
+    SELECT * FROM paymaster_users WHERE wallet_address = ${walletAddress}
+  `;
+  if (!row) throw new Error(`Paymaster user not found: ${walletAddress}`);
+  return row as unknown as PaymasterUserRecord;
+}
+
+/**
+ * Atomically increment the sponsorship counters for a user.
+ * Returns the updated record.
+ */
+export async function incrementSponsorship(
+  walletAddress: string,
+  feeStroops: number,
+  txHash: string,
+  innerTxHash?: string,
+): Promise<PaymasterUserRecord> {
+  const sql = getDb();
+
+  const [row] = await sql`
+    UPDATE paymaster_users
+    SET
+      sponsored_tx_count = sponsored_tx_count + 1,
+      total_budget_sponsored = total_budget_sponsored + ${feeStroops},
+      updated_at = NOW()
+    WHERE wallet_address = ${walletAddress}
+    RETURNING *
+  `;
+
+  // Log the transaction
+  await sql`
+    INSERT INTO paymaster_transactions (wallet_address, tx_hash, inner_tx_hash, fee_sponsored)
+    VALUES (${walletAddress}, ${txHash}, ${innerTxHash ?? null}, ${feeStroops})
+  `;
+
+  if (!row) throw new Error(`Failed to increment sponsorship for: ${walletAddress}`);
+  return row as unknown as PaymasterUserRecord;
+}
+
+// ─── Transactions (audit log) ──────────────────────────────────────────────
+
+/**
+ * Return the most recent sponsored transactions for a wallet.
+ */
+export async function getTransactionHistory(
+  walletAddress: string,
+  limit = 50,
+): Promise<PaymasterTxRecord[]> {
+  const sql = getDb();
+  const rows = await sql`
+    SELECT * FROM paymaster_transactions
+    WHERE wallet_address = ${walletAddress}
+    ORDER BY created_at DESC
+    LIMIT ${limit}
+  `;
+  return rows as unknown as PaymasterTxRecord[];
+}
+
+/**
+ * Return all sponsored transactions (admin view), newest first.
+ */
+export async function getAllTransactions(limit = 100, offset = 0): Promise<PaymasterTxRecord[]> {
+  const sql = getDb();
+  const rows = await sql`
+    SELECT * FROM paymaster_transactions
+    ORDER BY created_at DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+  `;
+  return rows as unknown as PaymasterTxRecord[];
+}
+
+// ─── Global config overrides ───────────────────────────────────────────────
+
+/**
+ * Get a single config override value. Returns `null` if not set.
+ */
+export async function getConfigValue(key: string): Promise<string | null> {
+  const sql = getDb();
+  const [row] = await sql`
+    SELECT value FROM paymaster_config WHERE key = ${key}
+  `;
+  return row ? (row as unknown as PaymasterConfigRecord).value : null;
+}
+
+/**
+ * Set or update a config override value.
+ */
+export async function setConfigValue(key: string, value: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO paymaster_config (key, value)
+    VALUES (${key}, ${value})
+    ON CONFLICT (key) DO UPDATE SET value = ${value}
+  `;
+}
+
+/**
+ * Delete a config override value (revert to default).
+ */
+export async function deleteConfigValue(key: string): Promise<void> {
+  const sql = getDb();
+  await sql`DELETE FROM paymaster_config WHERE key = ${key}`;
+}
+
+// ─── Admin helpers ─────────────────────────────────────────────────────────
+
+/**
+ * List all tracked paymaster users with their usage stats.
+ */
+export async function listUsers(): Promise<PaymasterUserRecord[]> {
+  const sql = getDb();
+  const rows = await sql`
+    SELECT * FROM paymaster_users ORDER BY updated_at DESC
+  `;
+  return rows as unknown as PaymasterUserRecord[];
+}
+
+/**
+ * Update sponsorship limits for a specific user.
+ */
+export async function updateUserLimits(
+  walletAddress: string,
+  limits: { maxSponsoredTx?: number; maxBudgetPerUser?: number },
+): Promise<PaymasterUserRecord> {
+  const sql = getDb();
+
+  const sets: string[] = [];
+  if (limits.maxSponsoredTx !== undefined) sets.push(`max_sponsored_tx = ${limits.maxSponsoredTx}`);
+  if (limits.maxBudgetPerUser !== undefined) sets.push(`max_budget_per_user = ${limits.maxBudgetPerUser}`);
+
+  if (sets.length === 0) throw new Error("No limits to update");
+
+  const [row] = await sql`
+    UPDATE paymaster_users
+    SET ${sql(sets.join(", "))}, updated_at = NOW()
+    WHERE wallet_address = ${walletAddress}
+    RETURNING *
+  `;
+
+  if (!row) throw new Error(`User not found: ${walletAddress}`);
+  return row as unknown as PaymasterUserRecord;
+}

--- a/apps/web/lib/paymaster/index.ts
+++ b/apps/web/lib/paymaster/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Paymaster module — fee abstraction for new users.
+ *
+ * Export surface for the paymaster service. Prefer importing from this
+ * barrel rather than deep-importing individual files.
+ */
+
+export { getPaymaster, resetPaymaster, StellarPaymaster } from "../paymaster";
+export { getPaymasterConfig } from "./config";
+export * from "./types";
+
+// DB operations (server-side only)
+export {
+  ensureUser,
+  getUser,
+  incrementSponsorship,
+  getTransactionHistory,
+  getAllTransactions,
+  listUsers,
+  updateUserLimits,
+  getConfigValue,
+  setConfigValue,
+  deleteConfigValue,
+} from "./db";

--- a/apps/web/lib/paymaster/migration.sql
+++ b/apps/web/lib/paymaster/migration.sql
@@ -1,0 +1,44 @@
+/**
+ * Paymaster database migration SQL.
+ *
+ * Run against the hunty PostgreSQL database to create the paymaster tables.
+ *
+ * Usage:
+ *   psql "$DATABASE_URL" -f lib/paymaster/migration.sql
+ *
+ * Or run via a one-off script:
+ *   node -e "require('@/lib/db').getDb().file('lib/paymaster/migration.sql')"
+ */
+
+-- Track per-user sponsorship quotas and budgets
+CREATE TABLE IF NOT EXISTS paymaster_users (
+    wallet_address    TEXT PRIMARY KEY,
+    sponsored_tx_count  INTEGER NOT NULL DEFAULT 0,
+    total_budget_sponsored BIGINT NOT NULL DEFAULT 0,  -- stroops (1 XLM = 10_000_000)
+    max_sponsored_tx    INTEGER NOT NULL DEFAULT 3,
+    max_budget_per_user BIGINT NOT NULL DEFAULT 10000000,  -- 1 XLM in stroops
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Record every sponsored transaction for audit
+CREATE TABLE IF NOT EXISTS paymaster_transactions (
+    id              SERIAL PRIMARY KEY,
+    wallet_address  TEXT NOT NULL REFERENCES paymaster_users(wallet_address),
+    tx_hash         TEXT NOT NULL,
+    inner_tx_hash   TEXT,
+    fee_sponsored   BIGINT NOT NULL,  -- stroops
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_paymaster_tx_wallet
+    ON paymaster_transactions(wallet_address);
+
+CREATE INDEX IF NOT EXISTS idx_paymaster_tx_created
+    ON paymaster_transactions(created_at DESC);
+
+-- Global key-value config overrides
+CREATE TABLE IF NOT EXISTS paymaster_config (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/apps/web/lib/paymaster/types.ts
+++ b/apps/web/lib/paymaster/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Type definitions for the Paymaster fee-abstraction service.
+ *
+ * The paymaster sponsors transaction fees for new users so they can
+ * interact with the app without needing XLM for gas. Each user gets a
+ * quota of sponsored transactions and a total sponsored-fee budget.
+ * Once either limit is exceeded the client falls back to user-paid fees.
+ */
+
+/** Default sponsorship quota for a new user. */
+export const DEFAULT_MAX_SPONSORED_TX = 3;
+
+/** Default XLM budget per user (in stroops — 1 XLM = 10_000_000 stroops). */
+export const DEFAULT_MAX_BUDGET_PER_USER = 10_000_000; // 1 XLM
+
+/** Default max fee per sponsored transaction (stroops). */
+export const DEFAULT_MAX_FEE_PER_TX = 100_000; // 0.01 XLM
+
+/** Key used in the paymaster_config table for global overrides. */
+export const CONFIG_KEYS = {
+  MAX_SPONSORED_TX: "max_sponsored_tx",
+  MAX_BUDGET_PER_USER: "max_budget_per_user_stroops",
+  MAX_FEE_PER_TX: "max_fee_per_tx_stroops",
+  PAYMASTER_PUBLIC_KEY: "paymaster_public_key",
+} as const;
+
+// ─── API Types ─────────────────────────────────────────────────────────────
+
+export interface SponsorRequest {
+  /** The original transaction XDR the user wants sponsored. */
+  txXdr: string;
+  /** Stellar G-address of the user requesting sponsorship. */
+  walletAddress: string;
+}
+
+export interface SponsorResponse {
+  /** Whether the sponsorship was accepted. */
+  sponsored: boolean;
+  /**
+   * If `sponsored === true`, the fee-bump transaction XDR signed by the
+   * paymaster. The client must submit this to the network.
+   */
+  feeBumpTxXdr?: string;
+  /**
+   * If `sponsored === false`, a reason explaining the fallback to
+   * user-paid fees.
+   */
+  reason?: string;
+  /** Remaining sponsored transaction count after this request. */
+  remainingTx: number;
+  /** Remaining sponsored budget (stroops) after this request. */
+  remainingBudget: number;
+}
+
+export interface BudgetInfo {
+  walletAddress: string;
+  /** How many sponsored transactions this user has used. */
+  usedTx: number;
+  /** Maximum sponsored transactions allowed. */
+  maxTx: number;
+  /** How many stroops of sponsored fees this user has consumed. */
+  usedBudget: number;
+  /** Maximum sponsored budget in stroops. */
+  maxBudget: number;
+  /** Whether the user is still eligible for sponsorship. */
+  eligible: boolean;
+}
+
+export interface PaymasterConfig {
+  maxSponsoredTx: number;
+  maxBudgetPerUserStroops: number;
+  maxFeePerTxStroops: number;
+  paymasterPublicKey?: string;
+}
+
+export interface AdminConfigUpdate {
+  maxSponsoredTx?: number;
+  maxBudgetPerUserStroops?: number;
+  maxFeePerTxStroops?: number;
+}
+
+// ─── Database Records ──────────────────────────────────────────────────────
+
+export interface PaymasterUserRecord {
+  wallet_address: string;
+  sponsored_tx_count: number;
+  total_budget_sponsored: number; // stroops
+  max_sponsored_tx: number;
+  max_budget_per_user: number;    // stroops
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface PaymasterTxRecord {
+  id: number;
+  wallet_address: string;
+  tx_hash: string;
+  fee_sponsored: number; // stroops
+  inner_tx_hash?: string;
+  created_at: Date;
+}
+
+export interface PaymasterConfigRecord {
+  key: string;
+  value: string;
+}


### PR DESCRIPTION
- Paymaster API endpoint at POST /api/paymaster/sponsor
- Fee sponsorship with configurable per-user quota (default: 3 txs)
- Budget tracking per user via PostgreSQL
- Admin controls at GET/POST /api/paymaster/admin/config
- Fallback to user-paid fees when budget exceeded
- Migration SQL for paymaster database tables



closes #573 