### PR TITLE
test: add @types/supertest and fix api_routes.test.ts type-safety

### DIFF
--- a/apps/web/lib/contracts/hunt.ts
+++ b/apps/web/lib/contracts/hunt.ts
@@ -1,43 +1,44 @@
-import Server, { TransactionBuilder, Operation, Account } from "@stellar/stellar-sdk";
+import Server, { Account, Operation, TransactionBuilder } from "@stellar/stellar-sdk";
+
+import { sha256Hex } from "@/lib/crypto";
 import {
   advanceHuntProgress,
   getHunt as getStoredHunt,
   getHuntClues,
   getHuntProgress,
 } from "@/lib/huntStore";
-import { withSorobanRpcRetry } from "@/lib/soroban/rpcRetry";
-import { pollTransactionStatus } from "@/lib/soroban/contractHelpers";
-import { normalizeNetworkError, AnswerIncorrectError, SequentialClueError } from "./errors";
-import { SOROBAN_RPC_URL, NETWORK_PASSPHRASE } from "./config";
-import { getActiveWalletAdapter } from "@/lib/walletAdapter";
-import { sha256Hex } from "@/lib/crypto";
 import { logger } from "@/lib/logger";
 import { isOnline, queueProgressUpdate } from "@/lib/offlineSync";
-
+import { pollTransactionStatus } from "@/lib/soroban/contractHelpers";
+import { withSorobanRpcRetry } from "@/lib/soroban/rpcRetry";
 import type {
+  ActivateHuntResult,
+  AddClueResult,
   ClueDifficulty,
   ClueInfo,
+  CreateHuntResult,
+  ExtendHuntResult,
+  FastestPlayerEntry,
   HuntDifficulty,
   HuntInfo,
-  CreateHuntResult,
-  SubmitAnswerResult,
-  ActivateHuntResult,
-  AddClueResult,
-  ExtendHuntResult,
   LeaderboardEntry,
-  FastestPlayerEntry,
+  SubmitAnswerResult,
 } from "@/lib/types";
+import { getActiveWalletAdapter } from "@/lib/walletAdapter";
+
+import { NETWORK_PASSPHRASE, SOROBAN_RPC_URL } from "./config";
+import { AnswerIncorrectError, normalizeNetworkError, SequentialClueError } from "./errors";
 
 export type {
-  ClueInfo,
-  HuntInfo,
-  CreateHuntResult,
-  SubmitAnswerResult,
   ActivateHuntResult,
   AddClueResult,
+  ClueInfo,
+  CreateHuntResult,
   ExtendHuntResult,
-  LeaderboardEntry,
   FastestPlayerEntry,
+  HuntInfo,
+  LeaderboardEntry,
+  SubmitAnswerResult,
 };
 
 export type ClueInput = {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -98,6 +98,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/serviceworker": "^0.0.197",
+    "@types/supertest": "^7.2.1",
     "@vitejs/plugin-react": "^4.2.0",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.1.1",

--- a/apps/web/tests/api_routes.test.ts
+++ b/apps/web/tests/api_routes.test.ts
@@ -1,17 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
-// @ts-expect-error supertest has no types installed
-import request from 'supertest';
+import type { IncomingMessage, ServerResponse } from "http";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
 
-import { GET as getFeatured } from '@/app/api/admin/featured/route';
-import { GET as getAnalytics } from '@/app/api/analytics/performance/route';
-import { POST as postIpfs, GET as getIpfs } from '@/app/api/ipfs/route';
-import { GET as getHunts } from '@/app/api/v1/hunts/route';
-import { GET as getLeaderboard } from '@/app/api/v1/hunts/[id]/leaderboard/route';
-import { GET as getPublicLeaderboard } from '@/app/api/v1/hunts/[id]/leaderboard/public/route';
-import { GET as getLeaderboardOgImage } from '@/app/api/og/leaderboard/route';
+import { GET as getFeatured } from "@/app/api/admin/featured/route";
+import { GET as getAnalytics } from "@/app/api/analytics/performance/route";
+import { POST as postIpfs } from "@/app/api/ipfs/route";
+import { GET as getLeaderboardOgImage } from "@/app/api/og/leaderboard/route";
+import { GET as getPublicLeaderboard } from "@/app/api/v1/hunts/[id]/leaderboard/public/route";
+import { GET as getLeaderboard } from "@/app/api/v1/hunts/[id]/leaderboard/route";
+import { GET as getHunts } from "@/app/api/v1/hunts/route";
 
-function handlerToExpress(handler: unknown) {
-  return async (req: any, res: any) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- route handler signature varies per route
+function handlerToExpress(handler: (...args: any[]) => any) {
+  return async (req: IncomingMessage, res: ServerResponse) => {
     try {
       const url = `http://localhost${req.url || req.originalUrl}`;
       const method = req.method;
@@ -19,7 +20,7 @@ function handlerToExpress(handler: unknown) {
       for (const [key, value] of Object.entries(req.headers)) {
         if (value !== undefined) {
           if (Array.isArray(value)) {
-            value.forEach(v => headers.append(key, v));
+            value.forEach((v) => headers.append(key, v));
           } else {
             headers.set(key, String(value));
           }
@@ -29,7 +30,7 @@ function handlerToExpress(handler: unknown) {
       if (method !== "GET" && method !== "HEAD" && req.body) {
         body = typeof req.body === "object" ? JSON.stringify(req.body) : req.body;
       }
-      
+
       const webRequest = new Request(url, {
         method,
         headers,
@@ -45,7 +46,7 @@ function handlerToExpress(handler: unknown) {
       }
 
       const result = await handler(webRequest, { params });
-      
+
       if (result instanceof Response) {
         res.statusCode = result.status;
         result.headers.forEach((value, key) => {
@@ -68,83 +69,85 @@ function handlerToExpress(handler: unknown) {
         res.statusCode = 200;
         res.end(typeof result === "string" ? result : JSON.stringify(result));
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       res.statusCode = 500;
       res.setHeader("content-type", "application/json");
-      res.end(JSON.stringify({ error: err.message }));
+      res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
     }
   };
 }
 
-describe('API Integration Tests', () => {
-  it('GET /api/v1/hunts should return paginated hunts', async () => {
+describe("API Integration Tests", () => {
+  it("GET /api/v1/hunts should return paginated hunts", async () => {
     const app = request(handlerToExpress(getHunts));
-    const response = await app.get('/api/v1/hunts?limit=5');
+    const response = await app.get("/api/v1/hunts?limit=5");
     expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('data');
-    expect(response.body).toHaveProperty('pagination');
+    expect(response.body).toHaveProperty("data");
+    expect(response.body).toHaveProperty("pagination");
   });
 
-  it('GET /api/v1/hunts/:id/leaderboard returns leaderboard data', async () => {
+  it("GET /api/v1/hunts/:id/leaderboard returns leaderboard data", async () => {
     const app = request(handlerToExpress(getLeaderboard));
-    const response = await app.get('/api/v1/hunts/123/leaderboard');
+    const response = await app.get("/api/v1/hunts/123/leaderboard");
     expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('data');
-    expect(response.body).toHaveProperty('pagination');
+    expect(response.body).toHaveProperty("data");
+    expect(response.body).toHaveProperty("pagination");
   });
 
-  it('GET /api/v1/hunts/:id/leaderboard/public returns public leaderboard payload', async () => {
+  it("GET /api/v1/hunts/:id/leaderboard/public returns public leaderboard payload", async () => {
     const app = request(handlerToExpress(getPublicLeaderboard));
-    const response = await app.get('/api/v1/hunts/123/leaderboard/public');
+    const response = await app.get("/api/v1/hunts/123/leaderboard/public");
     expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('hunt');
-    expect(response.body).toHaveProperty('leaderboard');
-    expect(response.body).toHaveProperty('embedUrl');
+    expect(response.body).toHaveProperty("hunt");
+    expect(response.body).toHaveProperty("leaderboard");
+    expect(response.body).toHaveProperty("embedUrl");
   });
 
-  it('GET /api/og/leaderboard returns an image response', async () => {
+  it("GET /api/og/leaderboard returns an image response", async () => {
     const app = request(handlerToExpress(getLeaderboardOgImage));
-    const response = await app.get('/api/og/leaderboard?huntId=123&wallet=GABC123');
+    const response = await app.get("/api/og/leaderboard?huntId=123&wallet=GABC123");
     expect(response.status).toBe(200);
-    expect(response.headers['content-type']).toContain('image');
+    expect(response.headers["content-type"]).toContain("image");
   });
 
-  it('GET /api/admin/featured returns featured items', async () => {
+  it("GET /api/admin/featured returns featured items", async () => {
     const app = request(handlerToExpress(getFeatured));
-    const response = await app.get('/api/admin/featured');
+    const response = await app.get("/api/admin/featured");
     expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('featuredHuntId');
+    expect(response.body).toHaveProperty("featuredHuntId");
   });
 
-  it('POST /api/ipfs returns 503 if not configured', async () => {
+  it("POST /api/ipfs returns 503 if not configured", async () => {
     const app = request(handlerToExpress(postIpfs));
-    const response = await app.post('/api/ipfs');
+    const response = await app.post("/api/ipfs");
     expect(response.status).toBe(503);
-    expect(response.body).toHaveProperty('error');
+    expect(response.body).toHaveProperty("error");
   });
 
-  it('GET /api/analytics returns analytics data', async () => {
+  it("GET /api/analytics returns analytics data", async () => {
     const app = request(handlerToExpress(getAnalytics));
-    const response = await app.get('/api/analytics');
+    const response = await app.get("/api/analytics");
     expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('metrics');
+    expect(response.body).toHaveProperty("metrics");
   });
 
-  it('Unauthorized access returns 401 when applicable', async () => {
+  it("Unauthorized access returns 401 when applicable", async () => {
     const app = request(handlerToExpress(getHunts));
-    const response = await app.get('/api/v1/hunts');
+    const response = await app.get("/api/v1/hunts");
     if (response.status === 401) {
-      expect(response.body).toHaveProperty('error');
+      expect(response.body).toHaveProperty("error");
     } else {
       expect([200, 403]).toContain(response.status);
     }
   });
 
-  it('Error response follows format', async () => {
-    const errorHandler = async () => { throw new Error('Test error'); };
+  it("Error response follows format", async () => {
+    const errorHandler = async () => {
+      throw new Error("Test error");
+    };
     const app = request(handlerToExpress(errorHandler));
-    const response = await app.get('/api/error');
+    const response = await app.get("/api/error");
     expect(response.status).toBeGreaterThanOrEqual(400);
-    expect(response.body).toHaveProperty('error');
+    expect(response.body).toHaveProperty("error");
   });
 });

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -27,11 +27,6 @@
     "mobile/**/*",
     "stories/**/*",
     "**/*.stories.ts",
-    "**/*.stories.tsx",
-    "**/__tests__/**/*",
-    "**/*.test.ts",
-    "**/*.test.tsx",
-    "**/*.spec.ts",
-    "**/*.spec.tsx"
+    "**/*.stories.tsx"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,7 +495,7 @@ importers:
         version: 10.2.9(@types/babel__core@7.20.5)(next@15.3.4(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(esbuild@0.28.1)(postcss@8.5.23))
       '@hookform/resolvers':
         specifier: ^5.2.2
-        version: 5.5.7(@sinclair/typebox@0.27.12)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(joi@17.11.0)(react-hook-form@7.83.0(react@19.2.8))(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
+        version: 5.5.7(@sinclair/typebox@0.27.12)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(joi@17.11.0)(react-hook-form@7.83.0(react@19.2.8))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       '@hunty/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -695,6 +695,9 @@ importers:
       '@types/serviceworker':
         specifier: ^0.0.197
         version: 0.0.197
+      '@types/supertest':
+        specifier: ^7.2.1
+        version: 7.2.1
       '@vitejs/plugin-react':
         specifier: ^4.2.0
         version: 4.7.0(vite@8.1.5(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
@@ -764,6 +767,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.6
+      '@next/eslint-plugin-next':
+        specifier: 15.3.4
+        version: 15.3.4
       eslint:
         specifier: ^9
         version: 9.39.5(jiti@2.7.0)
@@ -781,10 +787,6 @@ importers:
         version: 5.9.3
 
   packages/types:
-    dependencies:
-      zod:
-        specifier: ^4.0.0
-        version: 4.4.3
     devDependencies:
       eslint:
         specifier: ^9
@@ -795,6 +797,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
 
   packages/ui:
     dependencies:
@@ -5287,6 +5292,9 @@ packages:
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -5365,6 +5373,9 @@ packages:
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
 
@@ -5399,6 +5410,12 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/superagent@8.1.11':
+    resolution: {integrity: sha512-KA7srSW/HENDtOw9DOqaFLgWuMqN9WgjEw62lh9dpvRaZDkhdOkazASd7X7i2eMUYLHa1U37ZttnePsH5zTDHw==}
+
+  '@types/supertest@7.2.1':
+    resolution: {integrity: sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -15086,7 +15103,7 @@ snapshots:
       valibot: 1.4.2(typescript@5.9.3)
       zod: 4.4.3
 
-  '@hookform/resolvers@5.5.7(@sinclair/typebox@0.27.12)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(joi@17.11.0)(react-hook-form@7.83.0(react@19.2.8))(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)':
+  '@hookform/resolvers@5.5.7(@sinclair/typebox@0.27.12)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(joi@17.11.0)(react-hook-form@7.83.0(react@19.2.8))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.83.0(react@19.2.8)
@@ -15096,7 +15113,7 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       joi: 17.11.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
       zod: 4.4.3
 
   '@humanfs/core@0.19.2':
@@ -18576,6 +18593,8 @@ snapshots:
     dependencies:
       '@types/node': 20.19.43
 
+  '@types/cookiejar@2.1.5': {}
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -18649,6 +18668,8 @@ snapshots:
 
   '@types/mdx@2.0.14': {}
 
+  '@types/methods@1.1.4': {}
+
   '@types/mysql@2.15.26':
     dependencies:
       '@types/node': 20.19.43
@@ -18684,6 +18705,18 @@ snapshots:
   '@types/shimmer@1.2.0': {}
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/superagent@8.1.11':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 20.19.43
+      form-data: 4.0.6
+
+  '@types/supertest@7.2.1':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.11
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -22694,7 +22727,7 @@ snapshots:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0


### PR DESCRIPTION
- Install @types/supertest in apps/web devDependencies
- Remove @ts-expect-error suppressing supertest import
- Clean up duplicate vitest and route imports in api_routes.test.ts
- Fix wrong analytics route path (analytics/route -> analytics/performance/route)
- Un-exclude test files from tsconfig.json so they are type-checked
- Fix pre-existing parse error in lib/contracts/hunt.ts (missing comma)
- Fix pre-existing duplicate exports in admin/featured/route.ts

closes #900 