### PR TITLE
fix(mobile): add typecheck script and fix path aliases

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,6 +11,7 @@
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "typecheck": "tsc --noEmit",
     "test": "jest --passWithNoTests",
     "store:validate": "node scripts/validate-store-metadata.js",
     "store:generate": "node scripts/generate-store-assets.js",

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -6,7 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
-      "@lib/*": ["../lib/*"],
+      "@lib/*": ["./lib/*"],
       "@store/*": ["./store/*"],
       "@providers/*": ["./providers/*"],
       "@components/*": ["./components/*"],
@@ -15,7 +15,7 @@
       "@utils/*": ["./utils/*"],
       "@config/*": ["./config/*"],
       "@app/*": ["./app/*"],
-      "@shared/*": ["../shared/*"],
+      "@shared/*": ["./shared/*"],
       "@hunty/types": ["../../packages/types/src/index.ts"],
       "@hunty/types/*": ["../../packages/types/src/*"],
       "@hunty/ui": ["../../packages/ui/src/index.ts"],


### PR DESCRIPTION
Closes #845 

## Description
`apps/mobile/package.json` was missing a `typecheck` script, causing `turbo run typecheck` to silently skip the mobile app in CI. 

This PR:
- Adds `"typecheck": "tsc --noEmit"` to `apps/mobile/package.json`.
- Fixes the path aliases in `apps/mobile/tsconfig.json` (`@lib/*` and `@shared/*`) that were pointing to `../` instead of `./`, resolving the TypeScript fallout errors introduced by running typecheck.

## Acceptance Criteria Met
- [x] Added `typecheck` to `apps/mobile/package.json`
- [x] Fixed errors surfaced by broken path aliases
- [x] `turbo run typecheck` will now cover mobile as well