### PR TITLE
fix(web): add tsconfig path mappings for @stellar packages so apps/we…

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -32,7 +32,10 @@
       "@/types/*": ["./types/*"],
       "@shared/*": ["./shared/*"],
       "@hunty/types": ["../../packages/types/src/index.ts"],
-      "@hunty/types/*": ["../../packages/types/src/*"]
+      "@hunty/types/*": ["../../packages/types/src/*"],
+      "@stellar/stellar-sdk": ["../../node_modules/@stellar/stellar-sdk"],
+      "@stellar/*": ["../../node_modules/@stellar/*"],
+      "@stellar/freighter-api": ["../../node_modules/@stellar/freighter-api"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary

Fix TypeScript resolution errors for `@stellar/stellar-sdk` and `@stellar/freighter-api` when type-checking `apps/web` in the monorepo.

## Changes

- Update `apps/web/tsconfig.json` to add explicit `paths` mappings that point `@stellar/*` imports to the workspace root `node_modules`. This helps the TypeScript compiler and editor language servers resolve the SDK packages in pnpm workspaces where packages are hoisted.

## Why

In some pnpm workspace setups the editor/tsc running from a workspace package cannot discover hoisted dependencies by default, leading to TS2307 errors like `Cannot find module '@stellar/stellar-sdk'`. Pointing the compiler to the root node_modules location resolves this reliably without changing the package manager or dependency layout.

## Notes

- This is a compiler/IDE workaround; the ideal long-term solution is to ensure the workspace uses a single package manager and that editors are configured to use the monorepo's TypeScript and node resolution (or to enable pnpm's node-linker=hoisted). However, the path mappings are a minimal, non-invasive fix that stabilizes type checking for `apps/web`.

Closes #876 