### PR TITLE
fix(mobile): correct stale path aliases after monorepo restructure

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -12,7 +12,7 @@ module.exports = function (api) {
               root: ['.'],
               alias: {
                 '@': './',
-                '@lib': '../lib',
+                '@lib': './lib',
                 '@store': './store',
                 '@providers': './providers',
                 '@components': './components',
@@ -21,7 +21,6 @@ module.exports = function (api) {
                 '@services': './services',
                 '@hooks': './hooks',
                 '@app': './app',
-                '@shared': '../shared',
                 '@hunty/types': '../../packages/types/src',
                 '@hunty/ui': '../../packages/ui/src',
               },

--- a/apps/mobile/babel.config.test.js
+++ b/apps/mobile/babel.config.test.js
@@ -8,7 +8,7 @@ module.exports = {
         root: ['.'],
         alias: {
           '@': './',
-          '@lib': '../lib',
+          '@lib': './lib',
           '@store': './store',
           '@providers': './providers',
           '@components': './components',

--- a/apps/mobile/path-alias.js
+++ b/apps/mobile/path-alias.js
@@ -2,14 +2,10 @@ const path = require('path');
 
 const alias = {
   '@': path.resolve(__dirname, '.'),
-  '@lib': path.resolve(__dirname, '../lib'),
+  '@lib': path.resolve(__dirname, './lib'),
   '@store': path.resolve(__dirname, './store'),
   '@providers': path.resolve(__dirname, './providers'),
-  "@": path.resolve(__dirname, "."),
-  "@lib": path.resolve(__dirname, "../lib"),
-  "@store": path.resolve(__dirname, "./store"),
-  "@providers": path.resolve(__dirname, "./providers"),
-  "@hunty/types": path.resolve(__dirname, "../packages/types/src"),
+  '@hunty/types': path.resolve(__dirname, '../../packages/types/src'),
 };
 
 module.exports = alias;

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -6,7 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
-      "@lib/*": ["../lib/*"],
+      "@lib/*": ["./lib/*"],
       "@store/*": ["./store/*"],
       "@providers/*": ["./providers/*"],
       "@components/*": ["./components/*"],
@@ -15,7 +15,6 @@
       "@utils/*": ["./utils/*"],
       "@config/*": ["./config/*"],
       "@app/*": ["./app/*"],
-      "@shared/*": ["../shared/*"],
       "@hunty/types": ["../../packages/types/src/index.ts"],
       "@hunty/types/*": ["../../packages/types/src/*"],
       "@hunty/ui": ["../../packages/ui/src/index.ts"],


### PR DESCRIPTION
## Summary

Fixes stale path aliases in `apps/mobile` that broke after the monorepo restructure.

### Problem

After the monorepo was restructured, the path aliases in `apps/mobile` still pointed to the old pre-restructure layout:

| Alias | Old (broken) path | New (fixed) path |
|-------|-------------------|------------------|
| `@lib/*` | `../lib/*` → `apps/lib/*` (missing) | `./lib/*` → `apps/mobile/lib/*` ✅ |
| `@shared/*` | `../shared/*` → `apps/shared/*` (missing) | **Removed** (unused, no shared dir exists) |
| `@hunty/types` (path-alias.js) | `../packages/types/src` → `apps/packages/...` (missing) | `../../packages/types/src` ✅ |

### Changes

- **`apps/mobile/tsconfig.json`** — Corrected `@lib/*` to `./lib/*`, removed `@shared/*`
- **`apps/mobile/babel.config.js`** — Corrected `@lib` to `./lib`, removed `@shared`
- **`apps/mobile/babel.config.test.js`** — Corrected `@lib` to `./lib`
- **`apps/mobile/path-alias.js`** — Corrected `@lib` and `@hunty/types`, removed duplicate entries

### Verification

- ✅ TypeScript typecheck (`tsc --noEmit`) reports **zero unresolved-module errors**
- ✅ Code review confirmed all alias targets point to existing directories
- ✅ Code search confirmed `@shared` has 0 import references — safe to remove

Closes #844
