### PR TITLE
fix(security): harden /api/csp-report against log flooding (#863)

### DIFF
--- a/apps/web/app/api/csp-report/route.ts
+++ b/apps/web/app/api/csp-report/route.ts
@@ -1,23 +1,116 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
 import { ValidationError } from "@/lib/api/errors";
 import { withErrorHandling } from "@/lib/api/withErrorHandling";
 import { logger } from "@/lib/logger";
+import { getIP, rateLimit, rateLimitResponse } from "@/lib/rate-limit";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum accepted body size for a CSP report.
+ * The W3C CSP spec report payload is tiny; 16 KB is already very generous.
+ */
+const MAX_BODY_BYTES = 16 * 1024; // 16 KB
+
+/**
+ * Rate limit: at most 30 reports per IP per minute.
+ * A real browser sends at most one report per policy violation per page load,
+ * so 30/min per IP is more than sufficient for legitimate traffic.
+ */
+const RATE_LIMIT_CONFIG = { limit: 30, windowMs: 60 * 1_000 };
+
+/**
+ * Log only 1-in-N valid reports to avoid log flooding while preserving signal.
+ * Set CSP_REPORT_SAMPLE_RATE=1 in the environment to log every report (e.g.
+ * during initial CSP tuning).
+ */
+const SAMPLE_RATE = (() => {
+  const env = parseInt(process.env.CSP_REPORT_SAMPLE_RATE ?? "10", 10);
+  return Number.isFinite(env) && env > 0 ? env : 10;
+})();
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Zod schema for the nested "csp-report" object as defined by the W3C
+ * Content Security Policy Level 2 spec §7.3.
+ * All fields are optional because older / spec-non-compliant browsers may
+ * omit some of them; we only validate the shape of what is present.
+ */
+const CspReportSchema = z.object({
+  "document-uri": z.string().max(2_048).optional(),
+  referrer: z.string().max(2_048).optional(),
+  "blocked-uri": z.string().max(2_048).optional(),
+  "violated-directive": z.string().max(256).optional(),
+  "effective-directive": z.string().max(256).optional(),
+  "original-policy": z.string().max(8_192).optional(),
+  disposition: z.enum(["enforce", "report"]).optional(),
+  "status-code": z.number().int().min(0).max(999).optional(),
+  "script-sample": z.string().max(40).optional(),
+  "source-file": z.string().max(2_048).optional(),
+  "line-number": z.number().int().min(0).optional(),
+  "column-number": z.number().int().min(0).optional(),
+});
+
+/**
+ * Top-level envelope sent by the browser:
+ *   { "csp-report": { ... } }
+ */
+const CspReportEnvelopeSchema = z.object({
+  "csp-report": CspReportSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
 
 export const POST = withErrorHandling(async (req: NextRequest) => {
+  // 1. Rate limiting — applied before reading the body to keep overhead minimal.
+  const ip = getIP(req);
+  const { success, reset } = rateLimit(ip, RATE_LIMIT_CONFIG);
+  if (!success) {
+    return rateLimitResponse(reset);
+  }
+
+  // 2. Body size cap — read raw text and reject anything too large.
+  //    We read as text so we can validate JSON ourselves (no body-parser magic).
   const rawBody = await req.text();
+
   if (!rawBody) {
     throw new ValidationError("Empty body");
   }
 
-  let data: Record<string, unknown>;
+  if (Buffer.byteLength(rawBody, "utf8") > MAX_BODY_BYTES) {
+    throw new ValidationError("Payload too large");
+  }
+
+  // 3. JSON parse.
+  let data: unknown;
   try {
     data = JSON.parse(rawBody);
   } catch {
     throw new ValidationError("Invalid JSON body");
   }
-  const report = data["csp-report"] as Record<string, unknown> | undefined;
 
-  if (report) {
+  // 4. Schema validation — reject structurally invalid reports immediately.
+  const parsed = CspReportEnvelopeSchema.safeParse(data);
+  if (!parsed.success) {
+    // Return 400 but don't log attacker-controlled content verbatim.
+    throw new ValidationError("Invalid CSP report payload");
+  }
+
+  // 5. Sampling — log only 1-in-SAMPLE_RATE reports to limit log volume.
+  //    A deterministic hash on (ip, blocked-uri) would give consistent
+  //    sampling per source, but random sampling is simpler and equally
+  //    effective for aggregating signal across many reporters.
+  if (Math.random() * SAMPLE_RATE < 1) {
+    const report = parsed.data["csp-report"];
     logger.warn("CSP Violation Detected:", {
       documentUri: report["document-uri"],
       referrer: report["referrer"],
@@ -25,11 +118,10 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
       violatedDirective: report["violated-directive"],
       originalPolicy: report["original-policy"],
       disposition: report["disposition"],
+      sourceFile: report["source-file"],
+      lineNumber: report["line-number"],
     });
-  } else {
-    logger.warn("Received report payload without 'csp-report' field:", data);
   }
 
   return new NextResponse(null, { status: 204 });
 });
- 

--- a/apps/web/tests/csp_report.test.ts
+++ b/apps/web/tests/csp_report.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the /api/csp-report route.
+ *
+ * Covers all four acceptance-criteria items from issue #863:
+ *   1. Body size limit
+ *   2. Rate limiting per IP
+ *   3. Schema validation
+ *   4. Sampling (log volume reduction)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convenience builder for a POST request that looks like a Next.js request. */
+function makeRequest(body: unknown, opts: { ip?: string; size?: number } = {}): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.ip) {
+    headers.set("x-forwarded-for", opts.ip);
+  }
+
+  let bodyStr: string;
+  if (opts.size !== undefined) {
+    // Build an oversized payload by padding the "original-policy" field.
+    bodyStr = JSON.stringify({
+      "csp-report": {
+        "document-uri": "https://example.com/",
+        "original-policy": "x".repeat(opts.size),
+      },
+    });
+  } else {
+    bodyStr = JSON.stringify(body);
+  }
+
+  return new Request("http://localhost/api/csp-report", {
+    method: "POST",
+    headers,
+    body: bodyStr,
+  });
+}
+
+/** A valid minimal CSP report envelope. */
+const validReport = {
+  "csp-report": {
+    "document-uri": "https://example.com/",
+    referrer: "",
+    "blocked-uri": "https://evil.example/script.js",
+    "violated-directive": "script-src 'self'",
+    "original-policy": "script-src 'self'; report-uri /api/csp-report",
+    disposition: "enforce",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Module setup
+// ---------------------------------------------------------------------------
+
+// Reset the in-memory rate-limit cache between tests so they don't bleed.
+// The cache lives in lib/rate-limit.ts; we reset it by re-importing the module
+// through a vi.resetModules() call that forces each test suite to get a fresh
+// copy of the singleton cache.
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/csp-report", () => {
+  // -------------------------------------------------------------------------
+  // Body size limit
+  // -------------------------------------------------------------------------
+  describe("body size limit", () => {
+    it("returns 204 for a payload within the 16 KB limit", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const req = makeRequest(validReport, { ip: "1.2.3.4" });
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 400 when the payload exceeds 16 KB", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      // 17 KB body (well above the 16 KB cap)
+      const req = makeRequest(null, { ip: "1.2.3.5", size: 17_000 });
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/payload too large/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Schema validation
+  // -------------------------------------------------------------------------
+  describe("schema validation", () => {
+    it("accepts a valid CSP report envelope", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const req = makeRequest(validReport, { ip: "2.2.2.2" });
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 400 for an empty body", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const req = new Request("http://localhost/api/csp-report", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "",
+      });
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for non-JSON body", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const req = new Request("http://localhost/api/csp-report", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "not json at all",
+      });
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when the 'csp-report' key is missing", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const req = makeRequest({ "something-else": {} }, { ip: "3.3.3.3" });
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/invalid csp report payload/i);
+    });
+
+    it("returns 400 when a field exceeds its max length", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const req = makeRequest(
+        {
+          "csp-report": {
+            "document-uri": "https://example.com/",
+            "violated-directive": "x".repeat(300), // max is 256
+          },
+        },
+        { ip: "3.3.3.4" }
+      );
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for an invalid 'disposition' value", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const req = makeRequest(
+        {
+          "csp-report": {
+            "document-uri": "https://example.com/",
+            disposition: "INVALID_VALUE",
+          },
+        },
+        { ip: "3.3.3.5" }
+      );
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limiting
+  // -------------------------------------------------------------------------
+  describe("rate limiting", () => {
+    it("returns 429 after the per-IP limit is exceeded", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const ip = "5.5.5.5";
+
+      // Send 30 valid requests (the configured limit)
+      for (let i = 0; i < 30; i++) {
+        const req = makeRequest(validReport, { ip });
+        const res = await POST(req as any, {} as any);
+        expect(res.status).toBe(204);
+      }
+
+      // The 31st request must be rejected
+      const req = makeRequest(validReport, { ip });
+      const res = await POST(req as any, {} as any);
+      expect(res.status).toBe(429);
+    });
+
+    it("does not count a different IP against another's rate limit", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+
+      // Exhaust rate limit for ip-A
+      for (let i = 0; i < 30; i++) {
+        await POST(makeRequest(validReport, { ip: "6.6.6.6" }) as any, {} as any);
+      }
+
+      // ip-B should still succeed
+      const res = await POST(makeRequest(validReport, { ip: "7.7.7.7" }) as any, {} as any);
+      expect(res.status).toBe(204);
+    });
+
+    it("includes Retry-After header on 429 responses", async () => {
+      const { POST } = await import("@/app/api/csp-report/route");
+      const ip = "8.8.8.8";
+
+      for (let i = 0; i < 30; i++) {
+        await POST(makeRequest(validReport, { ip }) as any, {} as any);
+      }
+
+      const res = await POST(makeRequest(validReport, { ip }) as any, {} as any);
+      expect(res.status).toBe(429);
+      expect(res.headers.get("retry-after")).toBeTruthy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sampling
+  // -------------------------------------------------------------------------
+  describe("sampling", () => {
+    it("does not log every valid report (1-in-N sampling)", async () => {
+      // Import logger first to spy on it
+      const loggerModule = await import("@/lib/logger");
+      const warnSpy = vi.spyOn(loggerModule.logger, "warn");
+
+      // Force Math.random to always return 0.5 (above 1/10 threshold → skip log)
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+      const { POST } = await import("@/app/api/csp-report/route");
+      const res = await POST(makeRequest(validReport, { ip: "9.9.9.9" }) as any, {} as any);
+
+      expect(res.status).toBe(204);
+      // With random = 0.5, 0.5 * 10 = 5 which is NOT < 1, so the warn should NOT be called
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        "CSP Violation Detected:",
+        expect.anything()
+      );
+    });
+
+    it("does log when the sampler fires (random returns near-zero)", async () => {
+      const loggerModule = await import("@/lib/logger");
+      const warnSpy = vi.spyOn(loggerModule.logger, "warn");
+
+      // Force Math.random to return 0 → 0 * SAMPLE_RATE = 0 < 1 → always log
+      vi.spyOn(Math, "random").mockReturnValue(0);
+
+      const { POST } = await import("@/app/api/csp-report/route");
+      const res = await POST(makeRequest(validReport, { ip: "10.10.10.10" }) as any, {} as any);
+
+      expect(res.status).toBe(204);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "CSP Violation Detected:",
+        expect.objectContaining({ blockedUri: validReport["csp-report"]["blocked-uri"] })
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Add 16 KB body size cap to prevent oversized payloads
- Apply per-IP rate limiting (30 req/min) via existing rateLimit helper
- Validate incoming JSON against the W3C CSP Level 2 report schema (Zod) before touching any field; invalid/attacker-controlled data is rejected with 400 without being logged verbatim
- Sample valid reports at 1-in-10 (configurable via CSP_REPORT_SAMPLE_RATE env var) to avoid log flooding while preserving signal
- Add tests covering all four acceptance criteria

closes #863 