### PR TITLE
refactor: use shared tsconfig presets

### DIFF
--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,8 +1,6 @@
 {
-  "extends": "expo/tsconfig.base",
+  "extends": "@hunty/config/tsconfig/react-native.json",
   "compilerOptions": {
-    "strict": true,
-    "jsx": "react-native",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,23 +1,7 @@
 {
+  "extends": "@hunty/config/tsconfig/nextjs.json",
   "compilerOptions": {
-    "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "@/components": ["./components"],


### PR DESCRIPTION
Summary
Refactor the application TypeScript configurations to use the shared presets exported by @hunty/config.

Changes
Updated apps/web/tsconfig.json to extend @hunty/config/tsconfig/nextjs.json.
Updated apps/mobile/tsconfig.json to extend @hunty/config/tsconfig/react-native.json.
Removed duplicated compiler options that are already defined in the shared presets.
Preserved application-specific path mappings.

Testing
Verified the configuration changes.
Ran the project's type-check workflow.
Confirmed the changes align with the shared TypeScript configuration structure.

Checklist
- Uses the shared TypeScript configuration presets.
- Removes duplicated compiler options.
- Keeps application-specific configuration where required.

Closes #848