### PR TITLE
ci: add concurrency groups to cancel stale workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint and Type Check

--- a/.github/workflows/playwright-cross-browser.yml
+++ b/.github/workflows/playwright-cross-browser.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: playwright-cross-browser-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Axe accessibility audit (runs once on Chromium) ─────────────────────────
   # Serious and critical violations fail the build.


### PR DESCRIPTION
## Overview

`ci.yml` and `playwright-cross-browser.yml` lacked a `concurrency` group with `cancel-in-progress: true`, causing duplicate workflow runs to execute in full when commits were pushed in quick succession. This adds concurrency controls matching the pattern already used by `mobile-e2e.yml` and `ios-testflight.yml`, preventing unnecessary waste of CI minutes.

## Related Issue

Closes #894

## Changes

* **[FIX]** `ci.yml` — Added `concurrency` block keyed on `${{ github.ref }}` with `cancel-in-progress: true`
* **[FIX]** `playwright-cross-browser.yml` — Added `concurrency` block keyed on `${{ github.ref }}` with `cancel-in-progress: true`
* **[SKIP]** `smoke-tests.yml` — Already had the concurrency setting, left unchanged
* **[SKIP]** Deploy workflows — Deliberately excluded from cancellation

## Verification

```
- ci.yml -- concurrency group added (ci-${{ github.ref }})
- playwright-cross-browser.yml -- concurrency group added (playwright-cross-browser-${{ github.ref }})
- smoke-tests.yml -- already configured, no change needed
- Deploy workflows -- not modified (excluded from cancellation)
```

| Acceptance Criteria | Status |
|---|---|
| `ci.yml` sets a concurrency group keyed on the ref with `cancel-in-progress: true` | Done |
| The same is applied to `playwright-cross-browser.yml` | Done |
| `smoke-tests.yml` already has it -- no change required | Done |
| Deploy workflows are deliberately excluded from cancellation | Done |
