### PR TITLE
Add self-check for lockfile mismatch detection to lockfile-integrity workflow

### DIFF
--- a/.github/workflows/lockfile-integrity.yml
+++ b/.github/workflows/lockfile-integrity.yml
@@ -29,3 +29,47 @@ jobs:
         with:
           working-directory: ${{ matrix.project }}
           install-args: "--frozen-lockfile --ignore-scripts"
+
+  self-check-mismatch-detection:
+    name: Verify a lockfile mismatch fails the check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - '.'
+          - 'apps/mobile'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: ${{ matrix.project }}/pnpm-lock.yaml
+
+      - name: Introduce a deliberate lockfile mismatch
+        working-directory: ${{ matrix.project }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.dependencies = pkg.dependencies || {};
+            pkg.dependencies['lockfile-integrity-self-check'] = '1.0.0';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Confirm frozen-lockfile install fails on mismatch
+        working-directory: ${{ matrix.project }}
+        run: |
+          if pnpm install --frozen-lockfile --ignore-scripts; then
+            echo "::error::pnpm install --frozen-lockfile succeeded despite a deliberate lockfile mismatch. The lockfile-integrity check is not catching drift."
+            exit 1
+          fi
+          echo "Confirmed: frozen-lockfile install correctly failed on lockfile mismatch."


### PR DESCRIPTION
Closes #888

Summary
- The lockfile-integrity workflow's path/matrix fix (mobile/ → apps/mobile/, pnpm-only, matrix covering root + apps/mobile) was already merged in e1a86316 / 2f196f8d — verified all references, matrix entries, and package-manager alignment are correct on main.
- What was missing was criterion 4: nothing confirmed that a deliberate lockfile mismatch actually fails the check. I verified this manually (temporarily adding an undeclared dependency to apps/mobile/package.json and running `pnpm install --frozen-lockfile --ignore-scripts`, which correctly failed with `ERR_PNPM_OUTDATED_LOCKFILE`), then reverted the manual change.
- Since a one-off manual check doesn't protect against future regressions, this PR adds a permanent `self-check-mismatch-detection` job to `.github/workflows/lockfile-integrity.yml` that, for both `.` and `apps/mobile`, deliberately injects an undeclared dependency into `package.json` and asserts `pnpm install --frozen-lockfile --ignore-scripts` fails. If the install ever succeeds despite the mismatch, the job fails loudly, signaling the drift-detection itself is broken.

Test plan
- Ran the mismatch scenario locally in `apps/mobile` (added `lockfile-integrity-self-check@1.0.0` to `dependencies` without updating `pnpm-lock.yaml`) and confirmed `pnpm install --frozen-lockfile --ignore-scripts` fails with `ERR_PNPM_OUTDATED_LOCKFILE`; reverted the change afterward.
- New `self-check-mismatch-detection` job runs on CI for this PR (matrix: `.`, `apps/mobile`) and should pass, confirming the same behavior in the actual CI environment.