### PR TITLE
fix: add real security:test script and remove || true from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           files: ./coverage/coverage-final.json
           flags: unittests
           name: codecov-umbrella
-        continue-on-error: true
+        continue-on-error: true # Codecov is an external reporting service; a network failure should not fail the build
 
   mutation:
     name: Mutation Tests
@@ -132,7 +132,6 @@ jobs:
 
       - name: Run Visual Regression Tests
         run: npx playwright test visual-regression --reporter=github
-        continue-on-error: true
 
       - name: Upload Visual Diff Artifacts
         uses: actions/upload-artifact@v4
@@ -166,7 +165,6 @@ jobs:
 
       - name: Run Playwright tests
         run: npm run test:e2e
-        continue-on-error: true
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -18,26 +18,37 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build Next.js app
-        run: npm run build
+        run: pnpm --filter @hunty/web build
 
       - name: Start Next.js app in background
         run: |
-          npm start &
+          pnpm --filter @hunty/web start &
           npx wait-on http://localhost:3000 --timeout 30000
 
       - name: Dependency vulnerability scan
-        run: npm audit --audit-level=moderate || true
+        run: pnpm audit --audit-level=moderate
+
+      - name: Install Playwright browsers (Chromium only)
+        run: pnpm --filter @hunty/web exec playwright install chromium --with-deps
 
       - name: Run Playwright security tests
-        run: npm run security:test || true
+        run: pnpm run security:test
 
       - name: OWASP ZAP baseline scan
         uses: zaproxy/action-baseline@v0.8.0
         with:
           target: "http://localhost:3000"
-        continue-on-error: true # prevents workflow failure if ZAP fails
+        continue-on-error: true # ZAP scan is advisory; findings are reviewed separately
         # NOTE: The ZAP baseline expects a running server; we started it above.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "smoke": "playwright test --config=playwright.smoke.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "security:test": "playwright test e2e/security.spec.ts --project=chromium-desktop",
     "perf:budget": "node scripts/check-performance-budgets.mjs",
     "clean": "rm -rf .next"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "e2e": "npm run e2e --workspace @hunty/web",
     "smoke": "npm run smoke --workspace @hunty/web",
     "test:e2e": "npm run test:e2e --workspace @hunty/web",
+    "security:test": "npm run security:test --workspace @hunty/web",
     "analyze": "npm run analyze --workspace @hunty/web",
     "bundle:check": "npm run bundle:check --workspace @hunty/web",
     "perf:budget": "npm run perf:budget --workspace @hunty/web",


### PR DESCRIPTION
- Add security:test script to apps/web/package.json (runs e2e/security.spec.ts via Playwright on Chromium) and root package.json (workspace delegate)
- Remove '|| true' from pnpm audit and security:test steps in security-tests.yml so failures actually fail the job
- Fix pnpm setup in security-tests.yml (was incorrectly using npm ci)
- Add playwright install step before security tests
- Remove continue-on-error from e2e and visual-regression test steps in ci.yml
- Document why ZAP scan and Codecov upload legitimately keep continue-on-error


closes #890