### PR TITLE
Fix/next lint next intl plugin

### DIFF
--- a/apps/web/lib/nextIntlConfig.js
+++ b/apps/web/lib/nextIntlConfig.js
@@ -1,0 +1,21 @@
+function createWithNextIntl(loadPlugin = () => require('next-intl/plugin')) {
+  const pluginPath = './i18n/request.ts';
+  let withNextIntl = (config) => config;
+
+  try {
+    const plugin = loadPlugin();
+    const createNextIntlPlugin = (plugin && (plugin.default ?? plugin)) || null;
+
+    if (typeof createNextIntlPlugin === 'function') {
+      withNextIntl = createNextIntlPlugin(pluginPath);
+    }
+  } catch {
+    withNextIntl = (config) => config;
+  }
+
+  return withNextIntl;
+}
+
+module.exports = {
+  createWithNextIntl,
+};

--- a/apps/web/lib/nextIntlConfig.test.js
+++ b/apps/web/lib/nextIntlConfig.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createWithNextIntl } = require('./nextIntlConfig.js');
+
+test('falls back to an identity wrapper when next-intl/plugin cannot be loaded', () => {
+  const withNextIntl = createWithNextIntl(() => {
+    throw new Error('missing module');
+  });
+
+  const config = { reactStrictMode: true };
+  assert.equal(withNextIntl(config), config);
+});
+
+test('uses the next-intl plugin when it is available', () => {
+  const plugin = (path) => (config) => ({ ...config, pluginPath: path });
+  const withNextIntl = createWithNextIntl(() => ({ default: plugin }));
+
+  const config = { reactStrictMode: true };
+  const wrapped = withNextIntl(config);
+
+  assert.equal(wrapped.pluginPath, './i18n/request.ts');
+  assert.equal(wrapped.reactStrictMode, true);
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,24 +1,8 @@
 import type { NextConfig } from "next";
-// Load next-intl plugin dynamically so linting doesn't crash when the
-// dependency tree is split or the package isn't resolvable from this
-// workspace layout (see issue #850).
-let withNextIntl: (config: NextConfig) => NextConfig;
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const plugin = require("next-intl/plugin");
-  // Support both CJS and ESM default export shapes
-  const createNextIntlPlugin = (plugin && (plugin.default ?? plugin)) as (
-    path: string
-  ) => (cfg: NextConfig) => NextConfig;
-  withNextIntl = createNextIntlPlugin("./i18n/request.ts");
-} catch (err) {
-  // If the plugin cannot be resolved, provide a no-op passthrough so Next
-  // commands (like `next lint`) do not crash in contributor environments.
-  withNextIntl = (cfg: NextConfig) => cfg;
-}
 import { withSentryConfig } from "@sentry/nextjs";
+import { createWithNextIntl } from "./lib/nextIntlConfig";
 
-const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
+const withNextIntl = createWithNextIntl();
 
 const nextConfig: NextConfig = {
   experimental: {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,21 @@
 import type { NextConfig } from "next";
-import createNextIntlPlugin from "next-intl/plugin";
+// Load next-intl plugin dynamically so linting doesn't crash when the
+// dependency tree is split or the package isn't resolvable from this
+// workspace layout (see issue #850).
+let withNextIntl: (config: NextConfig) => NextConfig;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const plugin = require("next-intl/plugin");
+  // Support both CJS and ESM default export shapes
+  const createNextIntlPlugin = (plugin && (plugin.default ?? plugin)) as (
+    path: string
+  ) => (cfg: NextConfig) => NextConfig;
+  withNextIntl = createNextIntlPlugin("./i18n/request.ts");
+} catch (err) {
+  // If the plugin cannot be resolved, provide a no-op passthrough so Next
+  // commands (like `next lint`) do not crash in contributor environments.
+  withNextIntl = (cfg: NextConfig) => cfg;
+}
 import { withSentryConfig } from "@sentry/nextjs";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");


### PR DESCRIPTION
Summary
Fixes #850

This PR resolves the web app lint crash caused by the next-intl/plugin import in [next.config.ts](vscode-file://vscode-app/snap/code/252/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

What changed
Wrapped the next-intl plugin initialization in a small helper so the app gracefully falls back to a no-op wrapper when the plugin cannot be resolved in a split workspace install.
Added regression tests covering both the fallback and plugin-enabled paths.
Why
In some contributor environments, next-intl is not resolvable from the web app’s dependency tree, which caused next lint to crash before linting any files. This change prevents that failure and keeps the web app lint flow usable.

Verification
Ran node --test lib/nextIntlConfig.test.js
Result: 2 tests passed, 0 failed