### PR TITLE
test: add mobile unit tests for store, location, api modules

### DIFF
--- a/apps/mobile/__mocks__/expo-location.js
+++ b/apps/mobile/__mocks__/expo-location.js
@@ -1,0 +1,7 @@
+module.exports = {
+  requestForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getCurrentPositionAsync: jest.fn(() =>
+    Promise.resolve({ coords: { latitude: 0, longitude: 0 } }),
+  ),
+  Accuracy: { Lowest: 1, Low: 2, Balanced: 3, High: 4, Highest: 5 },
+};

--- a/apps/mobile/__tests__/clueZones.test.ts
+++ b/apps/mobile/__tests__/clueZones.test.ts
@@ -1,0 +1,78 @@
+import type { StoredHunt } from '@hunty/types';
+import { buildClueZones, zoneColor } from '../lib/clueZones';
+
+function makeHunt(overrides: Partial<StoredHunt> = {}): StoredHunt {
+  return {
+    id: 1,
+    title: 'Test Hunt',
+    description: 'A test hunt',
+    cluesCount: 5,
+    status: 'Active',
+    rewardType: 'XLM',
+    ...overrides,
+  };
+}
+
+describe('buildClueZones', () => {
+  it('returns empty array when there are no active hunts', () => {
+    expect(buildClueZones([], 0, 0)).toEqual([]);
+  });
+
+  it('filters out non-Active hunts', () => {
+    const hunts = [
+      makeHunt({ id: 1, status: 'Active' }),
+      makeHunt({ id: 2, status: 'Draft' }),
+      makeHunt({ id: 3, status: 'Cancelled' }),
+    ];
+    const zones = buildClueZones(hunts, 0, 0);
+    expect(zones).toHaveLength(1);
+    expect(zones[0].huntId).toBe(1);
+  });
+
+  it('places zones around the player position', () => {
+    const hunts = [makeHunt({ id: 1 })];
+    const zones = buildClueZones(hunts, 40.0, -74.0);
+    expect(zones).toHaveLength(1);
+    expect(zones[0].latitude).toBeCloseTo(40.0, 3);
+    expect(zones[0].longitude).toBeCloseTo(-74.0 + 0.005, 3);
+  });
+
+  it('spreads multiple zones at different angles', () => {
+    const hunts = [makeHunt({ id: 1 }), makeHunt({ id: 2 }), makeHunt({ id: 3 })];
+    const zones = buildClueZones(hunts, 0, 0);
+    expect(zones).toHaveLength(3);
+
+    const lats = zones.map((z) => z.latitude);
+    const lngs = zones.map((z) => z.longitude);
+
+    expect(new Set(lats).size).toBe(3);
+    expect(new Set(lngs).size).toBe(3);
+  });
+
+  it('calculates radius based on cluesCount', () => {
+    const hunts = [makeHunt({ id: 1, cluesCount: 10 })];
+    const zones = buildClueZones(hunts, 0, 0);
+    expect(zones[0].radius).toBe(150 + 10 * 20);
+  });
+
+  it('preserves title and rewardType from the hunt', () => {
+    const hunts = [makeHunt({ id: 1, title: 'My Hunt', rewardType: 'NFT' })];
+    const zones = buildClueZones(hunts, 0, 0);
+    expect(zones[0].title).toBe('My Hunt');
+    expect(zones[0].rewardType).toBe('NFT');
+  });
+});
+
+describe('zoneColor', () => {
+  it('returns blue for XLM', () => {
+    expect(zoneColor('XLM')).toBe('#3b82f6');
+  });
+
+  it('returns purple for NFT', () => {
+    expect(zoneColor('NFT')).toBe('#8b5cf6');
+  });
+
+  it('returns green for Both', () => {
+    expect(zoneColor('Both')).toBe('#10b981');
+  });
+});

--- a/apps/mobile/__tests__/huntStore.test.ts
+++ b/apps/mobile/__tests__/huntStore.test.ts
@@ -1,0 +1,420 @@
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { scheduleHuntExpiryNotification } from '@utils/huntNotifications';
+import {
+  readHunts,
+  readClues,
+  writeHunts,
+  writeClues,
+  cacheJoinedHuntClues,
+  queueClueAnswer,
+  getQueuedAnswers,
+  processQueuedAnswers,
+  getOfflineCachedClues,
+  getAllHunts,
+  getAllHuntsIncludingPrivate,
+  getCreatorHunts,
+  getHuntsByCreator,
+  getActiveHuntsForFeed,
+  getHuntById,
+  getHunt,
+  getHuntClues,
+  addHunt,
+  saveClueLocally,
+  updateHuntStatus,
+  archiveHunts,
+  deleteHunts,
+  getFeaturedHunts,
+  joinHunt,
+} from '@store/huntStore';
+
+jest.mock('expo-secure-store');
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+jest.mock('@utils/huntNotifications');
+
+const mockHunts = [
+  {
+    id: 1,
+    title: 'City Secrets',
+    description: 'desc',
+    cluesCount: 5,
+    status: 'Active' as const,
+    rewardType: 'Both' as const,
+    startTime: 1000,
+    endTime: 99999,
+  },
+  {
+    id: 2,
+    title: 'Campus Quest',
+    description: 'desc',
+    cluesCount: 7,
+    status: 'Active' as const,
+    rewardType: 'NFT' as const,
+    is_private: true,
+  },
+  {
+    id: 3,
+    title: 'Soroban Sprint',
+    description: 'desc',
+    cluesCount: 4,
+    status: 'Completed' as const,
+    rewardType: 'XLM' as const,
+  },
+];
+
+const mockClues = [
+  { id: 1, huntId: 1, question: 'Q1', answer: 'A1', points: 10 },
+  { id: 2, huntId: 1, question: 'Q2', answer: 'A2', points: 10 },
+  { id: 3, huntId: 2, question: 'Q3', answer: 'A3', points: 8 },
+];
+
+describe('huntStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+    (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('readHunts / readClues (seed fallback)', () => {
+    it('returns seed hunts when SecureStore is empty', async () => {
+      const hunts = await readHunts();
+      expect(hunts.length).toBeGreaterThan(0);
+      expect(hunts[0]).toHaveProperty('id');
+      expect(hunts[0]).toHaveProperty('title');
+    });
+
+    it('returns seed clues when SecureStore is empty', async () => {
+      const clues = await readClues();
+      expect(clues.length).toBeGreaterThan(0);
+      expect(clues[0]).toHaveProperty('huntId');
+    });
+  });
+
+  describe('writeHunts / writeClues', () => {
+    it('serialises hunts to SecureStore', async () => {
+      await writeHunts(mockHunts);
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'hunty_hunts',
+        JSON.stringify(mockHunts),
+      );
+    });
+
+    it('serialises clues to SecureStore', async () => {
+      await writeClues(mockClues);
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'hunty_clues',
+        JSON.stringify(mockClues),
+      );
+    });
+  });
+
+  describe('getAllHunts / getAllHuntsIncludingPrivate / getCreatorHunts / getHuntsByCreator', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('getAllHunts excludes private hunts', async () => {
+      const hunts = await getAllHunts();
+      expect(hunts.every((h) => !h.is_private)).toBe(true);
+    });
+
+    it('getAllHuntsIncludingPrivate includes all hunts', async () => {
+      const hunts = await getAllHuntsIncludingPrivate();
+      expect(hunts).toHaveLength(mockHunts.length);
+    });
+
+    it('getCreatorHunts returns all hunts', async () => {
+      const hunts = await getCreatorHunts();
+      expect(hunts).toHaveLength(mockHunts.length);
+    });
+
+    it('getHuntsByCreator returns all hunts', async () => {
+      const hunts = await getHuntsByCreator();
+      expect(hunts).toHaveLength(mockHunts.length);
+    });
+  });
+
+  describe('getActiveHuntsForFeed', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('returns only active, non-private hunts', async () => {
+      const hunts = await getActiveHuntsForFeed();
+      expect(hunts).toHaveLength(1);
+      expect(hunts[0].id).toBe(1);
+    });
+  });
+
+  describe('getHuntById / getHunt', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('returns the hunt matching the id', async () => {
+      const hunt = await getHuntById(2);
+      expect(hunt?.id).toBe(2);
+    });
+
+    it('returns undefined for a non-existent id', async () => {
+      const hunt = await getHuntById(999);
+      expect(hunt).toBeUndefined();
+    });
+
+    it('getHunt accepts a string id', async () => {
+      const hunt = await getHunt('3');
+      expect(hunt?.id).toBe(3);
+    });
+  });
+
+  describe('getHuntClues', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(JSON.stringify(mockClues))
+        .mockResolvedValueOnce(JSON.stringify(mockClues));
+    });
+
+    it('returns clues matching the hunt id and caches them', async () => {
+      const clues = await getHuntClues(1);
+      expect(clues).toHaveLength(2);
+      expect(clues.every((c) => c.huntId === 1)).toBe(true);
+      expect(AsyncStorage.setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe('addHunt', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('adds a new hunt to the store', async () => {
+      const newHunt = {
+        id: 10,
+        title: 'New Hunt',
+        description: '',
+        cluesCount: 0,
+        status: 'Draft' as const,
+        rewardType: 'XLM' as const,
+      };
+      await addHunt(newHunt);
+      expect(SecureStore.setItemAsync).toHaveBeenCalled();
+      const written = JSON.parse((SecureStore.setItemAsync as jest.Mock).mock.calls[0][1]);
+      expect(written).toHaveLength(mockHunts.length + 1);
+    });
+
+    it('does not duplicate a hunt with the same id', async () => {
+      await addHunt(mockHunts[0]);
+      expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateHuntStatus', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('updates the status of the target hunt', async () => {
+      await updateHuntStatus(1, 'Completed');
+      const written = JSON.parse((SecureStore.setItemAsync as jest.Mock).mock.calls[0][1]);
+      const updated = written.find((h: { id: number }) => h.id === 1);
+      expect(updated.status).toBe('Completed');
+    });
+  });
+
+  describe('archiveHunts', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('sets archived hunt status to Cancelled', async () => {
+      await archiveHunts([1, 2]);
+      const written = JSON.parse((SecureStore.setItemAsync as jest.Mock).mock.calls[0][1]);
+      expect(written.find((h: { id: number }) => h.id === 1).status).toBe('Cancelled');
+      expect(written.find((h: { id: number }) => h.id === 3).status).toBe('Completed');
+    });
+  });
+
+  describe('deleteHunts', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(JSON.stringify(mockHunts))
+        .mockResolvedValueOnce(JSON.stringify(mockClues));
+    });
+
+    it('removes hunts and their clues', async () => {
+      await deleteHunts([1]);
+      const writtenHunts = JSON.parse((SecureStore.setItemAsync as jest.Mock).mock.calls[0][1]);
+      expect(writtenHunts).toHaveLength(2);
+      expect(writtenHunts.find((h: { id: number }) => h.id === 1)).toBeUndefined();
+    });
+  });
+
+  describe('queueClueAnswer / getQueuedAnswers / processQueuedAnswers', () => {
+    it('queues an answer and retrieves it', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await queueClueAnswer(1, 1, 'spiral mural');
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        'hunty_clue_queue',
+        JSON.stringify([{ huntId: 1, clueId: 1, answer: 'spiral mural' }]),
+      );
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify([{ huntId: 1, clueId: 1, answer: 'spiral mural' }]),
+      );
+      const queued = await getQueuedAnswers();
+      expect(queued).toHaveLength(1);
+      expect(queued[0].answer).toBe('spiral mural');
+    });
+
+    it('appends to an existing queue', async () => {
+      const existing = [{ huntId: 1, clueId: 1, answer: 'first' }];
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(existing));
+      await queueClueAnswer(1, 2, 'second');
+
+      const written = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(written).toHaveLength(2);
+    });
+
+    it('processQueuedAnswers clears the queue', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify([{ huntId: 1, clueId: 1, answer: 'done' }]),
+      );
+      await processQueuedAnswers();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('hunty_clue_queue');
+    });
+
+    it('getQueuedAnswers returns empty array on error', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('fail'));
+      const queued = await getQueuedAnswers();
+      expect(queued).toEqual([]);
+    });
+  });
+
+  describe('cacheJoinedHuntClues / getOfflineCachedClues', () => {
+    it('caches and retrieves clues for a specific hunt', async () => {
+      await cacheJoinedHuntClues(
+        1,
+        mockClues.filter((c) => c.huntId === 1),
+      );
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith('hunty_clues_hunt_1', expect.any(String));
+
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockClues.filter((c) => c.huntId === 1)),
+      );
+      const cached = await getOfflineCachedClues(1);
+      expect(cached).toHaveLength(2);
+    });
+
+    it('returns empty array when no cached data', async () => {
+      const cached = await getOfflineCachedClues(999);
+      expect(cached).toEqual([]);
+    });
+  });
+
+  describe('getFeaturedHunts', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('returns active non-private hunts sorted by endTime', async () => {
+      const featured = await getFeaturedHunts();
+      expect(featured.length).toBeGreaterThan(0);
+      expect(featured.every((h) => h.status === 'Active' && !h.is_private)).toBe(true);
+    });
+
+    it('respects the limit parameter', async () => {
+      const featured = await getFeaturedHunts(1);
+      expect(featured).toHaveLength(1);
+    });
+  });
+
+  describe('joinHunt', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(mockHunts));
+    });
+
+    it('schedules an expiry notification for the hunt', async () => {
+      await joinHunt(1);
+      expect(scheduleHuntExpiryNotification).toHaveBeenCalledWith(1, 'City Secrets', 99999);
+    });
+
+    it('does nothing when hunt is not found', async () => {
+      await joinHunt(999);
+      expect(scheduleHuntExpiryNotification).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when hunt has no endTime', async () => {
+      const huntsNoEnd = [{ ...mockHunts[1], endTime: undefined }];
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(JSON.stringify(huntsNoEnd));
+      await joinHunt(2);
+      expect(scheduleHuntExpiryNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submission path (offline queue + process)', () => {
+    it('queues answers offline and clears them on process', async () => {
+      (AsyncStorage.getItem as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(
+          JSON.stringify([
+            { huntId: 1, clueId: 1, answer: 'spiral mural' },
+            { huntId: 1, clueId: 2, answer: 'lantern statue' },
+          ]),
+        );
+
+      await queueClueAnswer(1, 1, 'spiral mural');
+      await queueClueAnswer(1, 2, 'lantern statue');
+
+      const queued = await getQueuedAnswers();
+      expect(queued).toHaveLength(2);
+
+      await processQueuedAnswers();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('hunty_clue_queue');
+    });
+  });
+
+  describe('saveClueLocally', () => {
+    beforeEach(() => {
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(JSON.stringify(mockClues))
+        .mockResolvedValueOnce(JSON.stringify(mockHunts));
+    });
+
+    it('assigns an incrementing id and updates the hunt cluesCount', async () => {
+      await saveClueLocally({
+        huntId: 1,
+        question: 'New Q',
+        answer: 'New A',
+        points: 5,
+      });
+
+      const cluesCall = (SecureStore.setItemAsync as jest.Mock).mock.calls.find(
+        (call: [string, string]) => call[0] === 'hunty_clues',
+      );
+      expect(cluesCall).toBeTruthy();
+      const writtenClues = JSON.parse(cluesCall![1]);
+      expect(writtenClues).toHaveLength(mockClues.length + 1);
+      expect(writtenClues[writtenClues.length - 1].id).toBe(4);
+
+      const huntsCall = (SecureStore.setItemAsync as jest.Mock).mock.calls.find(
+        (call: [string, string]) => call[0] === 'hunty_hunts',
+      );
+      expect(huntsCall).toBeTruthy();
+      const writtenHunts = JSON.parse(huntsCall![1]);
+      const hunt1 = writtenHunts.find((h: { id: number }) => h.id === 1);
+      expect(hunt1.cluesCount).toBe(6);
+    });
+  });
+});

--- a/apps/mobile/__tests__/huntsApi.test.ts
+++ b/apps/mobile/__tests__/huntsApi.test.ts
@@ -1,0 +1,92 @@
+import { fetchActiveHuntsFromIndexer, fetchHuntByIdFromIndexer } from '@/lib/graphql/hunts';
+import { getActiveHuntsForFeed, getHuntById } from '@store/huntStore';
+import { getActiveHuntsNetworkFirst, getHuntNetworkFirst } from '@services/huntsApi';
+
+jest.mock('@/lib/graphql/hunts');
+jest.mock('@store/huntStore');
+
+const mockHunts = [
+  {
+    id: 1,
+    title: 'Hunt 1',
+    status: 'Active' as const,
+    rewardType: 'XLM' as const,
+    cluesCount: 5,
+    description: '',
+  },
+  {
+    id: 2,
+    title: 'Hunt 2',
+    status: 'Active' as const,
+    rewardType: 'NFT' as const,
+    cluesCount: 3,
+    description: '',
+  },
+];
+
+describe('getActiveHuntsNetworkFirst', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns hunts from the indexer when available', async () => {
+    (fetchActiveHuntsFromIndexer as jest.Mock).mockResolvedValue(mockHunts);
+
+    const result = await getActiveHuntsNetworkFirst();
+    expect(result).toEqual(mockHunts);
+    expect(fetchActiveHuntsFromIndexer).toHaveBeenCalledTimes(1);
+    expect(getActiveHuntsForFeed).not.toHaveBeenCalled();
+  });
+
+  it('falls back to local store when indexer returns empty', async () => {
+    (fetchActiveHuntsFromIndexer as jest.Mock).mockResolvedValue([]);
+    (getActiveHuntsForFeed as jest.Mock).mockResolvedValue(mockHunts);
+
+    const result = await getActiveHuntsNetworkFirst();
+    expect(result).toEqual(mockHunts);
+    expect(getActiveHuntsForFeed).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to local store when indexer throws', async () => {
+    (fetchActiveHuntsFromIndexer as jest.Mock).mockRejectedValue(new Error('Network error'));
+    (getActiveHuntsForFeed as jest.Mock).mockResolvedValue(mockHunts);
+
+    const result = await getActiveHuntsNetworkFirst();
+    expect(result).toEqual(mockHunts);
+    expect(getActiveHuntsForFeed).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getHuntNetworkFirst', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the hunt from the indexer when found', async () => {
+    const hunt = mockHunts[0];
+    (fetchHuntByIdFromIndexer as jest.Mock).mockResolvedValue(hunt);
+
+    const result = await getHuntNetworkFirst(1);
+    expect(result).toEqual(hunt);
+    expect(fetchHuntByIdFromIndexer).toHaveBeenCalledWith(1);
+    expect(getHuntById).not.toHaveBeenCalled();
+  });
+
+  it('falls back to local store when indexer returns undefined', async () => {
+    (fetchHuntByIdFromIndexer as jest.Mock).mockResolvedValue(undefined);
+    (getHuntById as jest.Mock).mockResolvedValue(mockHunts[0]);
+
+    const result = await getHuntNetworkFirst(1);
+    expect(result).toEqual(mockHunts[0]);
+    expect(getHuntById).toHaveBeenCalledWith(1);
+  });
+
+  it('falls back to local store when indexer throws', async () => {
+    (fetchHuntByIdFromIndexer as jest.Mock).mockRejectedValue(new Error('Network error'));
+    (getHuntById as jest.Mock).mockResolvedValue(mockHunts[0]);
+
+    const result = await getHuntNetworkFirst(1);
+    expect(result).toEqual(mockHunts[0]);
+    expect(getHuntById).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/mobile/__tests__/locationGate.test.ts
+++ b/apps/mobile/__tests__/locationGate.test.ts
@@ -1,0 +1,126 @@
+import type { Clue } from '@hunty/types';
+import * as Location from 'expo-location';
+import {
+  DEFAULT_GEOFENCE_RADIUS_METERS,
+  getClueGeofenceRadiusMeters,
+  getDistanceMeters,
+  isLocationWithinGeofence,
+  // eslint-disable-next-line import/no-unresolved -- resolved via jest moduleNameMapper
+} from '@lib/locationServices';
+import { hasClueGeofence, verifyClueGeofence } from '../lib/locationGate';
+
+jest.mock('expo-location');
+jest.mock('@lib/locationServices');
+
+function makeClue(overrides: Partial<Clue> = {}): Clue {
+  return {
+    id: 1,
+    huntId: 1,
+    question: 'Q',
+    answer: 'A',
+    points: 10,
+    ...overrides,
+  };
+}
+
+describe('hasClueGeofence', () => {
+  it('returns true when latitude and longitude are finite numbers', () => {
+    expect(hasClueGeofence(makeClue({ latitude: 40.0, longitude: -74.0 }))).toBe(true);
+  });
+
+  it('returns false when latitude is missing', () => {
+    expect(hasClueGeofence(makeClue({ longitude: -74.0 }))).toBe(false);
+  });
+
+  it('returns false when longitude is missing', () => {
+    expect(hasClueGeofence(makeClue({ latitude: 40.0 }))).toBe(false);
+  });
+
+  it('returns false when latitude is NaN', () => {
+    expect(hasClueGeofence(makeClue({ latitude: NaN, longitude: -74.0 }))).toBe(false);
+  });
+
+  it('returns false when longitude is Infinity', () => {
+    expect(hasClueGeofence(makeClue({ latitude: 40.0, longitude: Infinity }))).toBe(false);
+  });
+
+  it('returns false when both coordinates are absent', () => {
+    expect(hasClueGeofence(makeClue())).toBe(false);
+  });
+});
+
+describe('verifyClueGeofence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns not-allowed when clue has no geofence coordinates', async () => {
+    const result = await verifyClueGeofence(makeClue());
+    expect(result.allowed).toBe(false);
+    expect(result).toHaveProperty('reason', expect.stringContaining('missing geofence'));
+  });
+
+  it('returns not-allowed when location permission is denied', async () => {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: 'denied',
+    });
+
+    const result = await verifyClueGeofence(makeClue({ latitude: 40.0, longitude: -74.0 }));
+    expect(result.allowed).toBe(false);
+    expect(result).toHaveProperty('reason', expect.stringContaining('Location permission'));
+  });
+
+  it('returns allowed when within the geofence', async () => {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: 'granted',
+    });
+    (Location.getCurrentPositionAsync as jest.Mock).mockResolvedValue({
+      coords: { latitude: 40.001, longitude: -74.001 },
+    });
+    (getClueGeofenceRadiusMeters as jest.Mock).mockReturnValue(100);
+    (getDistanceMeters as jest.Mock).mockReturnValue(50);
+    (isLocationWithinGeofence as jest.Mock).mockReturnValue(true);
+
+    const result = await verifyClueGeofence(
+      makeClue({ latitude: 40.0, longitude: -74.0, geofenceRadiusMeters: 100 }),
+    );
+    expect(result.allowed).toBe(true);
+    expect(result).toHaveProperty('distanceMeters', 50);
+    expect(result).toHaveProperty('radiusMeters', 100);
+  });
+
+  it('returns not-allowed with distance info when outside the geofence', async () => {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: 'granted',
+    });
+    (Location.getCurrentPositionAsync as jest.Mock).mockResolvedValue({
+      coords: { latitude: 40.01, longitude: -74.01 },
+    });
+    (getClueGeofenceRadiusMeters as jest.Mock).mockReturnValue(100);
+    (getDistanceMeters as jest.Mock).mockReturnValue(1500);
+    (isLocationWithinGeofence as jest.Mock).mockReturnValue(false);
+
+    const result = await verifyClueGeofence(makeClue({ latitude: 40.0, longitude: -74.0 }));
+    expect(result.allowed).toBe(false);
+    expect(result).toHaveProperty('distanceMeters', 1500);
+    expect(result).toHaveProperty('radiusMeters', 100);
+    expect(result).toHaveProperty('reason', expect.stringContaining('100 m'));
+  });
+
+  it('returns not-allowed when GPS position fetch throws', async () => {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: 'granted',
+    });
+    (Location.getCurrentPositionAsync as jest.Mock).mockRejectedValue(new Error('GPS unavailable'));
+
+    const result = await verifyClueGeofence(makeClue({ latitude: 40.0, longitude: -74.0 }));
+    expect(result.allowed).toBe(false);
+    expect(result).toHaveProperty('reason', expect.stringContaining('GPS'));
+  });
+});
+
+describe('DEFAULT_GEOFENCE_RADIUS_METERS', () => {
+  it('re-exports the shared constant', () => {
+    expect(DEFAULT_GEOFENCE_RADIUS_METERS).toBe(100);
+  });
+});

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^@hooks/(.*)$': '<rootDir>/hooks/$1',
     '^@store/(.*)$': '<rootDir>/store/$1',
     '^@providers/(.*)$': '<rootDir>/providers/$1',
-    '^@lib/(.*)$': '<rootDir>/../lib/$1',
+    '^@lib/(.*)$': '<rootDir>/../web/lib/$1',
     '^@utils/(.*)$': '<rootDir>/utils/$1',
     '^@components/(.*)$': '<rootDir>/components/$1',
     '^@/(.*)$': '<rootDir>/$1',

--- a/apps/mobile/lib/graphql/hunts.ts
+++ b/apps/mobile/lib/graphql/hunts.ts
@@ -1,5 +1,4 @@
 import type { HuntStatus, StoredHunt } from '@hunty/types';
-import type { HuntStatus, StoredHunt } from '@lib/types';
 
 import { graphqlRequest } from './client';
 import { ACTIVE_HUNTS_QUERY, HUNT_BY_ID_QUERY } from './queries';

--- a/apps/mobile/lib/locationGate.ts
+++ b/apps/mobile/lib/locationGate.ts
@@ -6,8 +6,6 @@ import {
   getDistanceMeters,
   isLocationWithinGeofence,
 } from '@lib/locationServices';
-import type { Clue } from '@lib/types';
-import * as Location from 'expo-location';
 
 export type GeofenceCheckResult =
   | { allowed: true; distanceMeters: number; radiusMeters: number }

--- a/apps/mobile/services/huntsApi.ts
+++ b/apps/mobile/services/huntsApi.ts
@@ -1,9 +1,6 @@
 import type { StoredHunt } from '@hunty/types';
 import { fetchActiveHuntsFromIndexer, fetchHuntByIdFromIndexer } from '@/lib/graphql/hunts';
-import type { StoredHunt } from '@lib/types';
 import { getActiveHuntsForFeed, getHuntById } from '@store/huntStore';
-
-import { fetchActiveHuntsFromIndexer, fetchHuntByIdFromIndexer } from '@/lib/graphql/hunts';
 
 /**
  * Fetch active hunts from the Hunty GraphQL indexer, falling back to local seed

--- a/apps/mobile/store/huntStore.ts
+++ b/apps/mobile/store/huntStore.ts
@@ -5,17 +5,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import type { Clue, HuntStatus, StoredHunt } from '@hunty/types';
-
-import type { HuntStatus, StoredHunt, Clue } from '@lib/types';
-import * as SecureStore from 'expo-secure-store';
 import { scheduleHuntExpiryNotification } from '@utils/huntNotifications';
-import type { HuntStatus, StoredHunt, Clue } from "@hunty/types";
-import * as SecureStore from "expo-secure-store";
-import type { Clue, HuntStatus, StoredHunt } from '@lib/types';
-import type { Clue,HuntStatus, StoredHunt } from "@lib/types";
-import { scheduleHuntExpiryNotification } from "@utils/huntNotifications";
-import * as SecureStore from 'expo-secure-store';
-import * as SecureStore from "expo-secure-store";
 const HUNTS_KEY = 'hunty_hunts';
 const CLUES_KEY = 'hunty_clues';
 


### PR DESCRIPTION
- Add 58 unit tests across 4 suites covering huntStore (incl. offline submission path), locationGate, clueZones, and huntsApi
- Create manual mock for expo-location to fix test setup
- Remove duplicate import artifacts in locationGate, huntsApi, huntStore, and graphql/hunts that prevented test suite loading
- Fix @lib/ path alias in jest.config.js to resolve to apps/web/lib/

closes #898 